### PR TITLE
Refactor(App_kill) litmusbook to pick random pod name

### DIFF
--- a/experiments/chaos/app_pod_failure/test.yml
+++ b/experiments/chaos/app_pod_failure/test.yml
@@ -68,7 +68,7 @@
             - name: Get application pod name 
               shell: >
                 kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-                -o=custom-columns=NAME:".metadata.name"
+                -o=custom-columns=NAME:".metadata.name" | shuf -n 1
               args:
                 executable: /bin/bash
               register: app_pod_name

--- a/providers/cstor/cstor-disk-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-disk-pool/run_litmus_test.yml
@@ -44,7 +44,7 @@ spec:
             value: openebs
             # Number of cstor pool to be created based on disk distribution across the nodes
           - name: CSTOR_POOL_COUNT
-            value: 5
+            value: "5"
 
             ## two values: create and delete 
           - name: ACTION


### PR DESCRIPTION
- When Application deployment is there with multiple replica then this test should pick random pods name to perform chaos.
**Following is the log of ansible test container:**
```
TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:68
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n default -l app=gitaly  --no-headers -o=custom-columns=NAME:\".metadata.name\" | shuf -n 1", "delta": "0:00:01.403197", "end": "2019-05-15 11:56:27.338847", "rc": 0, "start": "2019-05-15 11:56:25.935650", "stderr": "", "stderr_lines": [], "stdout": "gitlab-openshift-gitaly-0", "stdout_lines": ["gitlab-openshift-gitaly-0"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:78
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n default", "delta": "0:00:01.596815", "end": "2019-05-15 11:56:29.490786", "rc": 0, "start": "2019-05-15 11:56:27.893971", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:11
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (30 retries left).
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (29 retries left).
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (28 retries left).
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n default | sort | uniq", "delta": "0:00:01.377767", "end": "2019-05-15 11:56:46.318049", "rc": 0, "start": "2019-05-15 11:56:44.940282", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:24
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod gitlab-openshift-gitaly-0 -n default --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.326924", "end": "2019-05-15 11:56:47.973446", "rc": 0, "start": "2019-05-15 11:56:46.646522", "stderr": "", "stderr_lines": [], "stdout": "node1-1551782451.mayalabs.io", "stdout_lines": ["node1-1551782451.mayalabs.io"]}

```