### PR TITLE
Add Cluster creation & deletion file for packet

### DIFF
--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -84,7 +84,7 @@
             - "{{ workers.devices }}"
 
         - name: install kubeadm inside master
-          shell: bash pre_requisite.sh {{ item.public_ipv4 }} master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
+          shell: bash pre_requisite.sh {{ item.public_ipv4 }} "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
           args:
             executable: /bin/bash
           delegate_to: "root@{{ item.public_ipv4 }}"

--- a/k8s/packet/k8s-installer/delete_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/delete_packet_cluster.yml
@@ -1,4 +1,4 @@
-# create_packet_cluster.yml
+# delete_packet_cluster.yml
 # Description:  This will delete a cluster in packet
 ###############################################################################################
 #Test Steps:

--- a/k8s/packet/k8s-installer/pre_requisite.sh
+++ b/k8s/packet/k8s-installer/pre_requisite.sh
@@ -10,14 +10,14 @@ master() {
     sed -i "s/cgroup-driver=systemd/cgroup-driver=cgroupfs/g" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
     systemctl daemon-reload
     systemctl restart kubelet
-    kubeadm init --apiserver-advertise-address=$1 --apiserver-cert-extra-sans=10.0.2.15 --pod-network-cidr 10.1.0.0/16
+    kubeadm init --apiserver-advertise-address=$1 --apiserver-cert-extra-sans=10.0.2.15 --pod-network-cidr=$2
     mkdir -p $HOME/.kube
     cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
     chown $(id -u):$(id -g) $HOME/.kube/config
     kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml
 }
 
-if [ "$2" = "master" ]
+if [ "$3" = "master" ]
 then
   master
 fi

--- a/k8s/packet/k8s-installer/vars.yml
+++ b/k8s/packet/k8s-installer/vars.yml
@@ -4,3 +4,4 @@ workers_count: 3
 master_count: 1 # kubeadm support single master only
 location: ams1
 os: ubuntu_16_04
+network_cidr: 10.1.0.0/16


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add file `create_packet_cluster.yml`, which will create the VM instances
and setup k8s cluster using `kubeadm`

- Add file `delete_packet_cluster.yml`, which will delete the instances
in packet using `devideId`

- Add file `master.sh`, which run inside master nodes and setup all
pre-requisite with `kubeadm init`

- Add file `workers.sh`, which run inside all workers nodes and setup
the pre-requisite with `kubeadm join`

- Add file `vars.yml`, which will store all necessary variable

Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>

**Special notes for your reviewer**:

O/P of create_packet_cluster.yml
```
$ ansible-playbook create_packet_cluster.yml -vv
ansible-playbook 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/chandan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: create_packet_cluster.yml *************************************************************************************************************************************
1 plays in create_packet_cluster.yml

PLAY [localhost] ********************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:18
ok: [localhost]
META: ran handlers

TASK [Generate ssh key for packet] **************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:28
changed: [localhost] => {"changed": true, "sshkeys": [{"fingerprint": "78:11:c0:68:cb:82:06:41:2c:b4:5d:9e:0b:20:41:af", "id": "cd72227c-90bd-4adc-98f4-8bbf93267cf6", "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2WaIhrEwXgHitBYnEMasY0mnul+rmjtlvJwsWwv2Xp0q8bsBhkN0e0vHtQ89K61eaXiQ8MzdaHx+j6o0QXgRxHrj3pWQzQZK2MNzcSLk6b3xLGniC5scVCUxYdzCI2kHjUhwRaN8ZITFEHjrPSQvaCxxLO+0099dWcrsRjstrfKyjMxzOGR9U9LRRlhQoSCF9LbJlZG86gl6OuV53jFbxTyVJtPG2th+ovXvMSB/50H5psGnUdyxULjk60NBr/ptxNv4iA3Js0FeeHLQ2aSdqi0sggTEE9TVBJJKga9TC+3F3KWmijPbwHxebNnM+dfJ44B1AyZm5RXHLlrfiekqN root@runner-500220b9-project-7-concurrent-1xn667", "label": "root@runner-500220b9-project-7-concurrent-1xn667"}]}

TASK [Generate random Cluster name] *************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:33
changed: [localhost] => {"changed": true, "cmd": ["python", "../../utils/name_generator/namesgenerator.py"], "delta": "0:00:00.011682", "end": "2018-09-06 18:42:29.447350", "rc": 0, "start": "2018-09-06 18:42:29.435668", "stderr": "", "stderr_lines": [], "stdout": "nifty-snyder", "stdout_lines": ["nifty-snyder"]}

TASK [set_fact] *********************************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:37
ok: [localhost] => {"ansible_facts": {"cluster_name": "nifty-snyder"}, "changed": false}

TASK [Creating master instance in packet] *******************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:41
changed: [localhost] => {"changed": true, "devices": [{"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}]}

TASK [Creating workers instance in packet] ******************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:53
changed: [localhost] => {"changed": true, "devices": [{"hostname": "node-nifty-snyder03", "id": "f7874e5c-80ea-4b89-b98c-fba2830738ce", "ip_addresses": [{"address": "147.75.80.179", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::7", "address_family": 6, "public": true}, {"address": "10.80.170.135", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.135", "public_ipv4": "147.75.80.179", "public_ipv6": "2604:1380:2001:2900::7", "state": "active", "tags": []}, {"hostname": "node-nifty-snyder01", "id": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04", "ip_addresses": [{"address": "147.75.80.103", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::3", "address_family": 6, "public": true}, {"address": "10.80.170.131", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.131", "public_ipv4": "147.75.80.103", "public_ipv6": "2604:1380:2001:2900::3", "state": "active", "tags": []}, {"hostname": "node-nifty-snyder02", "id": "b3f889c2-62ea-402f-b907-cb1e0d5323cd", "ip_addresses": [{"address": "147.75.80.177", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::5", "address_family": 6, "public": true}, {"address": "10.80.170.133", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.133", "public_ipv4": "147.75.80.177", "public_ipv6": "2604:1380:2001:2900::5", "state": "active", "tags": []}]}

TASK [Create a file for store device Ids] *******************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:65
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.32.127', u'public_ipv6': u'2604:1380:2001:2900::1', u'hostname': u'master-nifty-snyder', u'id': u'c7042943-1833-423f-a087-c54ed85b3fe8', u'state': u'active', u'private_ipv4': u'10.80.170.129', u'ip_addresses': [{u'address': u'147.75.32.127', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::1', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.129', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.179', u'public_ipv6': u'2604:1380:2001:2900::7', u'hostname': u'node-nifty-snyder03', u'id': u'f7874e5c-80ea-4b89-b98c-fba2830738ce', u'state': u'active', u'private_ipv4': u'10.80.170.135', u'ip_addresses': [{u'address': u'147.75.80.179', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::7', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.135', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-nifty-snyder03", "id": "f7874e5c-80ea-4b89-b98c-fba2830738ce", "ip_addresses": [{"address": "147.75.80.179", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::7", "address_family": 6, "public": true}, {"address": "10.80.170.135", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.135", "public_ipv4": "147.75.80.179", "public_ipv6": "2604:1380:2001:2900::7", "state": "active", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.103', u'public_ipv6': u'2604:1380:2001:2900::3', u'hostname': u'node-nifty-snyder01', u'id': u'1ac2aae9-faf4-4619-bac3-9a809b7bbd04', u'state': u'active', u'private_ipv4': u'10.80.170.131', u'ip_addresses': [{u'address': u'147.75.80.103', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::3', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.131', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-nifty-snyder01", "id": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04", "ip_addresses": [{"address": "147.75.80.103", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::3", "address_family": 6, "public": true}, {"address": "10.80.170.131", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.131", "public_ipv4": "147.75.80.103", "public_ipv6": "2604:1380:2001:2900::3", "state": "active", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.177', u'public_ipv6': u'2604:1380:2001:2900::5', u'hostname': u'node-nifty-snyder02', u'id': u'b3f889c2-62ea-402f-b907-cb1e0d5323cd', u'state': u'active', u'private_ipv4': u'10.80.170.133', u'ip_addresses': [{u'address': u'147.75.80.177', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::5', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.133', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-nifty-snyder02", "id": "b3f889c2-62ea-402f-b907-cb1e0d5323cd", "ip_addresses": [{"address": "147.75.80.177", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::5", "address_family": 6, "public": true}, {"address": "10.80.170.133", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.133", "public_ipv4": "147.75.80.177", "public_ipv6": "2604:1380:2001:2900::5", "state": "active", "tags": []}, "msg": "line added"}

TASK [Removing any known hosts] *****************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:76
changed: [localhost] => {"changed": true, "cmd": "cat ~/.ssh/known_hosts > ~/.ssh/known_hosts", "delta": "0:00:00.001935", "end": "2018-09-06 18:52:26.665731", "rc": 0, "start": "2018-09-06 18:52:26.663796", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [copy file to instances] *******************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:80
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.32.127', u'public_ipv6': u'2604:1380:2001:2900::1', u'hostname': u'master-nifty-snyder', u'id': u'c7042943-1833-423f-a087-c54ed85b3fe8', u'state': u'active', u'private_ipv4': u'10.80.170.129', u'ip_addresses': [{u'address': u'147.75.32.127', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::1', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.129', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.32.127:.", "delta": "0:00:02.418896", "end": "2018-09-06 18:52:29.224610", "item": {"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 18:52:26.805714", "stderr": "Warning: Permanently added '147.75.32.127' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.32.127' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.179', u'public_ipv6': u'2604:1380:2001:2900::7', u'hostname': u'node-nifty-snyder03', u'id': u'f7874e5c-80ea-4b89-b98c-fba2830738ce', u'state': u'active', u'private_ipv4': u'10.80.170.135', u'ip_addresses': [{u'address': u'147.75.80.179', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::7', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.135', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.80.179:.", "delta": "0:00:02.256876", "end": "2018-09-06 18:52:31.645605", "item": {"hostname": "node-nifty-snyder03", "id": "f7874e5c-80ea-4b89-b98c-fba2830738ce", "ip_addresses": [{"address": "147.75.80.179", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::7", "address_family": 6, "public": true}, {"address": "10.80.170.135", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.135", "public_ipv4": "147.75.80.179", "public_ipv6": "2604:1380:2001:2900::7", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 18:52:29.388729", "stderr": "Warning: Permanently added '147.75.80.179' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.80.179' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.103', u'public_ipv6': u'2604:1380:2001:2900::3', u'hostname': u'node-nifty-snyder01', u'id': u'1ac2aae9-faf4-4619-bac3-9a809b7bbd04', u'state': u'active', u'private_ipv4': u'10.80.170.131', u'ip_addresses': [{u'address': u'147.75.80.103', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::3', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.131', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.80.103:.", "delta": "0:00:02.483577", "end": "2018-09-06 18:52:34.315087", "item": {"hostname": "node-nifty-snyder01", "id": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04", "ip_addresses": [{"address": "147.75.80.103", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::3", "address_family": 6, "public": true}, {"address": "10.80.170.131", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.131", "public_ipv4": "147.75.80.103", "public_ipv6": "2604:1380:2001:2900::3", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 18:52:31.831510", "stderr": "Warning: Permanently added '147.75.80.103' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.80.103' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.177', u'public_ipv6': u'2604:1380:2001:2900::5', u'hostname': u'node-nifty-snyder02', u'id': u'b3f889c2-62ea-402f-b907-cb1e0d5323cd', u'state': u'active', u'private_ipv4': u'10.80.170.133', u'ip_addresses': [{u'address': u'147.75.80.177', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::5', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.133', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.80.177:.", "delta": "0:00:02.373203", "end": "2018-09-06 18:52:36.830565", "item": {"hostname": "node-nifty-snyder02", "id": "b3f889c2-62ea-402f-b907-cb1e0d5323cd", "ip_addresses": [{"address": "147.75.80.177", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::5", "address_family": 6, "public": true}, {"address": "10.80.170.133", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.133", "public_ipv4": "147.75.80.177", "public_ipv6": "2604:1380:2001:2900::5", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 18:52:34.457362", "stderr": "Warning: Permanently added '147.75.80.177' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.80.177' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}

TASK [install kubeadm inside master] ************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:86
changed: [localhost -> root@147.75.32.127] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.32.127', u'public_ipv6': u'2604:1380:2001:2900::1', u'hostname': u'master-nifty-snyder', u'id': u'c7042943-1833-423f-a087-c54ed85b3fe8', u'state': u'active', u'private_ipv4': u'10.80.170.129', u'ip_addresses': [{u'address': u'147.75.32.127', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::1', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.129', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh 147.75.32.127 master | grep \"kubeadm join\" | cut -d'\"' -f2 | sed -e 's/^[ \\t]*//'", "delta": "0:02:32.760706", "end": "2018-09-06 13:25:15.542550", "item": {"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 13:22:42.781844", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)\ndebconf: falling back to frontend: Readline\nI0906 13:23:24.322012    4853 kernel_validator.go:81] Validating kernel version\nI0906 13:23:24.322336    4853 kernel_validator.go:96] Validating kernel config", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)", "debconf: falling back to frontend: Readline", "I0906 13:23:24.322012    4853 kernel_validator.go:81] Validating kernel version", "I0906 13:23:24.322336    4853 kernel_validator.go:96] Validating kernel config"], "stdout": "kubeadm join 147.75.32.127:6443 --token stade3.g3slcrkzm45sc8nf --discovery-token-ca-cert-hash sha256:ec16b5d74fd597572e5c4dabfd53cd22b2d65b53c5031e94199409f25e1a0a5e", "stdout_lines": ["kubeadm join 147.75.32.127:6443 --token stade3.g3slcrkzm45sc8nf --discovery-token-ca-cert-hash sha256:ec16b5d74fd597572e5c4dabfd53cd22b2d65b53c5031e94199409f25e1a0a5e"]}

TASK [set kubeconfig to local] ******************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:94
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.32.127', u'public_ipv6': u'2604:1380:2001:2900::1', u'hostname': u'master-nifty-snyder', u'id': u'c7042943-1833-423f-a087-c54ed85b3fe8', u'state': u'active', u'private_ipv4': u'10.80.170.129', u'ip_addresses': [{u'address': u'147.75.32.127', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::1', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.129', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp root@147.75.32.127:/etc/kubernetes/admin.conf ~/.kube/config", "delta": "0:00:02.566567", "end": "2018-09-06 18:55:18.755136", "item": {"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 18:55:16.188569", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [joining workers node with master] *********************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:98
changed: [localhost -> root@147.75.80.179] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.179', u'public_ipv6': u'2604:1380:2001:2900::7', u'hostname': u'node-nifty-snyder03', u'id': u'f7874e5c-80ea-4b89-b98c-fba2830738ce', u'state': u'active', u'private_ipv4': u'10.80.170.135', u'ip_addresses': [{u'address': u'147.75.80.179', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::7', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.135', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh && kubeadm join 147.75.32.127:6443 --token stade3.g3slcrkzm45sc8nf --discovery-token-ca-cert-hash sha256:ec16b5d74fd597572e5c4dabfd53cd22b2d65b53c5031e94199409f25e1a0a5e", "delta": "0:00:43.834792", "end": "2018-09-06 13:26:08.920364", "item": {"hostname": "node-nifty-snyder03", "id": "f7874e5c-80ea-4b89-b98c-fba2830738ce", "ip_addresses": [{"address": "147.75.80.179", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::7", "address_family": 6, "public": true}, {"address": "10.80.170.135", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.135", "public_ipv4": "147.75.80.179", "public_ipv6": "2604:1380:2001:2900::7", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 13:25:25.085572", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)\ndebconf: falling back to frontend: Readline\n\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs_sh ip_vs ip_vs_rr ip_vs_wrr] or no builtin kernel ipvs support: map[ip_vs_rr:{} ip_vs_wrr:{} ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{}]\nyou can solve this problem with following methods:\n 1. Run 'modprobe -- ' to load missing kernel modules;\n2. Provide the missing builtin kernel ipvs support\n\nI0906 13:26:05.829130    5068 kernel_validator.go:81] Validating kernel version\nI0906 13:26:05.829369    5068 kernel_validator.go:96] Validating kernel config", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)", "debconf: falling back to frontend: Readline", "\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs_sh ip_vs ip_vs_rr ip_vs_wrr] or no builtin kernel ipvs support: map[ip_vs_rr:{} ip_vs_wrr:{} ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{}]", "you can solve this problem with following methods:", " 1. Run 'modprobe -- ' to load missing kernel modules;", "2. Provide the missing builtin kernel ipvs support", "", "I0906 13:26:05.829130    5068 kernel_validator.go:81] Validating kernel version", "I0906 13:26:05.829369    5068 kernel_validator.go:96] Validating kernel config"], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]\nFetched 3,651 kB in 1s (2,063 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nThe following additional packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man\n  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse\n  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\nThe following NEW packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io\n  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch\n  ubuntu-fan\n0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 22.0 MB of archives.\nAfter this operation, 119 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]\nPreconfiguring packages ...\nFetched 22.0 MB in 0s (26.6 MB/s)\nSelecting previously unselected package libapparmor-perl.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package bridge-utils.\r\nPreparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...\r\nUnpacking bridge-utils (1.5-9ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package dns-root-data.\r\nPreparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...\r\nUnpacking dns-root-data (2018013001~16.04.1) ...\r\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package dnsmasq-base.\r\nPreparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...\r\nUnpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSelecting previously unselected package docker.io.\r\nPreparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...\r\nUnpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSelecting previously unselected package ubuntu-fan.\r\nPreparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...\r\nUnpacking ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.9) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K05umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K05umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K07umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K07umountfs): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K06networking): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K08umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K08umountroot): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K10halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K10halt): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K03sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K03sendsigs): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K04rsyslog): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K02iscsid): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K05hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K05hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K01open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K09mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K04rsyslog): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K02iscsid): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K01open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K05umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K05umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K07umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K07umountfs): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K06networking): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K08umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K08umountroot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K10reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K10reboot): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K03sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K03sendsigs): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K04rsyslog): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K02iscsid): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K05hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K05hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K01open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K09mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up bridge-utils (1.5-9ubuntu1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up dns-root-data (2018013001~16.04.1) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSetting up docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nAdding group `docker' (GID 114) ...\r\nDone.\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.4) ...\r\nSetting up git (1:2.7.4-0ubuntu1.4) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSetting up ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nOK\nHit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]\nFetched 28.1 kB in 1s (17.2 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  cri-tools ebtables ethtool kubernetes-cni\nThe following NEW packages will be installed:\n  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 53.5 MB of archives.\nAfter this operation, 351 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]\nGet:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]\nFetched 53.5 MB in 2s (18.2 MB/s)\nSelecting previously unselected package cri-tools.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30870 files and directories currently installed.)\r\nPreparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.11.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.6.0-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.11.2-00_amd64.deb ...\r\nUnpacking kubelet (1.11.2-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.11.2-00_amd64.deb ...\r\nUnpacking kubectl (1.11.2-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...\r\nUnpacking kubeadm (1.11.2-00) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up cri-tools (1.11.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.6.0-00) ...\r\nSetting up kubelet (1.11.2-00) ...\r\nSetting up kubectl (1.11.2-00) ...\r\nSetting up kubeadm (1.11.2-00) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] running pre-flight checks\n[discovery] Trying to connect to API Server \"147.75.32.127:6443\"\n[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"\n[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key\n[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"\n[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"\n[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace\n[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[preflight] Activating the kubelet service\n[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...\n[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder03\" as an annotation\n\nThis node has joined the cluster:\n* Certificate signing request was sent to master and a response\n  was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the master to see this node join the cluster.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]", "Fetched 3,651 kB in 1s (2,063 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "The following additional packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man", "  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse", "  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "The following NEW packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io", "  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch", "  ubuntu-fan", "0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.", "Need to get 22.0 MB of archives.", "After this operation, 119 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]", "Preconfiguring packages ...", "Fetched 22.0 MB in 0s (26.6 MB/s)", "Selecting previously unselected package libapparmor-perl.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package bridge-utils.", "Preparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...", "Unpacking bridge-utils (1.5-9ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package dns-root-data.", "Preparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...", "Unpacking dns-root-data (2018013001~16.04.1) ...", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package dnsmasq-base.", "Preparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...", "Unpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Selecting previously unselected package docker.io.", "Preparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...", "Unpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.1) ...", "Selecting previously unselected package ubuntu-fan.", "Preparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...", "Unpacking ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Setting up apparmor (2.10.95-0ubuntu2.9) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K05umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K05umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K07umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K07umountfs): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K06networking): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K08umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K08umountroot): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K10halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K10halt): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K03sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K03sendsigs): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K04rsyslog): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K02iscsid): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K05hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K05hwclock.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K01open-iscsi): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K09mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K04rsyslog): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K02iscsid): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K01open-iscsi): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K05umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K05umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K07umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K07umountfs): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K06networking): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K08umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K08umountroot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K10reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K10reboot): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K03sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K03sendsigs): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K04rsyslog): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K02iscsid): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K05hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K05hwclock.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K01open-iscsi): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K09mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up bridge-utils (1.5-9ubuntu1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Setting up cgroupfs-mount (1.2) ...", "Setting up dns-root-data (2018013001~16.04.1) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Setting up docker.io (17.03.2-0ubuntu2~16.04.1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Adding group `docker' (GID 114) ...", "Done.", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.4) ...", "Setting up git (1:2.7.4-0ubuntu1.4) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.1) ...", "Setting up ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "OK", "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]", "Fetched 28.1 kB in 1s (17.2 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  cri-tools ebtables ethtool kubernetes-cni", "The following NEW packages will be installed:", "  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.", "Need to get 53.5 MB of archives.", "After this operation, 351 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]", "Get:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]", "Fetched 53.5 MB in 2s (18.2 MB/s)", "Selecting previously unselected package cri-tools.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30870 files and directories currently installed.)", "Preparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...", "Unpacking cri-tools (1.11.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...", "Unpacking kubernetes-cni (0.6.0-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.11.2-00_amd64.deb ...", "Unpacking kubelet (1.11.2-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.11.2-00_amd64.deb ...", "Unpacking kubectl (1.11.2-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...", "Unpacking kubeadm (1.11.2-00) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up cri-tools (1.11.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.6.0-00) ...", "Setting up kubelet (1.11.2-00) ...", "Setting up kubectl (1.11.2-00) ...", "Setting up kubeadm (1.11.2-00) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] running pre-flight checks", "[discovery] Trying to connect to API Server \"147.75.32.127:6443\"", "[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"", "[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key", "[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"", "[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"", "[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace", "[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[preflight] Activating the kubelet service", "[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...", "[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder03\" as an annotation", "", "This node has joined the cluster:", "* Certificate signing request was sent to master and a response", "  was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the master to see this node join the cluster."]}
changed: [localhost -> root@147.75.80.103] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.103', u'public_ipv6': u'2604:1380:2001:2900::3', u'hostname': u'node-nifty-snyder01', u'id': u'1ac2aae9-faf4-4619-bac3-9a809b7bbd04', u'state': u'active', u'private_ipv4': u'10.80.170.131', u'ip_addresses': [{u'address': u'147.75.80.103', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::3', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.131', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh && kubeadm join 147.75.32.127:6443 --token stade3.g3slcrkzm45sc8nf --discovery-token-ca-cert-hash sha256:ec16b5d74fd597572e5c4dabfd53cd22b2d65b53c5031e94199409f25e1a0a5e", "delta": "0:00:44.325300", "end": "2018-09-06 13:26:59.342674", "item": {"hostname": "node-nifty-snyder01", "id": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04", "ip_addresses": [{"address": "147.75.80.103", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::3", "address_family": 6, "public": true}, {"address": "10.80.170.131", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.131", "public_ipv4": "147.75.80.103", "public_ipv6": "2604:1380:2001:2900::3", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 13:26:15.017374", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)\ndebconf: falling back to frontend: Readline\n\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh] or no builtin kernel ipvs support: map[ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{} ip_vs_rr:{} ip_vs_wrr:{}]\nyou can solve this problem with following methods:\n 1. Run 'modprobe -- ' to load missing kernel modules;\n2. Provide the missing builtin kernel ipvs support\n\nI0906 13:26:55.836356    4758 kernel_validator.go:81] Validating kernel version\nI0906 13:26:55.836528    4758 kernel_validator.go:96] Validating kernel config", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)", "debconf: falling back to frontend: Readline", "\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh] or no builtin kernel ipvs support: map[ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{} ip_vs_rr:{} ip_vs_wrr:{}]", "you can solve this problem with following methods:", " 1. Run 'modprobe -- ' to load missing kernel modules;", "2. Provide the missing builtin kernel ipvs support", "", "I0906 13:26:55.836356    4758 kernel_validator.go:81] Validating kernel version", "I0906 13:26:55.836528    4758 kernel_validator.go:96] Validating kernel config"], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]\nFetched 3,651 kB in 1s (1,982 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nThe following additional packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man\n  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse\n  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\nThe following NEW packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io\n  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch\n  ubuntu-fan\n0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 22.0 MB of archives.\nAfter this operation, 119 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]\nPreconfiguring packages ...\nFetched 22.0 MB in 0s (25.9 MB/s)\nSelecting previously unselected package libapparmor-perl.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package bridge-utils.\r\nPreparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...\r\nUnpacking bridge-utils (1.5-9ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package dns-root-data.\r\nPreparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...\r\nUnpacking dns-root-data (2018013001~16.04.1) ...\r\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package dnsmasq-base.\r\nPreparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...\r\nUnpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSelecting previously unselected package docker.io.\r\nPreparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...\r\nUnpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSelecting previously unselected package ubuntu-fan.\r\nPreparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...\r\nUnpacking ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.9) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up bridge-utils (1.5-9ubuntu1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up dns-root-data (2018013001~16.04.1) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSetting up docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nAdding group `docker' (GID 114) ...\r\nDone.\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.4) ...\r\nSetting up git (1:2.7.4-0ubuntu1.4) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSetting up ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nOK\nHit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]\nFetched 28.1 kB in 1s (14.9 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  cri-tools ebtables ethtool kubernetes-cni\nThe following NEW packages will be installed:\n  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 53.5 MB of archives.\nAfter this operation, 351 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]\nGet:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]\nFetched 53.5 MB in 3s (16.4 MB/s)\nSelecting previously unselected package cri-tools.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30870 files and directories currently installed.)\r\nPreparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.11.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.6.0-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.11.2-00_amd64.deb ...\r\nUnpacking kubelet (1.11.2-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.11.2-00_amd64.deb ...\r\nUnpacking kubectl (1.11.2-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...\r\nUnpacking kubeadm (1.11.2-00) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up cri-tools (1.11.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.6.0-00) ...\r\nSetting up kubelet (1.11.2-00) ...\r\nSetting up kubectl (1.11.2-00) ...\r\nSetting up kubeadm (1.11.2-00) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] running pre-flight checks\n[discovery] Trying to connect to API Server \"147.75.32.127:6443\"\n[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"\n[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key\n[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"\n[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"\n[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace\n[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[preflight] Activating the kubelet service\n[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...\n[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder01\" as an annotation\n\nThis node has joined the cluster:\n* Certificate signing request was sent to master and a response\n  was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the master to see this node join the cluster.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]", "Fetched 3,651 kB in 1s (1,982 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "The following additional packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man", "  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse", "  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "The following NEW packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io", "  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch", "  ubuntu-fan", "0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.", "Need to get 22.0 MB of archives.", "After this operation, 119 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]", "Preconfiguring packages ...", "Fetched 22.0 MB in 0s (25.9 MB/s)", "Selecting previously unselected package libapparmor-perl.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package bridge-utils.", "Preparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...", "Unpacking bridge-utils (1.5-9ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package dns-root-data.", "Preparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...", "Unpacking dns-root-data (2018013001~16.04.1) ...", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package dnsmasq-base.", "Preparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...", "Unpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Selecting previously unselected package docker.io.", "Preparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...", "Unpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.1) ...", "Selecting previously unselected package ubuntu-fan.", "Preparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...", "Unpacking ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Setting up apparmor (2.10.95-0ubuntu2.9) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up bridge-utils (1.5-9ubuntu1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Setting up cgroupfs-mount (1.2) ...", "Setting up dns-root-data (2018013001~16.04.1) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Setting up docker.io (17.03.2-0ubuntu2~16.04.1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Adding group `docker' (GID 114) ...", "Done.", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.4) ...", "Setting up git (1:2.7.4-0ubuntu1.4) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.1) ...", "Setting up ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "OK", "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]", "Fetched 28.1 kB in 1s (14.9 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  cri-tools ebtables ethtool kubernetes-cni", "The following NEW packages will be installed:", "  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.", "Need to get 53.5 MB of archives.", "After this operation, 351 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]", "Get:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]", "Fetched 53.5 MB in 3s (16.4 MB/s)", "Selecting previously unselected package cri-tools.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30870 files and directories currently installed.)", "Preparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...", "Unpacking cri-tools (1.11.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...", "Unpacking kubernetes-cni (0.6.0-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.11.2-00_amd64.deb ...", "Unpacking kubelet (1.11.2-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.11.2-00_amd64.deb ...", "Unpacking kubectl (1.11.2-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...", "Unpacking kubeadm (1.11.2-00) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up cri-tools (1.11.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.6.0-00) ...", "Setting up kubelet (1.11.2-00) ...", "Setting up kubectl (1.11.2-00) ...", "Setting up kubeadm (1.11.2-00) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] running pre-flight checks", "[discovery] Trying to connect to API Server \"147.75.32.127:6443\"", "[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"", "[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key", "[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"", "[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"", "[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace", "[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[preflight] Activating the kubelet service", "[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...", "[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder01\" as an annotation", "", "This node has joined the cluster:", "* Certificate signing request was sent to master and a response", "  was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the master to see this node join the cluster."]}
changed: [localhost -> root@147.75.80.177] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.80.177', u'public_ipv6': u'2604:1380:2001:2900::5', u'hostname': u'node-nifty-snyder02', u'id': u'b3f889c2-62ea-402f-b907-cb1e0d5323cd', u'state': u'active', u'private_ipv4': u'10.80.170.133', u'ip_addresses': [{u'address': u'147.75.80.177', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:2001:2900::5', u'public': True, u'address_family': 6}, {u'address': u'10.80.170.133', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh && kubeadm join 147.75.32.127:6443 --token stade3.g3slcrkzm45sc8nf --discovery-token-ca-cert-hash sha256:ec16b5d74fd597572e5c4dabfd53cd22b2d65b53c5031e94199409f25e1a0a5e", "delta": "0:00:45.145283", "end": "2018-09-06 13:27:50.421146", "item": {"hostname": "node-nifty-snyder02", "id": "b3f889c2-62ea-402f-b907-cb1e0d5323cd", "ip_addresses": [{"address": "147.75.80.177", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::5", "address_family": 6, "public": true}, {"address": "10.80.170.133", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.133", "public_ipv4": "147.75.80.177", "public_ipv6": "2604:1380:2001:2900::5", "state": "active", "tags": []}, "rc": 0, "start": "2018-09-06 13:27:05.275863", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)\ndebconf: falling back to frontend: Readline\n\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs_rr ip_vs_wrr ip_vs_sh ip_vs] or no builtin kernel ipvs support: map[ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{} ip_vs_rr:{} ip_vs_wrr:{}]\nyou can solve this problem with following methods:\n 1. Run 'modprobe -- ' to load missing kernel modules;\n2. Provide the missing builtin kernel ipvs support\n\nI0906 13:27:46.427977    4800 kernel_validator.go:81] Validating kernel version\nI0906 13:27:46.428538    4800 kernel_validator.go:96] Validating kernel config", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 13.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 7.)", "debconf: falling back to frontend: Readline", "\t[WARNING RequiredIPVSKernelModulesAvailable]: the IPVS proxier will not be used, because the following required kernel modules are not loaded: [ip_vs_rr ip_vs_wrr ip_vs_sh ip_vs] or no builtin kernel ipvs support: map[ip_vs_sh:{} nf_conntrack_ipv4:{} ip_vs:{} ip_vs_rr:{} ip_vs_wrr:{}]", "you can solve this problem with following methods:", " 1. Run 'modprobe -- ' to load missing kernel modules;", "2. Provide the missing builtin kernel ipvs support", "", "I0906 13:27:46.427977    4800 kernel_validator.go:81] Validating kernel version", "I0906 13:27:46.428538    4800 kernel_validator.go:96] Validating kernel config"], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]\nFetched 3,651 kB in 1s (2,080 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nThe following additional packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man\n  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse\n  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\nThe following NEW packages will be installed:\n  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io\n  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch\n  ubuntu-fan\n0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 22.0 MB of archives.\nAfter this operation, 119 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]\nPreconfiguring packages ...\nFetched 22.0 MB in 0s (28.5 MB/s)\nSelecting previously unselected package libapparmor-perl.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.9) ...\r\nSelecting previously unselected package bridge-utils.\r\nPreparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...\r\nUnpacking bridge-utils (1.5-9ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package dns-root-data.\r\nPreparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...\r\nUnpacking dns-root-data (2018013001~16.04.1) ...\r\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package dnsmasq-base.\r\nPreparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...\r\nUnpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSelecting previously unselected package docker.io.\r\nPreparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...\r\nUnpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.4) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSelecting previously unselected package ubuntu-fan.\r\nPreparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...\r\nUnpacking ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.9) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.9) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up bridge-utils (1.5-9ubuntu1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up dns-root-data (2018013001~16.04.1) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...\r\nSetting up docker.io (17.03.2-0ubuntu2~16.04.1) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nAdding group `docker' (GID 114) ...\r\nDone.\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.4) ...\r\nSetting up git (1:2.7.4-0ubuntu1.4) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.1) ...\r\nSetting up ubuntu-fan (0.12.8~16.04.2) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for dbus (1.10.6-1ubuntu3.3) ...\r\nOK\nHit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]\nFetched 28.1 kB in 1s (18.0 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  cri-tools ebtables ethtool kubernetes-cni\nThe following NEW packages will be installed:\n  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 53.5 MB of archives.\nAfter this operation, 351 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]\nGet:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]\nFetched 53.5 MB in 3s (16.1 MB/s)\nSelecting previously unselected package cri-tools.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30870 files and directories currently installed.)\r\nPreparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.11.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.6.0-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.11.2-00_amd64.deb ...\r\nUnpacking kubelet (1.11.2-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.11.2-00_amd64.deb ...\r\nUnpacking kubectl (1.11.2-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...\r\nUnpacking kubeadm (1.11.2-00) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up cri-tools (1.11.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.6.0-00) ...\r\nSetting up kubelet (1.11.2-00) ...\r\nSetting up kubectl (1.11.2-00) ...\r\nSetting up kubeadm (1.11.2-00) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] running pre-flight checks\n[discovery] Trying to connect to API Server \"147.75.32.127:6443\"\n[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"\n[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key\n[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"\n[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"\n[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace\n[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[preflight] Activating the kubelet service\n[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...\n[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder02\" as an annotation\n\nThis node has joined the cluster:\n* Certificate signing request was sent to master and a response\n  was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the master to see this node join the cluster.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease [107 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [841 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [345 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [682 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [276 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [550 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [233 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [369 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [140 kB]", "Fetched 3,651 kB in 1s (2,080 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "The following additional packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base git git-man", "  libapparmor-perl liberror-perl libnetfilter-conntrack3 patch ubuntu-fan", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse", "  | zfsutils git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "The following NEW packages will be installed:", "  apparmor bridge-utils cgroupfs-mount dns-root-data dnsmasq-base docker.io", "  git git-man libapparmor-perl liberror-perl libnetfilter-conntrack3 patch", "  ubuntu-fan", "0 upgraded, 13 newly installed, 0 to remove and 3 not upgraded.", "Need to get 22.0 MB of archives.", "After this operation, 119 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.9 [31.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.9 [450 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5,424 B]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 docker.io amd64 17.03.2-0ubuntu2~16.04.1 [17.1 MB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.4 [736 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.4 [3,158 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.1 [90.5 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.2 [35.6 kB]", "Preconfiguring packages ...", "Fetched 22.0 MB in 0s (28.5 MB/s)", "Selecting previously unselected package libapparmor-perl.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.9_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.9) ...", "Selecting previously unselected package bridge-utils.", "Preparing to unpack .../bridge-utils_1.5-9ubuntu1_amd64.deb ...", "Unpacking bridge-utils (1.5-9ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package dns-root-data.", "Preparing to unpack .../dns-root-data_2018013001~16.04.1_all.deb ...", "Unpacking dns-root-data (2018013001~16.04.1) ...", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package dnsmasq-base.", "Preparing to unpack .../dnsmasq-base_2.75-1ubuntu0.16.04.5_amd64.deb ...", "Unpacking dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Selecting previously unselected package docker.io.", "Preparing to unpack .../docker.io_17.03.2-0ubuntu2~16.04.1_amd64.deb ...", "Unpacking docker.io (17.03.2-0ubuntu2~16.04.1) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.4_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.4_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.4) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.1_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.1) ...", "Selecting previously unselected package ubuntu-fan.", "Preparing to unpack .../ubuntu-fan_0.12.8~16.04.2_all.deb ...", "Unpacking ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.9) ...", "Setting up apparmor (2.10.95-0ubuntu2.9) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up bridge-utils (1.5-9ubuntu1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Setting up cgroupfs-mount (1.2) ...", "Setting up dns-root-data (2018013001~16.04.1) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up dnsmasq-base (2.75-1ubuntu0.16.04.5) ...", "Setting up docker.io (17.03.2-0ubuntu2~16.04.1) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "Adding group `docker' (GID 114) ...", "Done.", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.4) ...", "Setting up git (1:2.7.4-0ubuntu1.4) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.1) ...", "Setting up ubuntu-fan (0.12.8~16.04.2) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for dbus (1.10.6-1ubuntu3.3) ...", "OK", "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [19.1 kB]", "Fetched 28.1 kB in 1s (18.0 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  cri-tools ebtables ethtool kubernetes-cni", "The following NEW packages will be installed:", "  cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "0 upgraded, 7 newly installed, 0 to remove and 3 not upgraded.", "Need to get 53.5 MB of archives.", "After this operation, 351 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:3 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.11.0-00 [5,309 kB]", "Get:4 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.6.0-00 [5,910 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.11.2-00 [23.2 MB]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.11.2-00 [9,394 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.11.2-00 [9,420 kB]", "Fetched 53.5 MB in 3s (16.1 MB/s)", "Selecting previously unselected package cri-tools.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30870 files and directories currently installed.)", "Preparing to unpack .../cri-tools_1.11.0-00_amd64.deb ...", "Unpacking cri-tools (1.11.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.6.0-00_amd64.deb ...", "Unpacking kubernetes-cni (0.6.0-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.11.2-00_amd64.deb ...", "Unpacking kubelet (1.11.2-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.11.2-00_amd64.deb ...", "Unpacking kubectl (1.11.2-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.11.2-00_amd64.deb ...", "Unpacking kubeadm (1.11.2-00) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up cri-tools (1.11.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.6.0-00) ...", "Setting up kubelet (1.11.2-00) ...", "Setting up kubectl (1.11.2-00) ...", "Setting up kubeadm (1.11.2-00) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] running pre-flight checks", "[discovery] Trying to connect to API Server \"147.75.32.127:6443\"", "[discovery] Created cluster-info discovery client, requesting info from \"https://147.75.32.127:6443\"", "[discovery] Requesting info from \"https://147.75.32.127:6443\" again to validate TLS against the pinned public key", "[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server \"147.75.32.127:6443\"", "[discovery] Successfully established connection with API Server \"147.75.32.127:6443\"", "[kubelet] Downloading configuration for the kubelet from the \"kubelet-config-1.11\" ConfigMap in the kube-system namespace", "[kubelet] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[preflight] Activating the kubelet service", "[tlsbootstrap] Waiting for the kubelet to perform the TLS Bootstrap...", "[patchnode] Uploading the CRI Socket information \"/var/run/dockershim.sock\" to the Node API object \"node-nifty-snyder02\" as an annotation", "", "This node has joined the cluster:", "* Certificate signing request was sent to master and a response", "  was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the master to see this node join the cluster."]}

TASK [Test Passed] ******************************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:105
ok: [localhost] => {"ansible_facts": {"flag": "Test Passed"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************************************************************************************
localhost                  : ok=13   changed=10   unreachable=0    failed=0   
```
```
$ kubectl get nodes
NAME                   STATUS    ROLES     AGE       VERSION
master-tender-beaver   Ready     master    5m        v1.11.2
node-tender-beaver01   Ready     <none>    2m        v1.11.2
node-tender-beaver02   Ready     <none>    3m        v1.11.2
node-tender-beaver03   Ready     <none>    3m        v1.11.2
```
O/P of delete_packet_cluster.yml
```
$ ansible-playbook delete_packet_cluster.yml -vv
ansible-playbook 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/chandan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: delete_packet_cluster.yml *************************************************************************************************************************************
1 plays in delete_packet_cluster.yml

PLAY [localhost] ********************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/delete_packet_cluster.yml:12
ok: [localhost]
META: ran handlers

TASK [Deleting instances in packet] *************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/delete_packet_cluster.yml:19
changed: [localhost] => (item=c7042943-1833-423f-a087-c54ed85b3fe8) => {"changed": true, "devices": [{"hostname": "master-nifty-snyder", "id": "c7042943-1833-423f-a087-c54ed85b3fe8", "ip_addresses": [{"address": "147.75.32.127", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::1", "address_family": 6, "public": true}, {"address": "10.80.170.129", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.129", "public_ipv4": "147.75.32.127", "public_ipv6": "2604:1380:2001:2900::1", "state": "active", "tags": []}], "item": "c7042943-1833-423f-a087-c54ed85b3fe8"}
changed: [localhost] => (item=f7874e5c-80ea-4b89-b98c-fba2830738ce) => {"changed": true, "devices": [{"hostname": "node-nifty-snyder03", "id": "f7874e5c-80ea-4b89-b98c-fba2830738ce", "ip_addresses": [{"address": "147.75.80.179", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::7", "address_family": 6, "public": true}, {"address": "10.80.170.135", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.135", "public_ipv4": "147.75.80.179", "public_ipv6": "2604:1380:2001:2900::7", "state": "active", "tags": []}], "item": "f7874e5c-80ea-4b89-b98c-fba2830738ce"}
changed: [localhost] => (item=1ac2aae9-faf4-4619-bac3-9a809b7bbd04) => {"changed": true, "devices": [{"hostname": "node-nifty-snyder01", "id": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04", "ip_addresses": [{"address": "147.75.80.103", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::3", "address_family": 6, "public": true}, {"address": "10.80.170.131", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.131", "public_ipv4": "147.75.80.103", "public_ipv6": "2604:1380:2001:2900::3", "state": "active", "tags": []}], "item": "1ac2aae9-faf4-4619-bac3-9a809b7bbd04"}
changed: [localhost] => (item=b3f889c2-62ea-402f-b907-cb1e0d5323cd) => {"changed": true, "devices": [{"hostname": "node-nifty-snyder02", "id": "b3f889c2-62ea-402f-b907-cb1e0d5323cd", "ip_addresses": [{"address": "147.75.80.177", "address_family": 4, "public": true}, {"address": "2604:1380:2001:2900::5", "address_family": 6, "public": true}, {"address": "10.80.170.133", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.80.170.133", "public_ipv4": "147.75.80.177", "public_ipv6": "2604:1380:2001:2900::5", "state": "active", "tags": []}], "item": "b3f889c2-62ea-402f-b907-cb1e0d5323cd"}

TASK [Deleting device Id from file] *************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/delete_packet_cluster.yml:26
changed: [localhost] => {"backup": "", "changed": true, "found": 4, "msg": "4 line(s) removed"}

TASK [Deleting ssh key from packet] *************************************************************************************************************************************
task path: /home/chandan/gowork/src/github.com/openebs/litmus/k8s/packet/k8s-installer/delete_packet_cluster.yml:33
changed: [localhost] => {"changed": true, "sshkeys": [{"fingerprint": "78:11:c0:68:cb:82:06:41:2c:b4:5d:9e:0b:20:41:af", "id": "cd72227c-90bd-4adc-98f4-8bbf93267cf6", "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2WaIhrEwXgHitBYnEMasY0mnul+rmjtlvJwsWwv2Xp0q8bsBhkN0e0vHtQ89K61eaXiQ8MzdaHx+j6o0QXgRxHrj3pWQzQZK2MNzcSLk6b3xLGniC5scVCUxYdzCI2kHjUhwRaN8ZITFEHjrPSQvaCxxLO+0099dWcrsRjstrfKyjMxzOGR9U9LRRlhQoSCF9LbJlZG86gl6OuV53jFbxTyVJtPG2th+ovXvMSB/50H5psGnUdyxULjk60NBr/ptxNv4iA3Js0FeeHLQ2aSdqi0sggTEE9TVBJJKga9TC+3F3KWmijPbwHxebNnM+dfJ44B1AyZm5RXHLlrfiekqN root@runner-500220b9-project-7-concurrent-1xn667", "label": "root@runner-500220b9-project-7-concurrent-1xn667"}]}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************************************************************************************
localhost                  : ok=4    changed=3    unreachable=0    failed=0   
```
