### PR TITLE
feat[litmusbook]: Included litmusbook for statefulset target affinity check

### DIFF
--- a/experiments/functional/app-target-affinity/functional_util.j2
+++ b/experiments/functional/app-target-affinity/functional_util.j2
@@ -1,0 +1,5 @@
+{% if deploy_type is defined and deploy_type == 'deployment' %}
+  functional_util: scm/openebs/target_affinity_check.yml
+{% else %}
+  functional_util: scm/openebs/sts_target_affinity_check.yml
+{% endif %}

--- a/experiments/functional/app-target-affinity/run_litmus_test.yml
+++ b/experiments/functional/app-target-affinity/run_litmus_test.yml
@@ -35,5 +35,10 @@ spec:
           - name: OPERATOR_NS
             value: openebs
 
+            # To check affinity for deployments deploy type is deployment
+            # to check affinity for statefulset deploy type is statefulset
+          - name: DEPLOY_TYPE
+            value: deployment
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/app-target-affinity/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/app-target-affinity/run_litmus_test.yml
+++ b/experiments/functional/app-target-affinity/run_litmus_test.yml
@@ -35,8 +35,8 @@ spec:
           - name: OPERATOR_NS
             value: openebs
 
-            # To check affinity for deployments deploy type is deployment
-            # to check affinity for statefulset deploy type is statefulset
+            # To check affinity for deployments, 'DEPLOY_TYPE'  should be "deployment"
+            # To check affinity for statefulsets, 'DEPLOY_TYPE' should be "statefulset"
           - name: DEPLOY_TYPE
             value: deployment
 

--- a/experiments/functional/app-target-affinity/test.yml
+++ b/experiments/functional/app-target-affinity/test.yml
@@ -25,6 +25,18 @@
           vars:
             status: 'SOT'
 
+        - name: Identify the functional util to be invoked
+          template:
+            src: functional_util.j2
+            dest: functional_util.yml
+
+        - include_vars:
+            file: functional_util.yml
+
+        - name: Record the functional util path
+          set_fact: 
+            functional_util_path: "/utils/{{ functional_util }}"
+
         - name: Obtain the pvc name of the application.
           shell: >
             kubectl get pvc -n {{ application_ns }} -l {{ application_label }} 
@@ -33,15 +45,12 @@
             executable: /bin/bash
           register: pvc_name
 
-       ## Include an utility from litmus scm(solution common module) to check the application target affinity.
-       ## Passing app_ns, app_pvc, operator_ns, app_label and clone name as environmental variable.
-
-        - include_tasks: /utils/scm/openebs/target_affinity_check.yml
-          vars:
-            app_ns: "{{ application_ns}}"
-            app_label: "{{ application_label }}"
-            app_pvc: "{{ pvc_name.stdout }}"
-            operator_ns: "{{ operatorns }}"
+       ## Passing app_ns, app_pvc, operator_ns, app_label as environmental variable.
+        - include: "{{ functional_util_path }}"
+          app_ns: "{{ application_ns}}"
+          app_label: "{{ application_label }}"
+          app_pvc: "{{ pvc_name.stdout }}"
+          operator_ns: "{{ operatorns }}"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/app-target-affinity/test_vars.yml
+++ b/experiments/functional/app-target-affinity/test_vars.yml
@@ -6,3 +6,5 @@ application_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 operatorns: "{{ lookup('env','OPERATOR_NS') }}"
 
 application_label: "{{ lookup('env','APP_LABEL') }}"
+
+deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"

--- a/utils/scm/openebs/sts_target_affinity_check.yml
+++ b/utils/scm/openebs/sts_target_affinity_check.yml
@@ -1,0 +1,81 @@
+  - name: Obtain node where app pod resides
+    shell: >
+      kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+      --no-headers -o custom-columns=:spec.nodeName
+    args:
+      executable: /bin/bash
+    register: app_node
+
+  - name: Derive PVC from application pod
+    shell: >
+      kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+      --no-headers -o custom-columns=:spec.volumes[0].persistentVolumeClaim.claimName
+    args:
+      executable: /bin/bash
+    register: pvc
+
+  - name: Derive PV from application PVC
+    shell: >
+      kubectl get pvc {{ item }} 
+      -o custom-columns=:spec.volumeName -n {{ app_ns }}
+      --no-headers
+    args:
+      executable: /bin/bash
+    register: pv
+    with_items: 
+        - "{{ pvc.stdout_lines }}"
+
+  - name: Derive storage engine from PV
+    shell: >
+      kubectl get pv {{ item.stdout_lines[0] }} --no-headers
+      -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+    args:
+      executable: /bin/bash
+    register: stg_engine
+    with_items:
+        - "{{ pv.results }} "
+
+  - set_fact:
+      stg: "{{ stg|default([])}}"
+
+  - name: Build a list of storage engine
+    set_fact:
+      stg : "{{ stg  }} + [ '{{ item.stdout_lines[0] }}' ]"
+    with_items: "{{ stg_engine.results }}"
+
+  - set_fact:
+      target_ns: "{{ app_ns }}"
+      target_label: "openebs.io/controller=jiva-controller"
+    when: "((stg|unique)|length) == 1 and 'jiva' in stg"
+
+  - set_fact:
+      target_ns: "{{ operator_ns }}"
+      target_label: "openebs.io/target=cstor-target"
+    when: "((stg|unique)|length) == 1 and 'cstor' in stg"
+
+  - name: Obtain the node where PV target pod resides
+    shell: >
+      kubectl get pod -n {{ target_ns }} 
+      -l openebs.io/target=cstor-target
+      -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume-claim=="{{ item }}")].spec.nodeName}' 
+    args:
+      executable: /bin/bash
+    register: target_node
+    with_items: 
+        - "{{ pvc.stdout_lines }}"
+
+  - set_fact: 
+      targetnode: "{{ targetnode|default([])}}"
+
+  - name: Build a list of target nodes
+    set_fact:
+      targetnode : "{{ targetnode  }} + [ '{{ item.stdout_lines[0] }}' ]"
+    with_items: "{{ target_node.results }}"
+
+  - name: Verify whether the app & target pod co-exist on same node
+    debug: 
+      msg: "App and Target affinity is maintained"
+    failed_when: "item.0  !=  item.1"
+    with_together:
+      - "{{ targetnode }}"
+      - "{{ app_node.stdout_lines }}"

--- a/utils/scm/openebs/sts_target_affinity_check.yml
+++ b/utils/scm/openebs/sts_target_affinity_check.yml
@@ -56,7 +56,7 @@
   - name: Obtain the node where PV target pod resides
     shell: >
       kubectl get pod -n {{ target_ns }} 
-      -l openebs.io/target=cstor-target
+      -l {{ target_label }}
       -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume-claim=="{{ item }}")].spec.nodeName}' 
     args:
       executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Created util for statefulset target affinity check
- Modified the target affinity check litmubook to use the utils based on env

```
ansible-playbook 2.7.8
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/app-target-affinity/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:11
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:21
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:24
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "70ecada792ff7601e79af6b588f7ab2a08600218", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "14bf30aa512da3c90c5db005b94cded3", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1557727204.8-65966693839104/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.091446", "end": "2019-05-13 06:00:07.428601", "rc": 0, "start": "2019-05-13 06:00:06.337155", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.847445", "end": "2019-05-13 06:00:09.611958", "failed_when_result": false, "rc": 0, "start": "2019-05-13 06:00:07.764513", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/app-target-affinity configured", "stdout_lines": ["litmusresult.litmus.io/app-target-affinity configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the functional util to be invoked] ******************************
task path: /experiments/functional/app-target-affinity/test.yml:28
changed: [127.0.0.1] => {"changed": true, "checksum": "5b029dca2313c0d7a37d7c299f865d44f7b57375", "dest": "./functional_util.yml", "gid": 0, "group": "root", "md5sum": "45cf49a49c8cd235848cd4557b36567c", "mode": "0644", "owner": "root", "size": 61, "src": "/root/.ansible/tmp/ansible-tmp-1557727210.18-50730392145126/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:33
ok: [127.0.0.1] => {"ansible_facts": {"functional_util": "scm/openebs/sts_target_affinity_check.yml"}, "ansible_included_var_files": ["/experiments/functional/app-target-affinity/functional_util.yml"], "changed": false}

TASK [Record the functional util path] *****************************************
task path: /experiments/functional/app-target-affinity/test.yml:36
ok: [127.0.0.1] => {"ansible_facts": {"functional_util_path": "/utils/scm/openebs/sts_target_affinity_check.yml"}, "changed": false}

TASK [Obtain the pvc name of the application.] *********************************
task path: /experiments/functional/app-target-affinity/test.yml:40
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n bb-sts -l app=busybox -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.368209", "end": "2019-05-13 06:00:12.613817", "rc": 0, "start": "2019-05-13 06:00:11.245608", "stderr": "", "stderr_lines": [], "stdout": "busybox-claim-busybox-0\nbusybox-claim-busybox-1", "stdout_lines": ["busybox-claim-busybox-0", "busybox-claim-busybox-1"]}

TASK [include] *****************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:49
included: /utils/scm/openebs/sts_target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=busybox -n bb-sts --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:02.204333", "end": "2019-05-13 06:00:15.570376", "rc": 0, "start": "2019-05-13 06:00:13.366043", "stderr": "", "stderr_lines": [], "stdout": "node1-1552029851.mayalabs.io\nnode2-1552029851.mayalabs.io", "stdout_lines": ["node1-1552029851.mayalabs.io", "node2-1552029851.mayalabs.io"]}

TASK [Derive PVC from application pod] *****************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:9
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=busybox -n bb-sts --no-headers -o custom-columns=:spec.volumes[0].persistentVolumeClaim.claimName", "delta": "0:00:01.254268", "end": "2019-05-13 06:00:17.244149", "rc": 0, "start": "2019-05-13 06:00:15.989881", "stderr": "", "stderr_lines": [], "stdout": "busybox-claim-busybox-0\nbusybox-claim-busybox-1", "stdout_lines": ["busybox-claim-busybox-0", "busybox-claim-busybox-1"]}

TASK [Derive PV from application PVC] ******************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:17
changed: [127.0.0.1] => (item=busybox-claim-busybox-0) => {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.341640", "end": "2019-05-13 06:00:19.091416", "item": "busybox-claim-busybox-0", "rc": 0, "start": "2019-05-13 06:00:17.749776", "stderr": "", "stderr_lines": [], "stdout": "pvc-df3ecdcc-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-df3ecdcc-7308-11e9-93ba-0050569846e3"]}
changed: [127.0.0.1] => (item=busybox-claim-busybox-1) => {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.354431", "end": "2019-05-13 06:00:20.723372", "item": "busybox-claim-busybox-1", "rc": 0, "start": "2019-05-13 06:00:19.368941", "stderr": "", "stderr_lines": [], "stdout": "pvc-ef745077-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-ef745077-7308-11e9-93ba-0050569846e3"]}

TASK [Derive storage engine from PV] *******************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:28
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.341640', 'stdout_lines': [u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-0', u'end': u'2019-05-13 06:00:19.091416', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', 'item': u'busybox-claim-busybox-0', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:17.749776', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pv pvc-df3ecdcc-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.349344", "end": "2019-05-13 06:00:22.325838", "item": {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.341640", "end": "2019-05-13 06:00:19.091416", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-0", "rc": 0, "start": "2019-05-13 06:00:17.749776", "stderr": "", "stderr_lines": [], "stdout": "pvc-df3ecdcc-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-df3ecdcc-7308-11e9-93ba-0050569846e3"]}, "rc": 0, "start": "2019-05-13 06:00:20.976494", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'pvc-ef745077-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.354431', 'stdout_lines': [u'pvc-ef745077-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-1', u'end': u'2019-05-13 06:00:20.723372', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', 'item': u'busybox-claim-busybox-1', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:19.368941', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pv pvc-ef745077-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.177720", "end": "2019-05-13 06:00:23.798320", "item": {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.354431", "end": "2019-05-13 06:00:20.723372", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-1", "rc": 0, "start": "2019-05-13 06:00:19.368941", "stderr": "", "stderr_lines": [], "stdout": "pvc-ef745077-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-ef745077-7308-11e9-93ba-0050569846e3"]}, "rc": 0, "start": "2019-05-13 06:00:22.620600", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:38
ok: [127.0.0.1] => {"ansible_facts": {"stg": []}, "changed": false}

TASK [Build a list of storage engine] ******************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:41
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor', '_ansible_item_result': True, u'delta': u'0:00:01.349344', 'stdout_lines': [u'cstor'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.341640', 'stdout_lines': [u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-0', u'end': u'2019-05-13 06:00:19.091416', '_ansible_no_log': False, u'start': u'2019-05-13 06:00:17.749776', u'cmd': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', 'failed': False, 'item': u'busybox-claim-busybox-0', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-05-13 06:00:22.325838', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pv pvc-df3ecdcc-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath="{.metadata.annotations.openebs\\\\.io/cas-type}"', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.341640', 'stdout_lines': [u'pvc-df3ecdcc-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-0', u'end': u'2019-05-13 06:00:19.091416', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'start': u'2019-05-13 06:00:17.749776', 'item': u'busybox-claim-busybox-0', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pv pvc-df3ecdcc-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath="{.metadata.annotations.openebs\\\\.io/cas-type}"', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:20.976494', '_ansible_ignore_errors': None}) => {"ansible_facts": {"stg": ["cstor"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pv pvc-df3ecdcc-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.349344", "end": "2019-05-13 06:00:22.325838", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pv pvc-df3ecdcc-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.341640", "end": "2019-05-13 06:00:19.091416", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pvc busybox-claim-busybox-0 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-0", "rc": 0, "start": "2019-05-13 06:00:17.749776", "stderr": "", "stderr_lines": [], "stdout": "pvc-df3ecdcc-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-df3ecdcc-7308-11e9-93ba-0050569846e3"]}, "rc": 0, "start": "2019-05-13 06:00:20.976494", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor', '_ansible_item_result': True, u'delta': u'0:00:01.177720', 'stdout_lines': [u'cstor'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'pvc-ef745077-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.354431', 'stdout_lines': [u'pvc-ef745077-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-1', u'end': u'2019-05-13 06:00:20.723372', '_ansible_no_log': False, u'start': u'2019-05-13 06:00:19.368941', u'cmd': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', 'failed': False, 'item': u'busybox-claim-busybox-1', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-05-13 06:00:23.798320', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pv pvc-ef745077-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath="{.metadata.annotations.openebs\\\\.io/cas-type}"', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'pvc-ef745077-7308-11e9-93ba-0050569846e3', '_ansible_item_result': True, u'delta': u'0:00:01.354431', 'stdout_lines': [u'pvc-ef745077-7308-11e9-93ba-0050569846e3'], '_ansible_item_label': u'busybox-claim-busybox-1', u'end': u'2019-05-13 06:00:20.723372', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'start': u'2019-05-13 06:00:19.368941', 'item': u'busybox-claim-busybox-1', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pv pvc-ef745077-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath="{.metadata.annotations.openebs\\\\.io/cas-type}"', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:22.620600', '_ansible_ignore_errors': None}) => {"ansible_facts": {"stg": ["cstor", "cstor"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pv pvc-ef745077-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.177720", "end": "2019-05-13 06:00:23.798320", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pv pvc-ef745077-7308-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "delta": "0:00:01.354431", "end": "2019-05-13 06:00:20.723372", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pvc busybox-claim-busybox-1 -o custom-columns=:spec.volumeName -n bb-sts --no-headers", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-1", "rc": 0, "start": "2019-05-13 06:00:19.368941", "stderr": "", "stderr_lines": [], "stdout": "pvc-ef745077-7308-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-ef745077-7308-11e9-93ba-0050569846e3"]}, "rc": 0, "start": "2019-05-13 06:00:22.620600", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:46
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:51
ok: [127.0.0.1] => {"ansible_facts": {"target_label": "openebs.io/target=cstor-target", "target_ns": "openebs"}, "changed": false}

TASK [Obtain the node where PV target pod resides] *****************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:56
changed: [127.0.0.1] => (item=busybox-claim-busybox-0) => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-0\")].spec.nodeName}'", "delta": "0:00:01.255567", "end": "2019-05-13 06:00:26.128947", "item": "busybox-claim-busybox-0", "rc": 0, "start": "2019-05-13 06:00:24.873380", "stderr": "", "stderr_lines": [], "stdout": "node1-1552029851.mayalabs.io", "stdout_lines": ["node1-1552029851.mayalabs.io"]}
changed: [127.0.0.1] => (item=busybox-claim-busybox-1) => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-1\")].spec.nodeName}'", "delta": "0:00:01.213420", "end": "2019-05-13 06:00:27.667473", "item": "busybox-claim-busybox-1", "rc": 0, "start": "2019-05-13 06:00:26.454053", "stderr": "", "stderr_lines": [], "stdout": "node2-1552029851.mayalabs.io", "stdout_lines": ["node2-1552029851.mayalabs.io"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:67
ok: [127.0.0.1] => {"ansible_facts": {"targetnode": []}, "changed": false}

TASK [Build a list of target nodes] ********************************************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:70
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'node1-1552029851.mayalabs.io', '_ansible_item_result': True, u'delta': u'0:00:01.255567', 'stdout_lines': [u'node1-1552029851.mayalabs.io'], '_ansible_item_label': u'busybox-claim-busybox-0', u'end': u'2019-05-13 06:00:26.128947', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath=\'{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim=="busybox-claim-busybox-0")].spec.nodeName}\'', 'item': u'busybox-claim-busybox-0', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath=\'{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim=="busybox-claim-busybox-0")].spec.nodeName}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:24.873380', '_ansible_ignore_errors': None}) => {"ansible_facts": {"targetnode": ["node1-1552029851.mayalabs.io"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-0\")].spec.nodeName}'", "delta": "0:00:01.255567", "end": "2019-05-13 06:00:26.128947", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-0\")].spec.nodeName}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-0", "rc": 0, "start": "2019-05-13 06:00:24.873380", "stderr": "", "stderr_lines": [], "stdout": "node1-1552029851.mayalabs.io", "stdout_lines": ["node1-1552029851.mayalabs.io"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'node2-1552029851.mayalabs.io', '_ansible_item_result': True, u'delta': u'0:00:01.213420', 'stdout_lines': [u'node2-1552029851.mayalabs.io'], '_ansible_item_label': u'busybox-claim-busybox-1', u'end': u'2019-05-13 06:00:27.667473', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath=\'{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim=="busybox-claim-busybox-1")].spec.nodeName}\'', 'item': u'busybox-claim-busybox-1', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath=\'{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim=="busybox-claim-busybox-1")].spec.nodeName}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-05-13 06:00:26.454053', '_ansible_ignore_errors': None}) => {"ansible_facts": {"targetnode": ["node1-1552029851.mayalabs.io", "node2-1552029851.mayalabs.io"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-1\")].spec.nodeName}'", "delta": "0:00:01.213420", "end": "2019-05-13 06:00:27.667473", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume-claim==\"busybox-claim-busybox-1\")].spec.nodeName}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "busybox-claim-busybox-1", "rc": 0, "start": "2019-05-13 06:00:26.454053", "stderr": "", "stderr_lines": [], "stdout": "node2-1552029851.mayalabs.io", "stdout_lines": ["node2-1552029851.mayalabs.io"]}}

TASK [Verify whether the app & target pod co-exist on same node] ***************
task path: /utils/scm/openebs/sts_target_affinity_check.yml:75
ok: [127.0.0.1] => (item=[u'node1-1552029851.mayalabs.io', u'node1-1552029851.mayalabs.io']) => {
    "msg": "App and Target affinity is maintained"
}
ok: [127.0.0.1] => (item=[u'node2-1552029851.mayalabs.io', u'node2-1552029851.mayalabs.io']) => {
    "msg": "App and Target affinity is maintained"
}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:55
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:64
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "0699a5e03a635b74e1f34e3333959b014cfc5a44", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "70712221afc41193cb8805683862b90e", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1557727228.95-45654229632597/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.143073", "end": "2019-05-13 06:00:32.629999", "rc": 0, "start": "2019-05-13 06:00:31.486926", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.564464", "end": "2019-05-13 06:00:34.485276", "failed_when_result": false, "rc": 0, "start": "2019-05-13 06:00:32.920812", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/app-target-affinity configured", "stdout_lines": ["litmusresult.litmus.io/app-target-affinity configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=13   unreachable=0    failed=0 
```