### PR TITLE
Adds prometheus-liveness litmus job scripts

### DIFF
--- a/apps/prometheus/liveness/prometheus_liveness.yml
+++ b/apps/prometheus/liveness/prometheus_liveness.yml
@@ -1,0 +1,75 @@
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-namespace
+  namespace: app-namespace
+  labels:
+    name: app-namespace
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-namespace
+subjects:
+- kind: ServiceAccount
+  name: app-namespace
+  namespace: app-namespace
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: prometheus-liveness-
+  namespace: app-namespace
+spec:
+  template:
+    metadata:
+      name: prometheus-liveness
+      namespace: app-namespace
+      labels:
+        liveness: prometheus-liveness
+    spec:
+      serviceAccountName: app-namespace
+      restartPolicy: Never
+      containers:
+      - name: prometheus-liveness  
+        image: openebs/prometheus-liveness
+        imagePullPolicy: Always
+        env:
+
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "liveness-timeout-seconds"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "liveness-retry-count"
+
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "liveness-period-seconds"
+
+            # Namespace in which prometheus is running
+          - name: APP_NAMESPACE
+            value: "app-namespace"
+
+        

--- a/apps/prometheus/liveness/run_litmus_test.yml
+++ b/apps/prometheus/liveness/run_litmus_test.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-prometheus-liveness-
+  namespace: litmus
+spec:
+  activeDeadlineSeconds: 5400
+  template:
+    metadata:
+      name: litmus-prometheus-liveness
+      namespace: litmus
+      labels:
+        liveness: litmus-prometheus-liveness
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+ 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "5"
+          
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "5"
+
+          # Namespace in which prometheus is running
+          - name: APP_NAMESPACE
+            value: 'app-prometheus'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./apps/prometheus/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+           
+         
+

--- a/apps/prometheus/liveness/test.yml
+++ b/apps/prometheus/liveness/test.yml
@@ -1,0 +1,74 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Replacing the placeholder for namespace
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "app-namespace"
+            replace: "{{ namespace }}"   
+
+        - name: Replacing the placeholder for liveness-retry-count
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-retry-count"
+            replace: "{{ liveness_retry }}"   
+
+        - name: Replacing the placeholder for liveness-timeout
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-timeout-seconds"
+            replace: "{{ liveness_timeout }}"   
+
+        - name: Replacing the placeholder for liveness-period
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-period-seconds"
+            replace: "{{ liveness_period }}"   
+
+        - name: Creating prometheus-liveness job
+          shell: kubectl create -f {{ prometheus_liveness }} 
+
+        - name: Verifying whether liveness pod is started successfully  
+          shell: kubectl get pod -n {{ namespace }} -l liveness=prometheus-liveness -o jsonpath={.items[0].status.phase} 
+          register: pod_status
+          until: "'Running' in pod_status.stdout"
+          delay: 60 
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+        

--- a/apps/prometheus/liveness/vars.yml
+++ b/apps/prometheus/liveness/vars.yml
@@ -1,0 +1,7 @@
+test_name: prometheus-liveness
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+prometheus_liveness: prometheus_liveness.yml
+liveness_retry: "{{ lookup('env','LIVENESS_RETRY_COUNT') }}"
+liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
+liveness_period: "{{ lookup('env','LIVENESS_PERIOD_SECONDS') }}"
+liveness_log: "liveness-running"


### PR DESCRIPTION
Added following prometheus-liveness litmus job scripts
  - apps/prometheus/liveness/prometheus_liveness.yml
  - apps/prometheus/liveness/run_litmus_test.yml
  - apps/prometheus/liveness/test.yml
  - apps/prometheus/liveness/vars.yml

Here are litmus job logs for your reference:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "19d6cec750cb72d905a4b6a07a3b4ee69232787c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b0286b01826f1a67e12d874303bda641", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1558080874.36-123089852329511/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.256544", "end": "2019-05-17 08:14:36.963981", "rc": 0, "start": "2019-05-17 08:14:35.707437", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.899912", "end": "2019-05-17 08:14:39.162180", "failed_when_result": false, "rc": 0, "start": "2019-05-17 08:14:37.262268", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-liveness unchanged", "stdout_lines": ["litmusresult.litmus.io/prometheus-liveness unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for namespace] *********************************
changed: [127.0.0.1] => {"changed": true, "msg": "14 replacements made"}

TASK [Replacing the placeholder for liveness-retry-count] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-timeout] **************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-period] ***************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating prometheus-liveness job] ****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f prometheus_liveness.yml", "delta": "0:00:01.817872", "end": "2019-05-17 08:14:43.237620", "rc": 0, "start": "2019-05-17 08:14:41.419748", "stderr": "", "stderr_lines": [], "stdout": "clusterrole.rbac.authorization.k8s.io/app-prometheus created\nserviceaccount/app-prometheus created\nclusterrolebinding.rbac.authorization.k8s.io/app-prometheus created\njob.batch/prometheus-liveness-sb665 created", "stdout_lines": ["clusterrole.rbac.authorization.k8s.io/app-prometheus created", "serviceaccount/app-prometheus created", "clusterrolebinding.rbac.authorization.k8s.io/app-prometheus created", "job.batch/prometheus-liveness-sb665 created"]}

TASK [Verifying whether liveness pod is started successfully] ******************
FAILED - RETRYING: Verifying whether liveness pod is started successfully (20 retries left).
^C
[root@master-1554817485 ~]# watch kubectl get po -n app-prometheus
[root@master-1554817485 ~]# kubectl logs -f litmus-prometheus-liveness-j4xsf-x8l9b -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "19d6cec750cb72d905a4b6a07a3b4ee69232787c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b0286b01826f1a67e12d874303bda641", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1558080874.36-123089852329511/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.256544", "end": "2019-05-17 08:14:36.963981", "rc": 0, "start": "2019-05-17 08:14:35.707437", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.899912", "end": "2019-05-17 08:14:39.162180", "failed_when_result": false, "rc": 0, "start": "2019-05-17 08:14:37.262268", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-liveness unchanged", "stdout_lines": ["litmusresult.litmus.io/prometheus-liveness unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for namespace] *********************************
changed: [127.0.0.1] => {"changed": true, "msg": "14 replacements made"}

TASK [Replacing the placeholder for liveness-retry-count] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-timeout] **************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-period] ***************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating prometheus-liveness job] ****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f prometheus_liveness.yml", "delta": "0:00:01.817872", "end": "2019-05-17 08:14:43.237620", "rc": 0, "start": "2019-05-17 08:14:41.419748", "stderr": "", "stderr_lines": [], "stdout": "clusterrole.rbac.authorization.k8s.io/app-prometheus created\nserviceaccount/app-prometheus created\nclusterrolebinding.rbac.authorization.k8s.io/app-prometheus created\njob.batch/prometheus-liveness-sb665 created", "stdout_lines": ["clusterrole.rbac.authorization.k8s.io/app-prometheus created", "serviceaccount/app-prometheus created", "clusterrolebinding.rbac.authorization.k8s.io/app-prometheus created", "job.batch/prometheus-liveness-sb665 created"]}

TASK [Verifying whether liveness pod is started successfully] ******************
FAILED - RETRYING: Verifying whether liveness pod is started successfully (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n app-prometheus -l liveness=prometheus-liveness -o jsonpath={.items[0].status.phase}", "delta": "0:00:01.600977", "end": "2019-05-17 08:15:46.966632", "rc": 0, "start": "2019-05-17 08:15:45.365655", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "0806d167140e699ab9e2229d8a959d82ea669b4c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "12a7a73c256179a94e064b612ec5be59", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1558080947.53-135410470320662/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.444109", "end": "2019-05-17 08:15:52.241650", "rc": 0, "start": "2019-05-17 08:15:50.797541", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.671612", "end": "2019-05-17 08:15:54.273615", "failed_when_result": false, "rc": 0, "start": "2019-05-17 08:15:52.602003", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-liveness configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-liveness configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=16   changed=12   unreachable=0    failed=0   

```
Here are the logs of prometheus liveness pod for your reference:
```
[root@master-1554817485 ~]# kubectl logs -f pod/prometheus-liveness-sb665-sg5s2 -n app-prometheus
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Failed
Retrying to establish connection
Liveness finally failed:
```
Note : I have deleted the prometheus app pod to check liveness functionality that's why logs are showing failed status at the end





@nsathyaseelan @gprasath 