### PR TITLE
refactor(yaml): Updated the task for busybox deployer litmusbook

### DIFF
--- a/apps/busybox/deployers/test.yml
+++ b/apps/busybox/deployers/test.yml
@@ -17,7 +17,7 @@
             status: 'SOT'
 
         - block:
-            - block: 
+            - block:
                   ## Creating namespaces and making the application for deployment
                 - include_tasks: /utils/k8s/pre_create_app_deploy.yml
                   vars:
@@ -76,7 +76,7 @@
                     delay: 10
                     retries: 20
               when: "'deprovision' not in action"
-            
+
             - name: Deprovisioning the Application
               include_tasks: "/utils/k8s/deprovision_deployment.yml"
               vars:

--- a/apps/busybox/deployers/test.yml
+++ b/apps/busybox/deployers/test.yml
@@ -17,73 +17,73 @@
             status: 'SOT'
 
         - block:
-              ## Creating namespaces and making the application for deployment
-            - include_tasks: /utils/k8s/pre_create_app_deploy.yml
-              vars:
-                application_deployment: "{{ application_statefulset }}"
+            - block: 
+                  ## Creating namespaces and making the application for deployment
+                - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+                  vars:
+                    application_deployment: "{{ application_statefulset }}"
 
-            - name: Replace the affinity label annotation in statefulset yml
-              replace:
-                path: "{{ application_statefulset }}"
-                regexp: "affinity_label: lvalue"
-                replace: "{{ affinity_label }}: {{ app_lvalue }}"
+                - name: Replace the affinity label annotation in statefulset yml
+                  replace:
+                    path: "{{ application_statefulset }}"
+                    regexp: "affinity_label: lvalue"
+                    replace: "{{ affinity_label }}: {{ app_lvalue }}"
 
-            - name: Replace the volume capcity placeholder with provider
-              replace:
-                path: "{{ application_statefulset }}"
-                regexp: "teststorage"
-                replace: "{{ lookup('env','PV_CAPACITY') }}"
+                - name: Replace the volume capcity placeholder with provider
+                  replace:
+                    path: "{{ application_statefulset }}"
+                    regexp: "teststorage"
+                    replace: "{{ lookup('env','PV_CAPACITY') }}"
 
-              ## Deploying the application
-            - include_tasks: /utils/k8s/deploy_single_app.yml
-              vars:
-                application_deployment: "{{ application_statefulset }}"
-                check_app_pod: 'no'
-                delay: 10
-                retries: 20
-
-          when: lookup('env','DEPLOY_TYPE') == 'statefulset'
-
-        - block:
-              ## Creating namespaces and making the application for deployment
-            - include_tasks: /utils/k8s/pre_create_app_deploy.yml
-
-            - name: Replace the affinity label annotation in deployment yml
-              replace:
-                path: "{{ application_deployment }}"
-                regexp: "affinity_label: lvalue"
-                replace: "{{ affinity_label }}: {{ app_lvalue }}"
-
-            - name: Replace the volume capcity placeholder with provider
-              replace:
-                path: "{{ application_deployment }}"
-                regexp: "teststorage"
-                replace: "{{ lookup('env','PV_CAPACITY') }}"
-
-              ## Deploying the application
-            - include_tasks: /utils/k8s/deploy_single_app.yml
-              vars:
-                check_app_pod: 'yes'
-                delay: 10
-                retries: 20
-
-          when: lookup('env','DEPLOY_TYPE') == 'deployment'
-
-        - block:
+                  ## Deploying the application
+                - include_tasks: /utils/k8s/deploy_single_app.yml
+                  vars:
+                    application_deployment: "{{ application_statefulset }}"
+                    check_app_pod: 'no'
+                    delay: 10
+                    retries: 20
+              when: "'deprovision' not in action"
 
             - name: Deprovisioning the Application
               include_tasks: /utils/k8s/deprovision_statefulset.yml
               vars:
                 app_deployer: "{{ application_statefulset }}"
-              when: lookup('env','DEPLOY_TYPE') == 'statefulset'
+              when: "'deprovision' is in action"
 
+          when: lookup('env','DEPLOY_TYPE') == 'statefulset'
+
+        - block:
+            - block:
+                  ## Creating namespaces and making the application for deployment
+                - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+
+                - name: Replace the affinity label annotation in deployment yml
+                  replace:
+                    path: "{{ application_deployment }}"
+                    regexp: "affinity_label: lvalue"
+                    replace: "{{ affinity_label }}: {{ app_lvalue }}"
+
+                - name: Replace the volume capcity placeholder with provider
+                  replace:
+                    path: "{{ application_deployment }}"
+                    regexp: "teststorage"
+                    replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+                  ## Deploying the application
+                - include_tasks: /utils/k8s/deploy_single_app.yml
+                  vars:
+                    check_app_pod: 'yes'
+                    delay: 10
+                    retries: 20
+              when: "'deprovision' not in action"
+            
             - name: Deprovisioning the Application
               include_tasks: "/utils/k8s/deprovision_deployment.yml"
               vars:
                 app_deployer: "{{ application_deployment }}"
-              when: lookup('env','DEPLOY_TYPE') == 'deployment'
+              when: "'deprovision' is in action"
 
-          when: "'deprovision' is in action"
+          when: lookup('env','DEPLOY_TYPE') == 'deployment'
 
         - set_fact:
             flag: "Pass"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the busybox deploy litmusbook for deprovision.

```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "b1a2b86ab1d4a8c754cfc91bf002e3c89d0ce8be", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "040b98e2f1c30cd3f7b26533fa5da957", "mode": "0644", "owner": "root", "size": 435, "src": "/root/.ansible/tmp/ansible-tmp-1557840725.81-269026126929864/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.925411", "end": "2019-05-14 13:32:08.001348", "rc": 0, "start": "2019-05-14 13:32:07.075937", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-deprovision-app-busybox-ns \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-deprovision-app-busybox-ns ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.903769", "end": "2019-05-14 13:32:10.308981", "failed_when_result": false, "rc": 0, "start": "2019-05-14 13:32:08.405212", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-deprovision-app-busybox-ns configured", "stdout_lines": ["litmusresult.litmus.io/busybox-deprovision-app-busybox-ns configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the volume capcity placeholder with provider] ********************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
included: /utils/k8s/deprovision_statefulset.yml for 127.0.0.1

TASK [Check if the statefulset application exists.] ****************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox", "delta": "0:00:01.230758", "end": "2019-05-14 13:32:12.947876", "failed_when_result": false, "rc": 0, "start": "2019-05-14 13:32:11.717118", "stderr": "", "stderr_lines": [], "stdout": "NAME        READY   STATUS    RESTARTS   AGE\nbusybox-0   1/1     Running   0          13m\nbusybox-1   1/1     Running   0          12m", "stdout_lines": ["NAME        READY   STATUS    RESTARTS   AGE", "busybox-0   1/1     Running   0          13m", "busybox-1   1/1     Running   0          12m"]}

TASK [Obtaining PVCs related to the application.] ******************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-ns -l app=busybox --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.158319", "end": "2019-05-14 13:32:14.558711", "rc": 0, "start": "2019-05-14 13:32:13.400392", "stderr": "", "stderr_lines": [], "stdout": "openebs-busybox-busybox-0\nopenebs-busybox-busybox-1", "stdout_lines": ["openebs-busybox-busybox-0", "openebs-busybox-busybox-1"]}

TASK [Obtaining the PV names.] *************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -l app=busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.242469", "end": "2019-05-14 13:32:16.239118", "rc": 0, "start": "2019-05-14 13:32:14.996649", "stderr": "", "stderr_lines": [], "stdout": "pvc-c3dda261-764a-11e9-93ba-0050569846e3\npvc-fc9583d9-764a-11e9-93ba-0050569846e3", "stdout_lines": ["pvc-c3dda261-764a-11e9-93ba-0050569846e3", "pvc-fc9583d9-764a-11e9-93ba-0050569846e3"]}

TASK [Check for presence & value of cas type annotation] ***********************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-c3dda261-764a-11e9-93ba-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.273697", "end": "2019-05-14 13:32:17.987698", "rc": 0, "start": "2019-05-14 13:32:16.714001", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Replace the PVC name in application deployer spec.] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application replica values from env] *****************************
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application label placeholder] *******************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox"}, "changed": false}

TASK [Replace the application label placeholder] *******************************
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Delete the application and its related service.] *************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl delete -f busybox_statefulset.yml -n app-busybox-ns", "delta": "0:00:01.284630", "end": "2019-05-14 13:32:22.048626", "rc": 0, "start": "2019-05-14 13:32:20.763996", "stderr": "", "stderr_lines": [], "stdout": "service \"busybox\" deleted\nstatefulset.apps \"busybox\" deleted", "stdout_lines": ["service \"busybox\" deleted", "statefulset.apps \"busybox\" deleted"]}

TASK [Deleting the PVC] ********************************************************
changed: [127.0.0.1] => (item=openebs-busybox-busybox-0) => {"changed": true, "cmd": "kubectl delete pvc openebs-busybox-busybox-0 -n app-busybox-ns", "delta": "0:00:30.123199", "end": "2019-05-14 13:32:52.594417", "item": "openebs-busybox-busybox-0", "rc": 0, "start": "2019-05-14 13:32:22.471218", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"openebs-busybox-busybox-0\" deleted", "stdout_lines": ["persistentvolumeclaim \"openebs-busybox-busybox-0\" deleted"]}
changed: [127.0.0.1] => (item=openebs-busybox-busybox-1) => {"changed": true, "cmd": "kubectl delete pvc openebs-busybox-busybox-1 -n app-busybox-ns", "delta": "0:00:01.362996", "end": "2019-05-14 13:32:54.199014", "item": "openebs-busybox-busybox-1", "rc": 0, "start": "2019-05-14 13:32:52.836018", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"openebs-busybox-busybox-1\" deleted", "stdout_lines": ["persistentvolumeclaim \"openebs-busybox-busybox-1\" deleted"]}

TASK [Check if the PVCs are deleted] *******************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n app-busybox-ns", "delta": "0:00:01.072929", "end": "2019-05-14 13:32:55.564195", "rc": 0, "start": "2019-05-14 13:32:54.491266", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Check if the ctrl-pod is deleted.] ***************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the  replica-pod is deleted.] ***********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the target pod is deleted.] *************************************
FAILED - RETRYING: Check if the target pod is deleted. (20 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (19 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (18 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (17 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (16 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (15 retries left).
changed: [127.0.0.1] => (item=pvc-c3dda261-764a-11e9-93ba-0050569846e3) => {"attempts": 7, "changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume=pvc-c3dda261-764a-11e9-93ba-0050569846e3 -n openebs --no-headers", "delta": "0:00:01.581661", "end": "2019-05-14 13:33:37.058771", "item": "pvc-c3dda261-764a-11e9-93ba-0050569846e3", "rc": 0, "start": "2019-05-14 13:33:35.477110", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-fc9583d9-764a-11e9-93ba-0050569846e3) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume=pvc-fc9583d9-764a-11e9-93ba-0050569846e3 -n openebs --no-headers", "delta": "0:00:01.352737", "end": "2019-05-14 13:33:38.836222", "item": "pvc-fc9583d9-764a-11e9-93ba-0050569846e3", "rc": 0, "start": "2019-05-14 13:33:37.483485", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Check status of the pool deployments from cvr] ***************************
changed: [127.0.0.1] => (item=pvc-c3dda261-764a-11e9-93ba-0050569846e3) => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-c3dda261-764a-11e9-93ba-0050569846e3 --no-headers", "delta": "0:00:01.308667", "end": "2019-05-14 13:33:40.512430", "item": "pvc-c3dda261-764a-11e9-93ba-0050569846e3", "rc": 0, "start": "2019-05-14 13:33:39.203763", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-fc9583d9-764a-11e9-93ba-0050569846e3) => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-fc9583d9-764a-11e9-93ba-0050569846e3 --no-headers", "delta": "0:00:01.147713", "end": "2019-05-14 13:33:41.986475", "item": "pvc-fc9583d9-764a-11e9-93ba-0050569846e3", "rc": 0, "start": "2019-05-14 13:33:40.838762", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete the namespace.] ***************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete ns app-busybox-ns", "delta": "0:00:06.905683", "end": "2019-05-14 13:33:49.355514", "rc": 0, "start": "2019-05-14 13:33:42.449831", "stderr": "", "stderr_lines": [], "stdout": "namespace \"app-busybox-ns\" deleted", "stdout_lines": ["namespace \"app-busybox-ns\" deleted"]}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the affinity label annotation in deployment yml] *****************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the volume capcity placeholder with provider] ********************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "a38e1ea9ae0772e2c1f936f93618cd9c75cddb5f", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b0ae3662c5e338e0fa490fca25abe448", "mode": "0644", "owner": "root", "size": 433, "src": "/root/.ansible/tmp/ansible-tmp-1557840830.84-71006008435440/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.018287", "end": "2019-05-14 13:33:54.751072", "rc": 0, "start": "2019-05-14 13:33:53.732785", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-deprovision-app-busybox-ns \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-deprovision-app-busybox-ns ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.521509", "end": "2019-05-14 13:33:56.528108", "failed_when_result": false, "rc": 0, "start": "2019-05-14 13:33:55.006599", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-deprovision-app-busybox-ns configured", "stdout_lines": ["litmusresult.litmus.io/busybox-deprovision-app-busybox-ns configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=29   changed=20   unreachable=0    failed=0 
```