### PR TITLE
feat(yaml):Including a storage class with performance tunable parameters

### DIFF
--- a/providers/cstor-storage-policies/cstor-perf-parameters.j2
+++ b/providers/cstor-storage-policies/cstor-perf-parameters.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cstor-performance-config
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "{{ pool_name }}"
+      - name: QueueDepth
+        value: "{{ queue_depth_value }}"
+      - name: Luworkers
+        value: "{{ lu_workers }}"
+      - name: ZvolWorkers
+        value: "{{ zvol_workers }}"
+provisioner: openebs.io/provisioner-iscsi

--- a/providers/cstor-storage-policies/run_litmus_test.yml
+++ b/providers/cstor-storage-policies/run_litmus_test.yml
@@ -32,6 +32,15 @@ spec:
           - name: POOL_PATH
             value: "/var/openebs/local"
 
+          - name: QUEUE_DEPTH
+            value: "20"
+
+          - name: LU_WORKER
+            value: "10"
+
+          - name: ZVOL_WORKER
+            value: "4"
+
             ## two values: create and delete 
           - name: ACTION
             value: create

--- a/providers/cstor-storage-policies/test.yml
+++ b/providers/cstor-storage-policies/test.yml
@@ -25,6 +25,7 @@
              - { src: cstor-volume-monitor-sc.j2,dest: cstor-volume-monitor-sc.yml }
              - { src: cstor-disk-standalone.j2,dest: cstor-disk-standalone.yml }
              - { src: local-pv-hostpath.j2,dest: local-pv-hostpath.yml }
+             - { src: cstor-perf-parameters.j2,dest: cstor-perf-parameters.yml }
 
         - block:
 
@@ -50,6 +51,7 @@
                 - cstor-disk-standalone
                 - openebs-jiva-standalone
                 - local-pv-hostpath
+                - cstor-performance-config
 
           when: lookup('env','ACTION') == 'create'
 

--- a/providers/cstor-storage-policies/test_vars.yml
+++ b/providers/cstor-storage-policies/test_vars.yml
@@ -1,5 +1,5 @@
 # Test-specific parameters
-test_name: cstor-perf-parameters
+test_name: cstor-storage-policies
 pool_name: "{{ lookup('env','POOL_NAME') }}"
 local_pv_hostpath: "{{ lookup('env','POOL_PATH') }}"
 queue_depth_value: "{{ lookup('env','QUEUE_DEPTH') }}"

--- a/providers/cstor-storage-policies/test_vars.yml
+++ b/providers/cstor-storage-policies/test_vars.yml
@@ -1,11 +1,15 @@
 # Test-specific parameters
-test_name: cstor-storage-policies
+test_name: cstor-perf-parameters
 pool_name: "{{ lookup('env','POOL_NAME') }}"
 local_pv_hostpath: "{{ lookup('env','POOL_PATH') }}"
+queue_depth_value: "{{ lookup('env','QUEUE_DEPTH') }}"
+lu_workers: "{{ lookup('env','LU_WORKER') }}"
+zvol_workers: "{{ lookup('env','ZVOL_WORKER') }}"
 storage_policies:
   - cstor-xfs-sc.yml
   - cstor-volume-monitor-sc.yml
   - cstor-disk-standalone.yml
   - jiva-standalone.yml
   - local-pv-hostpath.yml
+  - cstor-perf-parameters.yml
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:

- Included storage class spec with performance tunables.
- Create a storage class (cstor-performance-config)  in storage policies playbook.
- Check if such storage class is created.

```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "788cf92c24da4fbc10f339a4abf744c4651dc111", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "564863cac7c8651c2ea91c5d096fe2bf", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1557815211.73-46951779847999/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.026773", "end": "2019-05-14 06:26:54.298437", "rc": 0, "start": "2019-05-14 06:26:53.271664", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-perf-parameters \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-perf-parameters ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.691983", "end": "2019-05-14 06:26:57.267066", "failed_when_result": false, "rc": 0, "start": "2019-05-14 06:26:54.575083", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-perf-parameters configured", "stdout_lines": ["litmusresult.litmus.io/cstor-perf-parameters configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate yaml files to create storage class] *****************************
changed: [127.0.0.1] => (item={u'dest': u'cstor-xfs-sc.yml', u'src': u'cstor-xfs-sc.j2'}) => {"changed": true, "checksum": "f4b16877fa436b114c365f624962c49277a55fef", "dest": "./cstor-xfs-sc.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-xfs-sc.yml", "src": "cstor-xfs-sc.j2"}, "md5sum": "14f993a75d2ea35f9c78f3025b703710", "mode": "0644", "owner": "root", "size": 312, "src": "/root/.ansible/tmp/ansible-tmp-1557815217.71-276382604229551/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'cstor-volume-monitor-sc.yml', u'src': u'cstor-volume-monitor-sc.j2'}) => {"changed": true, "checksum": "1b899f26f7597e60f2bdb55012a327f2a4d8a4ad", "dest": "./cstor-volume-monitor-sc.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-volume-monitor-sc.yml", "src": "cstor-volume-monitor-sc.j2"}, "md5sum": "a4ae032084ac5ae732d75db07e790fbc", "mode": "0644", "owner": "root", "size": 335, "src": "/root/.ansible/tmp/ansible-tmp-1557815218.15-185703422041817/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'cstor-disk-standalone.yml', u'src': u'cstor-disk-standalone.j2'}) => {"changed": true, "checksum": "9fb2ba2ee11400e66523a84a440a38da43c6d3d6", "dest": "./cstor-disk-standalone.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-disk-standalone.yml", "src": "cstor-disk-standalone.j2"}, "md5sum": "77679b5f8ab64cd295f13284c820ccb8", "mode": "0644", "owner": "root", "size": 322, "src": "/root/.ansible/tmp/ansible-tmp-1557815218.65-178188011756469/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'local-pv-hostpath.yml', u'src': u'local-pv-hostpath.j2'}) => {"changed": true, "checksum": "16dea3bd6a40f33030dc3bc11640b881afdac8a4", "dest": "./local-pv-hostpath.yml", "gid": 0, "group": "root", "item": {"dest": "local-pv-hostpath.yml", "src": "local-pv-hostpath.j2"}, "md5sum": "0c8be3880da5e7ebbdd2c8f5642037bb", "mode": "0644", "owner": "root", "size": 368, "src": "/root/.ansible/tmp/ansible-tmp-1557815219.02-42131178962386/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item={u'dest': u'cstor-perf-parameters.yml', u'src': u'cstor-perf-parameters.j2'}) => {"changed": true, "checksum": "7f427cbff69a280381c6a3aca435028e4bf45577", "dest": "./cstor-perf-parameters.yml", "gid": 0, "group": "root", "item": {"dest": "cstor-perf-parameters.yml", "src": "cstor-perf-parameters.j2"}, "md5sum": "9837bdd3a07d1f540b563dc49bd07d5a", "mode": "0644", "owner": "root", "size": 413, "src": "/root/.ansible/tmp/ansible-tmp-1557815219.59-252014895655442/source", "state": "file", "uid": 0}

TASK [Create storage classes with specific storage policies] *******************
changed: [127.0.0.1] => (item=cstor-xfs-sc.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-xfs-sc.yml", "delta": "0:00:01.692622", "end": "2019-05-14 06:27:02.082299", "item": "cstor-xfs-sc.yml", "rc": 0, "start": "2019-05-14 06:27:00.389677", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-xfs created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-xfs created"]}
changed: [127.0.0.1] => (item=cstor-volume-monitor-sc.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-volume-monitor-sc.yml", "delta": "0:00:01.582437", "end": "2019-05-14 06:27:03.894055", "item": "cstor-volume-monitor-sc.yml", "rc": 0, "start": "2019-05-14 06:27:02.311618", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-volume-monitor created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-volume-monitor created"]}
changed: [127.0.0.1] => (item=cstor-disk-standalone.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-disk-standalone.yml", "delta": "0:00:01.464475", "end": "2019-05-14 06:27:05.557693", "item": "cstor-disk-standalone.yml", "rc": 0, "start": "2019-05-14 06:27:04.093218", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/cstor-disk-standalone created", "stdout_lines": ["storageclass.storage.k8s.io/cstor-disk-standalone created"]}
changed: [127.0.0.1] => (item=jiva-standalone.yml) => {"changed": true, "cmd": "kubectl apply -f jiva-standalone.yml", "delta": "0:00:01.600466", "end": "2019-05-14 06:27:07.446276", "item": "jiva-standalone.yml", "rc": 0, "start": "2019-05-14 06:27:05.845810", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-jiva-standalone created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-jiva-standalone created"]}
changed: [127.0.0.1] => (item=local-pv-hostpath.yml) => {"changed": true, "cmd": "kubectl apply -f local-pv-hostpath.yml", "delta": "0:00:01.624177", "end": "2019-05-14 06:27:09.316386", "item": "local-pv-hostpath.yml", "rc": 0, "start": "2019-05-14 06:27:07.692209", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/local-pv-hostpath created", "stdout_lines": ["storageclass.storage.k8s.io/local-pv-hostpath created"]}
changed: [127.0.0.1] => (item=cstor-perf-parameters.yml) => {"changed": true, "cmd": "kubectl apply -f cstor-perf-parameters.yml", "delta": "0:00:01.473146", "end": "2019-05-14 06:27:11.086236", "item": "cstor-perf-parameters.yml", "rc": 0, "start": "2019-05-14 06:27:09.613090", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/cstor-performance-config created", "stdout_lines": ["storageclass.storage.k8s.io/cstor-performance-config created"]}

TASK [Confirm that the storage classes are created] ****************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ item }}" in result_sc.stdout
changed: [127.0.0.1] => (item=openebs-cstor-xfs) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.349175", "end": "2019-05-14 06:27:12.766249", "item": "openebs-cstor-xfs", "rc": 0, "start": "2019-05-14 06:27:11.417074", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   7s\ncstor-performance-config       openebs.io/provisioner-iscsi   1s\nlocal-pv-hostpath              openebs.io/local               3s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   9s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   10s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   5s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   7s", "cstor-performance-config       openebs.io/provisioner-iscsi   1s", "local-pv-hostpath              openebs.io/local               3s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   9s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   10s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   5s"]}
changed: [127.0.0.1] => (item=openebs-cstor-volume-monitor) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.364969", "end": "2019-05-14 06:27:14.413983", "item": "openebs-cstor-volume-monitor", "rc": 0, "start": "2019-05-14 06:27:13.049014", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   9s\ncstor-performance-config       openebs.io/provisioner-iscsi   3s\nlocal-pv-hostpath              openebs.io/local               5s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   11s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   12s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   7s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   9s", "cstor-performance-config       openebs.io/provisioner-iscsi   3s", "local-pv-hostpath              openebs.io/local               5s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   11s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   12s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   7s"]}
changed: [127.0.0.1] => (item=cstor-disk-standalone) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:02.361979", "end": "2019-05-14 06:27:17.124015", "item": "cstor-disk-standalone", "rc": 0, "start": "2019-05-14 06:27:14.762036", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   11s\ncstor-performance-config       openebs.io/provisioner-iscsi   5s\nlocal-pv-hostpath              openebs.io/local               7s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   13s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   14s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   9s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   11s", "cstor-performance-config       openebs.io/provisioner-iscsi   5s", "local-pv-hostpath              openebs.io/local               7s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   13s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   14s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   9s"]}
changed: [127.0.0.1] => (item=openebs-jiva-standalone) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.336064", "end": "2019-05-14 06:27:18.842378", "item": "openebs-jiva-standalone", "rc": 0, "start": "2019-05-14 06:27:17.506314", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   13s\ncstor-performance-config       openebs.io/provisioner-iscsi   7s\nlocal-pv-hostpath              openebs.io/local               9s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   15s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   16s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   11s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   13s", "cstor-performance-config       openebs.io/provisioner-iscsi   7s", "local-pv-hostpath              openebs.io/local               9s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   15s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   16s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   11s"]}
changed: [127.0.0.1] => (item=local-pv-hostpath) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:01.305629", "end": "2019-05-14 06:27:20.405084", "item": "local-pv-hostpath", "rc": 0, "start": "2019-05-14 06:27:19.099455", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   15s\ncstor-performance-config       openebs.io/provisioner-iscsi   9s\nlocal-pv-hostpath              openebs.io/local               11s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   17s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   18s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   13s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   15s", "cstor-performance-config       openebs.io/provisioner-iscsi   9s", "local-pv-hostpath              openebs.io/local               11s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   17s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   18s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   13s"]}
changed: [127.0.0.1] => (item=cstor-performance-config) => {"attempts": 1, "changed": true, "cmd": "kubectl get storageclass", "delta": "0:00:02.405110", "end": "2019-05-14 06:27:23.109025", "item": "cstor-performance-config", "rc": 0, "start": "2019-05-14 06:27:20.703915", "stderr": "", "stderr_lines": [], "stdout": "NAME                           PROVISIONER                    AGE\ncstor-disk-standalone          openebs.io/provisioner-iscsi   17s\ncstor-performance-config       openebs.io/provisioner-iscsi   11s\nlocal-pv-hostpath              openebs.io/local               13s\nopenebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   19s\nopenebs-cstor-xfs              openebs.io/provisioner-iscsi   20s\nopenebs-jiva-standalone        openebs.io/provisioner-iscsi   15s", "stdout_lines": ["NAME                           PROVISIONER                    AGE", "cstor-disk-standalone          openebs.io/provisioner-iscsi   17s", "cstor-performance-config       openebs.io/provisioner-iscsi   11s", "local-pv-hostpath              openebs.io/local               13s", "openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   19s", "openebs-cstor-xfs              openebs.io/provisioner-iscsi   20s", "openebs-jiva-standalone        openebs.io/provisioner-iscsi   15s"]}

TASK [Delete storage classes with specific storage policies] *******************
skipping: [127.0.0.1] => (item=cstor-xfs-sc.yml)  => {"changed": false, "item": "cstor-xfs-sc.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-volume-monitor-sc.yml)  => {"changed": false, "item": "cstor-volume-monitor-sc.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-disk-standalone.yml)  => {"changed": false, "item": "cstor-disk-standalone.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=jiva-standalone.yml)  => {"changed": false, "item": "jiva-standalone.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=local-pv-hostpath.yml)  => {"changed": false, "item": "local-pv-hostpath.yml", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-perf-parameters.yml)  => {"changed": false, "item": "cstor-perf-parameters.yml", "skip_reason": "Conditional result was False"}

TASK [Confirm that the storage classes are deleted] ****************************
skipping: [127.0.0.1] => (item=openebs-cstor-xfs)  => {"changed": false, "item": "openebs-cstor-xfs", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-cstor-volume-monitor)  => {"changed": false, "item": "openebs-cstor-volume-monitor", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=local-pv-hostpath)  => {"changed": false, "item": "local-pv-hostpath", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-disk-standalone)  => {"changed": false, "item": "cstor-disk-standalone", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-jiva-standalone)  => {"changed": false, "item": "openebs-jiva-standalone", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "89d5b73b28467dc1ea3ea0402e708fae34e9e073", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "055000617fd32ad15e0947cc3fdc94e8", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1557815244.34-137987807135642/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.092607", "end": "2019-05-14 06:27:28.356901", "rc": 0, "start": "2019-05-14 06:27:27.264294", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-perf-parameters \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-perf-parameters ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.579000", "end": "2019-05-14 06:27:30.230505", "failed_when_result": false, "rc": 0, "start": "2019-05-14 06:27:28.651505", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-perf-parameters configured", "stdout_lines": ["litmusresult.litmus.io/cstor-perf-parameters configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=14   changed=9    unreachable=0    failed=0 
```

```
[root@master-1552853078 cstor-storage-policies]# kubectl get sc
NAME                           PROVISIONER                    AGE
cstor-disk-standalone          openebs.io/provisioner-iscsi   9m
cstor-performance-config       openebs.io/provisioner-iscsi   9m
local-pv-hostpath              openebs.io/local               9m
openebs-cstor-volume-monitor   openebs.io/provisioner-iscsi   9m
openebs-cstor-xfs              openebs.io/provisioner-iscsi   9m
openebs-jiva-standalone        openebs.io/provisioner-iscsi   9m
```

```
[root@master-1552853078 cstor-storage-policies]# kubectl describe sc cstor-performance-config
Name:            cstor-performance-config
IsDefaultClass:  No
Annotations:     cas.openebs.io/config=- name: StoragePoolClaim
  value: "cstor-sparse-pool"
- name: QueueDepth
  value: "20"
- name: Luworkers
  value: "10"
- name: ZvolWorkers
  value: "4"
,kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"cas.openebs.io/config":"- name: StoragePoolClaim\n  value: \"cstor-sparse-pool\"\n- name: QueueDepth\n  value: \"20\"\n- name: Luworkers\n  value: \"10\"\n- name: ZvolWorkers\n  value: \"4\"\n","openebs.io/cas-type":"cstor"},"name":"cstor-performance-config"},"provisioner":"openebs.io/provisioner-iscsi"}
,openebs.io/cas-type=cstor
Provisioner:           openebs.io/provisioner-iscsi
Parameters:            <none>
AllowVolumeExpansion:  <unset>
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>
```

