### PR TITLE
Includes deprovision in busybox-loadgen limusbook

### DIFF
--- a/apps/busybox/liveness/busybox_liveness.yml
+++ b/apps/busybox/liveness/busybox_liveness.yml
@@ -59,7 +59,7 @@ spec:
  
       containers:
       - name: busybox-liveness  
-        image: openebs/busybox-liveness-client
+        image: openebs/busybox-liveness
         imagePullPolicy: Always
 
         env:

--- a/apps/busybox/liveness/run_litmus_test.yml
+++ b/apps/busybox/liveness/run_litmus_test.yml
@@ -47,6 +47,9 @@ spec:
           - name: APPLICATION_LABEL
             value: 'app=busybox-sts'
 
+          - name: ACTION
+            value: provision
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/busybox/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/apps/busybox/liveness/test.yml
+++ b/apps/busybox/liveness/test.yml
@@ -24,46 +24,64 @@
           vars:
             status: 'SOT'
 
-        - name: Getting the application pod name
-          shell: kubectl get po -n {{ namespace }} -l {{ app_label }} -o jsonpath={.items[0].metadata.name}
-          register: pod_name
+        - block:
 
-        - name: Replacing the placeholder for pod-name
-          replace:
-            path: "{{ busybox_liveness }}"
-            regexp: "pod-name"
-            replace: "{{ pod_name.stdout }}"   
+            - name: Getting the application pod name
+              shell: kubectl get pod -n {{ namespace }} -l {{ app_label }} -o jsonpath={.items[0].metadata.name}
+              register: pod_name
+    
+            - name: Replacing the placeholder for pod-name
+              replace:
+                path: "{{ busybox_liveness }}"
+                regexp: "pod-name"
+                replace: "{{ pod_name.stdout }}"   
+    
+            - name: Replacing the placeholder for namespace
+              replace:
+                path: "{{ busybox_liveness }}"
+                regexp: "app-namespace"
+                replace: "{{ namespace }}"   
+    
+            - name: Replacing the placeholder for liveness-retry-count
+              replace:
+                path: "{{ busybox_liveness }}"
+                regexp: "liveness-retry-count"
+                replace: "{{ liveness_retry }}"   
+    
+            - name: Replacing the placeholder for liveness-timeout
+              replace:
+                path: "{{ busybox_liveness }}"
+                regexp: "liveness-timeout-seconds"
+                replace: "{{ liveness_timeout }}"   
+    
+            - name: Creating busybox-liveness job
+              shell: kubectl create -f {{ busybox_liveness }} 
+    
+            - name: Verifying whether liveness pod is started successfully  
+              shell: kubectl get pod -n {{ namespace }} -l liveness=busybox-liveness -o jsonpath={.items[0].status.phase} 
+              register: pod_status
+              until: "'Running' in pod_status.stdout"
+              delay: 60 
+              retries: 20
+    
+            - set_fact:
+                flag: "Pass"
+          
+          when: "'deprovision' not in action"
 
-        - name: Replacing the placeholder for namespace
-          replace:
-            path: "{{ busybox_liveness }}"
-            regexp: "app-namespace"
-            replace: "{{ namespace }}"   
+        - block: 
+            - name: Getting the busybox liveness job
+              shell: kubectl get job -l liveness=busybox-liveness -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}'
+              register: liveness_job
 
-        - name: Replacing the placeholder for liveness-retry-count
-          replace:
-            path: "{{ busybox_liveness }}"
-            regexp: "liveness-retry-count"
-            replace: "{{ liveness_retry }}"   
+            - name: Deleting busybox liveness job
+              shell: kubectl delete job {{ liveness_job.stdout }} -n {{ namespace }}
 
-        - name: Replacing the placeholder for liveness-timeout
-          replace:
-            path: "{{ busybox_liveness }}"
-            regexp: "liveness-timeout-seconds"
-            replace: "{{ liveness_timeout }}"   
+            - set_fact:
+                flag: "Pass"
 
-        - name: Creating busybox-liveness job
-          shell: kubectl create -f {{ busybox_liveness }} 
+          when: "'deprovision' is in action"
 
-        - name: Verifying whether liveness pod is started successfully  
-          shell: kubectl get pod -n {{ namespace }} -l liveness=busybox-liveness -o jsonpath={.items[0].status.phase} 
-          register: pod_status
-          until: "'Running' in pod_status.stdout"
-          delay: 60 
-          retries: 20
-
-        - set_fact:
-            flag: "Pass"
 
       rescue:
         - set_fact:

--- a/apps/busybox/liveness/vars.yml
+++ b/apps/busybox/liveness/vars.yml
@@ -5,3 +5,4 @@ busybox_liveness: busybox_liveness.yml
 liveness_retry: "{{ lookup('env','LIVENESS_RETRY_COUNT') }}"
 liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
 liveness_log: "liveness-running"
+action: "{{ lookup('env','ACTION') }}"


### PR DESCRIPTION
**Following is the log of ansible-test containter:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "42145c7f2a9614dea70a5b418c60011cf39c45c4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bb5fa585c59969956fa1ec5a096acd24", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1558010371.44-268066805804185/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.165492", "end": "2019-05-16 12:39:33.880786", "rc": 0, "start": "2019-05-16 12:39:32.715294", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.926631", "end": "2019-05-16 12:39:36.144416", "failed_when_result": false, "rc": 0, "start": "2019-05-16 12:39:34.217785", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-liveness configured", "stdout_lines": ["litmusresult.litmus.io/busybox-liveness configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application pod name] ****************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for pod-name] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for namespace] *********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for liveness-retry-count] **********************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for liveness-timeout] **************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating busybox-liveness job] *******************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verifying whether liveness pod is started successfully] ******************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the busybox liveness job] ****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get job -l liveness=busybox-liveness -n bb-sts -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.336255", "end": "2019-05-16 12:39:38.567702", "rc": 0, "start": "2019-05-16 12:39:37.231447", "stderr": "", "stderr_lines": [], "stdout": "busybox-liveness-rnvsw", "stdout_lines": ["busybox-liveness-rnvsw"]}

TASK [Deleting busybox liveness job] *******************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete job busybox-liveness-rnvsw -n bb-sts", "delta": "0:00:01.383696", "end": "2019-05-16 12:39:40.420451", "rc": 0, "start": "2019-05-16 12:39:39.036755", "stderr": "", "stderr_lines": [], "stdout": "job.batch \"busybox-liveness-rnvsw\" deleted", "stdout_lines": ["job.batch \"busybox-liveness-rnvsw\" deleted"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "be4eaa0d097868df2568b19bb3912ca5e0172866", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a6e427d28894bb8af4d1d513f7e47d9c", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1558010381.07-206224630619777/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.147313", "end": "2019-05-16 12:39:45.047715", "rc": 0, "start": "2019-05-16 12:39:43.900402", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.598930", "end": "2019-05-16 12:39:47.015418", "failed_when_result": false, "rc": 0, "start": "2019-05-16 12:39:45.416488", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-liveness configured", "stdout_lines": ["litmusresult.litmus.io/busybox-liveness configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=12   changed=8    unreachable=0    failed=0 
```