### PR TITLE
feat(yaml):Creating storage class for local pv provisioning

### DIFF
--- a/providers/cstor-storage-policies/local-pv-hostpath.j2
+++ b/providers/cstor-storage-policies/local-pv-hostpath.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-pv-hostpath
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      - name: StorageType
+        value: "hostpath"
+      - name: BasePath
+        value: "{{ local_pv_hostpath }}"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+

--- a/providers/cstor-storage-policies/run_litmus_test.yml
+++ b/providers/cstor-storage-policies/run_litmus_test.yml
@@ -28,6 +28,10 @@ spec:
           - name: POOL_NAME
             value: cstor-sparse-pool
 
+            # The path where the local pv can be created
+          - name: POOL_PATH
+            value: "/var/openebs/local"
+
             ## two values: create and delete 
           - name: ACTION
             value: create

--- a/providers/cstor-storage-policies/test.yml
+++ b/providers/cstor-storage-policies/test.yml
@@ -24,6 +24,7 @@
              - { src: cstor-xfs-sc.j2,dest: cstor-xfs-sc.yml }
              - { src: cstor-volume-monitor-sc.j2,dest: cstor-volume-monitor-sc.yml }
              - { src: cstor-disk-standalone.j2,dest: cstor-disk-standalone.yml }
+             - { src: local-pv-hostpath.j2,dest: local-pv-hostpath.yml }
 
         - block:
 
@@ -48,6 +49,7 @@
                 - openebs-cstor-volume-monitor
                 - cstor-disk-standalone
                 - openebs-jiva-standalone
+                - local-pv-hostpath
 
           when: lookup('env','ACTION') == 'create'
 
@@ -72,6 +74,9 @@
               with_items:
                 - openebs-cstor-xfs
                 - openebs-cstor-volume-monitor
+                - local-pv-hostpath
+                - cstor-disk-standalone
+                - openebs-jiva-standalone
 
           when: lookup('env','ACTION') == 'delete'
 

--- a/providers/cstor-storage-policies/test_vars.yml
+++ b/providers/cstor-storage-policies/test_vars.yml
@@ -1,8 +1,11 @@
 # Test-specific parameters
 test_name: cstor-storage-policies
 pool_name: "{{ lookup('env','POOL_NAME') }}"
+local_pv_hostpath: "{{ lookup('env','POOL_PATH') }}"
 storage_policies:
   - cstor-xfs-sc.yml
   - cstor-volume-monitor-sc.yml
   - cstor-disk-standalone.yml
   - jiva-standalone.yml
+  - local-pv-hostpath.yml
+


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>


**What this PR does / why we need it**:
- Keeping storage class template for local pv provisoning
- Updating the host path value in template
- Checking if the storage class is created.

```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "25bb20fe509f09c8b530b38ccc1aa9766840adf9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6ad18312bdd4c12e9105d4741a39a708", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1557395367.57-238590441315195/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.264149", "end": "2019-05-09 09:49:30.286384", "rc": 0, "start": "2019-05-09 09:49:29.022235", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-storage-policies \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-storage-policies ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.790067", "end": "2019-05-09 09:49:32.379668", "failed_when_result": false, "rc": 0, "start": "2019-05-09 09:49:30.589601", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-storage-policies configured", "stdout_lines": ["litmusresult.litmus.io/cstor-storage-policies configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate yaml files to create storage class] *****************************
changed: [127.0.0.1] => (item={u'dest': u'cstor-xfs-sc.yml', u'src': u'cstor-xfs-sc.j2'}) => {"changed": true, "checksum": "f4b16877fa436b114c365f624962c49277a55fef", "dest": "./cstor-xfs-sc.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-xfs-sc.yml", "src": "cstor-xfs-sc.j2"}, "md5sum": "14f993a75d2ea35f9c78f3025b703710", "mode": "0644", "owner": "root", "size": 312, "src": "/root/.ansible/tmp/ansible-tmp-1557395372.81-132886102609388/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'cstor-volume-monitor-sc.yml', u'src': u'cstor-volume-monitor-sc.j2'}) => {"changed": true, "checksum": "1b899f26f7597e60f2bdb55012a327f2a4d8a4ad", "dest": "./cstor-volume-monitor-sc.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-volume-monitor-sc.yml", "src": "cstor-volume-monitor-sc.j2"}, "md5sum": "a4ae032084ac5ae732d75db07e790fbc", "mode": "0644", "owner": "root", "size": 335, "src": "/root/.ansible/tmp/ansible-tmp-1557395373.34-48723160980770/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'cstor-disk-standalone.yml', u'src': u'cstor-disk-standalone.j2'}) => {"changed": true, "checksum": "9fb2ba2ee11400e66523a84a440a38da43c6d3d6", "dest": "./cstor-disk-standalone.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-disk-standalone.yml", "src": "cstor-disk-standalone.j2"}, "md5sum": "77679b5f8ab64cd295f13284c820ccb8", "mode": "0644", "owner": "root", "size": 322, "src": "/root/.ansible/tmp/ansible-tmp-1557395373.74-4351310375482/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'local-pv-hostpath.yml', u'src': u'local-pv-hostpath.j2'}) => {"changed": true, "checksum": "16dea3bd6a40f33030dc3bc11640b881afdac8a4", "dest": "./local-pv-hostpath.yml", "gid": 0, "group": "root", "item": {"dest": "local-pv-hostpath.yml", "src": "local-pv-hostpath.j2"}, "md5sum": "0c8be3880da5e7ebbdd2c8f5642037bb", "mode": "0644", "owner": "root", "size": 368, "src": "/root/.ansible/tmp/ansible-tmp-1557395374.1-13876303748893/source", "state": "file", "uid": 0}

TASK [Create storage classes with specific storage policies] *******************
changed: [127.0.0.1] => (item=cstor-xfs-sc.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-xfs-sc.yml", "delta": "0:00:01.389540", "end": "2019-05-09 09:49:36.142021", "item": "cstor-xfs-sc.yml", "rc": 0, "start": "2019-05-09 09:49:34.752481", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-xfs created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-xfs created"]}
changed: [127.0.0.1] => (item=cstor-volume-monitor-sc.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-volume-monitor-sc.yml", "delta": "0:00:01.513747", "end": "2019-05-09 09:49:37.846903", "item": "cstor-volume-monitor-sc.yml", "rc": 0, "start": "2019-05-09 09:49:36.333156", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-volume-monitor created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-volume-monitor created"]}
changed: [127.0.0.1] => (item=cstor-disk-standalone.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-disk-standalone.yml", "delta": "0:00:01.513384", "end": "2019-05-09 09:49:39.572036", "item": "cstor-disk-standalone.yml", "rc": 0, "start": "2019-05-09 09:49:38.058652", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/cstor-disk-standalone created", "stdout_lines": ["storageclass.storage.k8s.io/cstor-disk-standalone created"]}
changed: [127.0.0.1] => (item=jiva-standalone.yml) => {"changed": true, "cmd": "kubectl apply -f jiva-standalone.yml", "delta": "0:00:01.512436", "end": "2019-05-09 09:49:41.331619", "item": "jiva-standalone.yml", "rc": 0, "start": "2019-05-09 09:49:39.819183", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-jiva-standalone created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-jiva-standalone created"]}
changed: [127.0.0.1] => (item=local-pv-hostpath.yml) => {"changed": true, "cmd": "kubectl apply -f local-pv-hostpath.yml", "delta": "0:00:01.610214", "end": "2019-05-09 09:49:43.170425", "item": "local-pv-hostpath.yml", "rc": 0, "start": "2019-05-09 09:49:41.560211", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/local-pv-hostpath created", "stdout_lines": ["storageclass.storage.k8s.io/local-pv-hostpath created"]}

TASK [Confirm that the storage classes are created] ****************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ item }}" in result_sc.stdout
changed: [127.0.0.1] => (item=openebs-cstor-xfs) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.509457", "end": "2019-05-09 09:49:45.103406", "item": "openebs-cstor-xfs", "rc": 0, "start": "2019-05-09 09:49:43.593949", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                                                  AGE\ncstor-1r                       openebs.io/provisioner-iscsi                                 27d\ncstor-disk-standalone          openebs.io/provisioner-iscsi                                 6s\ncstor-new                      openebs.io/provisioner-iscsi                                 1d\ncstor-sts                      openebs.io/provisioner-iscsi                                 1d\njiva-1r                        openebs.io/provisioner-iscsi                                 34d\nlocal-pv-hostpath              openebs.io/local                                             2s\nnfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d\nopenebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 8s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi                                 9s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi                                 4s\nopenebs-mongodb                openebs.io/provisioner-iscsi                                 27d\nopenebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d\nopenebs-standalone             openebs.io/provisioner-iscsi                                 27d\nopenebs-standard               openebs.io/provisioner-iscsi                                 27d\nwordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d", "stdout_lines": ["NAME                           PROVISIONER                                                  AGE", "cstor-1r                       openebs.io/provisioner-iscsi                                 27d", "cstor-disk-standalone          openebs.io/provisioner-iscsi                                 6s", "cstor-new                      openebs.io/provisioner-iscsi                                 1d", "cstor-sts                      openebs.io/provisioner-iscsi                                 1d", "jiva-1r                        openebs.io/provisioner-iscsi                                 34d", "local-pv-hostpath              openebs.io/local                                             2s", "nfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d", "openebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 8s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi                                 9s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi                                 4s", "openebs-mongodb                openebs.io/provisioner-iscsi                                 27d", "openebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d", "openebs-standalone             openebs.io/provisioner-iscsi                                 27d", "openebs-standard               openebs.io/provisioner-iscsi                                 27d", "wordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d"]}
changed: [127.0.0.1] => (item=openebs-cstor-volume-monitor) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.323249", "end": "2019-05-09 09:49:46.660946", "item": "openebs-cstor-volume-monitor", "rc": 0, "start": "2019-05-09 09:49:45.337697", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                                                  AGE\ncstor-1r                       openebs.io/provisioner-iscsi                                 27d\ncstor-disk-standalone          openebs.io/provisioner-iscsi                                 7s\ncstor-new                      openebs.io/provisioner-iscsi                                 1d\ncstor-sts                      openebs.io/provisioner-iscsi                                 1d\njiva-1r                        openebs.io/provisioner-iscsi                                 34d\nlocal-pv-hostpath              openebs.io/local                                             3s\nnfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d\nopenebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 9s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi                                 10s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi                                 5s\nopenebs-mongodb                openebs.io/provisioner-iscsi                                 27d\nopenebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d\nopenebs-standalone             openebs.io/provisioner-iscsi                                 27d\nopenebs-standard               openebs.io/provisioner-iscsi                                 27d\nwordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d", "stdout_lines": ["NAME                           PROVISIONER                                                  AGE", "cstor-1r                       openebs.io/provisioner-iscsi                                 27d", "cstor-disk-standalone          openebs.io/provisioner-iscsi                                 7s", "cstor-new                      openebs.io/provisioner-iscsi                                 1d", "cstor-sts                      openebs.io/provisioner-iscsi                                 1d", "jiva-1r                        openebs.io/provisioner-iscsi                                 34d", "local-pv-hostpath              openebs.io/local                                             3s", "nfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d", "openebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 9s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi                                 10s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi                                 5s", "openebs-mongodb                openebs.io/provisioner-iscsi                                 27d", "openebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d", "openebs-standalone             openebs.io/provisioner-iscsi                                 27d", "openebs-standard               openebs.io/provisioner-iscsi                                 27d", "wordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d"]}
changed: [127.0.0.1] => (item=cstor-disk-standalone) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.331226", "end": "2019-05-09 09:49:48.252988", "item": "cstor-disk-standalone", "rc": 0, "start": "2019-05-09 09:49:46.921762", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                                                  AGE\ncstor-1r                       openebs.io/provisioner-iscsi                                 27d\ncstor-disk-standalone          openebs.io/provisioner-iscsi                                 9s\ncstor-new                      openebs.io/provisioner-iscsi                                 1d\ncstor-sts                      openebs.io/provisioner-iscsi                                 1d\njiva-1r                        openebs.io/provisioner-iscsi                                 34d\nlocal-pv-hostpath              openebs.io/local                                             5s\nnfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d\nopenebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 11s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi                                 12s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi                                 7s\nopenebs-mongodb                openebs.io/provisioner-iscsi                                 27d\nopenebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d\nopenebs-standalone             openebs.io/provisioner-iscsi                                 27d\nopenebs-standard               openebs.io/provisioner-iscsi                                 27d\nwordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d", "stdout_lines": ["NAME                           PROVISIONER                                                  AGE", "cstor-1r                       openebs.io/provisioner-iscsi                                 27d", "cstor-disk-standalone          openebs.io/provisioner-iscsi                                 9s", "cstor-new                      openebs.io/provisioner-iscsi                                 1d", "cstor-sts                      openebs.io/provisioner-iscsi                                 1d", "jiva-1r                        openebs.io/provisioner-iscsi                                 34d", "local-pv-hostpath              openebs.io/local                                             5s", "nfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d", "openebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 11s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi                                 12s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi                                 7s", "openebs-mongodb                openebs.io/provisioner-iscsi                                 27d", "openebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d", "openebs-standalone             openebs.io/provisioner-iscsi                                 27d", "openebs-standard               openebs.io/provisioner-iscsi                                 27d", "wordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d"]}
changed: [127.0.0.1] => (item=openebs-jiva-standalone) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:02.266497", "end": "2019-05-09 09:49:50.834832", "item": "openebs-jiva-standalone", "rc": 0, "start": "2019-05-09 09:49:48.568335", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                                                  AGE\ncstor-1r                       openebs.io/provisioner-iscsi                                 27d\ncstor-disk-standalone          openebs.io/provisioner-iscsi                                 10s\ncstor-new                      openebs.io/provisioner-iscsi                                 1d\ncstor-sts                      openebs.io/provisioner-iscsi                                 1d\njiva-1r                        openebs.io/provisioner-iscsi                                 34d\nlocal-pv-hostpath              openebs.io/local                                             6s\nnfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d\nopenebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 12s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi                                 13s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi                                 8s\nopenebs-mongodb                openebs.io/provisioner-iscsi                                 27d\nopenebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d\nopenebs-standalone             openebs.io/provisioner-iscsi                                 27d\nopenebs-standard               openebs.io/provisioner-iscsi                                 27d\nwordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d", "stdout_lines": ["NAME                           PROVISIONER                                                  AGE", "cstor-1r                       openebs.io/provisioner-iscsi                                 27d", "cstor-disk-standalone          openebs.io/provisioner-iscsi                                 10s", "cstor-new                      openebs.io/provisioner-iscsi                                 1d", "cstor-sts                      openebs.io/provisioner-iscsi                                 1d", "jiva-1r                        openebs.io/provisioner-iscsi                                 34d", "local-pv-hostpath              openebs.io/local                                             6s", "nfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d", "openebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 12s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi                                 13s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi                                 8s", "openebs-mongodb                openebs.io/provisioner-iscsi                                 27d", "openebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d", "openebs-standalone             openebs.io/provisioner-iscsi                                 27d", "openebs-standard               openebs.io/provisioner-iscsi                                 27d", "wordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d"]}
changed: [127.0.0.1] => (item=local-pv-hostpath) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:02.276887", "end": "2019-05-09 09:49:53.406261", "item": "local-pv-hostpath", "rc": 0, "start": "2019-05-09 09:49:51.129374", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                                                  AGE\ncstor-1r                       openebs.io/provisioner-iscsi                                 27d\ncstor-disk-standalone          openebs.io/provisioner-iscsi                                 13s\ncstor-new                      openebs.io/provisioner-iscsi                                 1d\ncstor-sts                      openebs.io/provisioner-iscsi                                 1d\njiva-1r                        openebs.io/provisioner-iscsi                                 34d\nlocal-pv-hostpath              openebs.io/local                                             9s\nnfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d\nopenebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 15s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi                                 16s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi                                 11s\nopenebs-mongodb                openebs.io/provisioner-iscsi                                 27d\nopenebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d\nopenebs-standalone             openebs.io/provisioner-iscsi                                 27d\nopenebs-standard               openebs.io/provisioner-iscsi                                 27d\nwordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d", "stdout_lines": ["NAME                           PROVISIONER                                                  AGE", "cstor-1r                       openebs.io/provisioner-iscsi                                 27d", "cstor-disk-standalone          openebs.io/provisioner-iscsi                                 13s", "cstor-new                      openebs.io/provisioner-iscsi                                 1d", "cstor-sts                      openebs.io/provisioner-iscsi                                 1d", "jiva-1r                        openebs.io/provisioner-iscsi                                 34d", "local-pv-hostpath              openebs.io/local                                             9s", "nfs-sc1                        cluster.local/openebs-nfs-nfs-server-provisioner             24d", "openebs-cstor-sparse           openebs.io/provisioner-iscsi                                 50d", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi                                 15s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi                                 16s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi                                 11s", "openebs-mongodb                openebs.io/provisioner-iscsi                                 27d", "openebs-snapshot-promoter      volumesnapshot.external-storage.k8s.io/snapshot-promoter     50d", "openebs-standalone             openebs.io/provisioner-iscsi                                 27d", "openebs-standard               openebs.io/provisioner-iscsi                                 27d", "wordpress-nfs-sc1              cluster.local/openebs-nfs-wordpress-nfs-server-provisioner   24d"]}

TASK [Delete storage classes with specific storage policies] *******************
skipping: [127.0.0.1] => (item=cstor-xfs-sc.yml)  => {"changed": false, "item": "cstor-xfs-sc.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-volume-monitor-sc.yml)  => {"changed": false, "item": "cstor-volume-monitor-sc.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-disk-standalone.yml)  => {"changed": false, "item": "cstor-disk-standalone.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=jiva-standalone.yml)  => {"changed": false, "item": "jiva-standalone.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=local-pv-hostpath.yml)  => {"changed": false, "item": "local-pv-hostpath.yml", "skip_reason": "Conditional result was False"}

TASK [Confirm that the storage classes are deleted] ****************************
skipping: [127.0.0.1] => (item=openebs-cstor-xfs)  => {"changed": false, "item": "openebs-cstor-xfs", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-cstor-volume-monitor)  => {"changed": false, "item": "openebs-cstor-volume-monitor", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=local-pv-hostpath)  => {"changed": false, "item": "local-pv-hostpath", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-disk-standalone)  => {"changed": false, "item": "cstor-disk-standalone", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-jiva-standalone)  => {"changed": false, "item": "openebs-jiva-standalone", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "6e94dfb55c4ccfb6432dba6acf4a8b8ceb69b3eb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "d034c749a7babc059b60d5c108da3c55", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1557395394.41-214683266946564/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.191860", "end": "2019-05-09 09:49:58.693599", "rc": 0, "start": "2019-05-09 09:49:57.501739", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-storage-policies \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-storage-policies ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.441355", "end": "2019-05-09 09:50:00.486330", "failed_when_result": false, "rc": 0, "start": "2019-05-09 09:49:59.044975", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-storage-policies configured", "stdout_lines": ["litmusresult.litmus.io/cstor-storage-policies configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=14   changed=9    unreachable=0    failed=0   
```