### PR TITLE
refactor(yaml): Using default images for cstor pool and volumes

### DIFF
--- a/providers/cstor/cstor-disk-pool/cstor-spc.j2
+++ b/providers/cstor/cstor-disk-pool/cstor-spc.j2
@@ -3,12 +3,12 @@ apiVersion: openebs.io/v1alpha1
 kind: StoragePoolClaim
 metadata:
   name: {{ pool_name }}
-  annotations:
-    cas.openebs.io/config: |
-      - name: CstorPoolImage
-        value: openebs/cstor-pool:{{ cstor_image }}
-      - name: CstorPoolMgmtImage
-        value: openebs/cstor-pool-mgmt:{{ cstor_image }}
+#  annotations:
+#    cas.openebs.io/config: |
+#      - name: CstorPoolImage
+#        value: openebs/cstor-pool:{{ cstor_image }}
+#      - name: CstorPoolMgmtImage
+#        value: openebs/cstor-pool-mgmt:{{ cstor_image }}
 spec:
   name: {{ pool_name }}
   type: disk
@@ -35,10 +35,10 @@ metadata:
         value: "{{ pool_name }}"
       - name: ReplicaCount
         value: "3"
-      - name: VolumeControllerImage
-        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
-      - name: VolumeTargetImage
-        value: openebs/cstor-istgt:{{ cstor_image }}
-      - name: VolumeMonitorImage
-        value: openebs/m-exporter:{{ cstor_image }}
+#      - name: VolumeControllerImage
+#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
+#      - name: VolumeTargetImage
+#        value: openebs/cstor-istgt:{{ cstor_image }}
+#      - name: VolumeMonitorImage
+#        value: openebs/m-exporter:{{ cstor_image }}
 provisioner: openebs.io/provisioner-iscsi


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Commented the annotations where we overriding the default images
- Using default images for cstor pool and volumes