### PR TITLE
refactor(playbook): Add task for taint node in packet cluster

### DIFF
--- a/k8s/packet/k8s-installer/README.md
+++ b/k8s/packet/k8s-installer/README.md
@@ -50,6 +50,18 @@ ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=<version>" 
 ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=1.11.3-00 cluster_name=<name-of-cluster>"
 ```
 
+3. Taint Node:
+
+```bash
+ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=1.11.3-00 taint_value=<taint_value>"
+```
+
+example:
+
+```bash
+ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=1.11.3-00 taint_value=ak=av:NoSchedule"
+```
+
 ### Deleting k8s cluster in packet
 
 - Run `delete_packet_cluster`, this will delete the cluster as well as ssh key.

--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -116,6 +116,23 @@
           shell: bash pre_requisite.sh "{{ k8s_version }}" && {{ storage.results[0].stdout }}
           delegate_to: "root@{{ item.public_ipv4 }}"
           with_items: "{{ workers.devices }}"
+
+        - block:
+            - name: Getting nodes name
+              shell: kubectl get nodes --no-headers | grep -v master | awk '{print $1}' | head -n 1
+              register: node_name
+
+            - name: Taint node using key and value
+              shell: kubectl taint nodes {{ node_name.stdout }} {{ taint_value }}
+
+            - name: Create a file for store taint node property
+              lineinfile:
+                create: yes
+                state: present
+                path: "/tmp/packet/node_property"
+                line: 'taint_node_name: {{ node_name.stdout }}, taint_value: {{ taint_value }}'
+                mode: 0755
+          when: taint_value is defined
   
         - name: Set Test Status
           set_fact:


### PR DESCRIPTION

Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- At the time of running the playbook if in extra-vars, taint_value is
passed with required detail, it will taint the first node leaving master

- Taint detail will store in a file at /tmp/packet/node_property

**Special notes for your reviewer**:

```
TASK [Getting nodes name] ***********************************************************************************************************************************************
changed: [localhost]

TASK [Taint node using key and value] ***********************************************************************************************************************************
changed: [localhost]

TASK [Create a file for store taint node property] **********************************************************************************************************************
changed: [localhost]
```
```
└─ $ ▶ kubectl describe nodes node-sumit-test01
Name:               node-sumit-test01
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/os=linux
                    kubernetes.io/hostname=node-sumit-test01
Annotations:        node.alpha.kubernetes.io/ttl=0
                    volumes.kubernetes.io/controller-managed-attach-detach=true
CreationTimestamp:  Tue, 30 Oct 2018 21:01:45 +0530
Taints:             ak=av:NoSchedule
Unschedulable:      false
```