### PR TITLE
Refactor litmusbook for cstor-pool provision to take pool-count as env

### DIFF
--- a/providers/cstor/cstor-disk-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-disk-pool/run_litmus_test.yml
@@ -42,6 +42,9 @@ spec:
 
           - name: OPERATOR_NS
             value: openebs
+            # Number of cstor pool to be created based on disk distribution across the nodes
+          - name: CSTOR_POOL_COUNT
+            value: 5
 
             ## two values: create and delete 
           - name: ACTION

--- a/providers/cstor/cstor-disk-pool/test.yml
+++ b/providers/cstor/cstor-disk-pool/test.yml
@@ -77,7 +77,7 @@
               args:
                 executable: /bin/bash
               register: pool_count
-              until: pool_count.stdout_lines|length == diskList.stdout_lines|length
+              until: "(pool_count.stdout_lines|length) == (cstor_pool_count|int)" 
               retries: 10
               delay: 15
 

--- a/providers/cstor/cstor-disk-pool/test_vars.yml
+++ b/providers/cstor/cstor-disk-pool/test_vars.yml
@@ -3,6 +3,7 @@
 cstor_spc: cstor-spc.yaml
 test_name: cstor-disk-pool-provision
 pool_name: "{{ lookup('env','POOL_NAME') }}"
+cstor_pool_count: "{{ lookup('env','CSTOR_POOL_COUNT') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
 cstor_image: "{{ lookup('env','CSTOR_IMAGE') }}"
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- This litmusbook now takes CSTOR_POOL_COUNT as env-var and consumes its value to validate number of pool pods created.

**Following is the log of ansible-test container:**
```
TASK [Getting list of unused disks attached] ***********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "sort used_disks > a1\n sort all_disks > a2\n diff a2 a1 | grep -e \"<\" -e \">\" | awk '{print $2}'", "delta": "0:00:01.161429", "end": "2019-05-10 09:36:26.719681", "rc": 0, "start": "2019-05-10 09:36:25.558252", "stderr": "", "stderr_lines": [], "stdout": "disk-592f162914abf0c392bea480845d8422\ndisk-6911d32fb9e9d958966e09b373fd679c\ndisk-6d77e19f09d49a1b9395779f150e8de5", "stdout_lines": ["disk-592f162914abf0c392bea480845d8422", "disk-6911d32fb9e9d958966e09b373fd679c", "disk-6d77e19f09d49a1b9395779f150e8de5"]}

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "8de4efdb514af9fbc326c6034dbdcb9d41ce2105", "dest": "./cstor-spc.yaml", "gid": 0, "group": "root", "md5sum": "1790a067d02f7f476c1e40254b13990f", "mode": "0644", "owner": "root", "size": 1183, "src": "/root/.ansible/tmp/ansible-tmp-1557480986.83-160940397765248/source", "state": "file", "uid": 0}

TASK [Add the discovered disks to the pool specs file.] ************************
changed: [127.0.0.1] => (item=disk-592f162914abf0c392bea480845d8422) => {"backup": "", "changed": true, "item": "disk-592f162914abf0c392bea480845d8422", "msg": "line added"}
changed: [127.0.0.1] => (item=disk-6911d32fb9e9d958966e09b373fd679c) => {"backup": "", "changed": true, "item": "disk-6911d32fb9e9d958966e09b373fd679c", "msg": "line added"}
changed: [127.0.0.1] => (item=disk-6d77e19f09d49a1b9395779f150e8de5) => {"backup": "", "changed": true, "item": "disk-6d77e19f09d49a1b9395779f150e8de5", "msg": "line added"}

TASK [Create cStor Disk Pool] **************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f \"/providers/cstor/cstor-disk-pool/cstor-spc.yaml\"", "delta": "0:00:01.284275", "end": "2019-05-10 09:36:29.645922", "rc": 0, "start": "2019-05-10 09:36:28.361647", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-disk-pool created\nstorageclass.storage.k8s.io/openebs-cstor-disk created", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-disk-pool created", "storageclass.storage.k8s.io/openebs-cstor-disk created"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
FAILED - RETRYING: Verify if cStor Disk Pool are Running (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-disk-pool --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.278289", "end": "2019-05-10 09:37:18.064897", "rc": 0, "start": "2019-05-10 09:37:16.786608", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Verify if cStor Disk Pool are created on each node] **********************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-disk-pool --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.105393", "end": "2019-05-10 09:37:19.484650", "rc": 0, "start": "2019-05-10 09:37:18.379257", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.131902", "end": "2019-05-10 09:37:21.107307", "rc": 0, "start": "2019-05-10 09:37:19.975405", "stderr": "", "stderr_lines": [], "stdout": "cstor-disk-pool-7hbs-6485f8fbd8-qx6k2\ncstor-disk-pool-7yvd-7bbc9cfb5f-2xn6p\ncstor-disk-pool-dk3h-57f6dbbd9d-5f648", "stdout_lines": ["cstor-disk-pool-7hbs-6485f8fbd8-qx6k2", "cstor-disk-pool-7yvd-7bbc9cfb5f-2xn6p", "cstor-disk-pool-dk3h-57f6dbbd9d-5f648"]}

```
