### PR TITLE
Adds prometheus-liveness litmus job script

### DIFF
--- a/apps/prometheus/liveness/prometheus_liveness.yml
+++ b/apps/prometheus/liveness/prometheus_liveness.yml
@@ -1,0 +1,75 @@
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-namespace
+  namespace: app-namespace
+  labels:
+    name: app-namespace
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-namespace
+subjects:
+- kind: ServiceAccount
+  name: app-namespace
+  namespace: app-namespace
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: prometheus-liveness-
+  namespace: app-namespace
+spec:
+  template:
+    metadata:
+      name: prometheus-liveness
+      namespace: app-namespace
+      labels:
+        liveness: prometheus-liveness
+    spec:
+      serviceAccountName: app-namespace
+      restartPolicy: Never
+      containers:
+      - name: prometheus-liveness  
+        image: openebs/prometheus-liveness
+        imagePullPolicy: Always
+        env:
+
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "liveness-timeout-seconds"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "liveness-retry-count"
+
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "liveness-period-seconds"
+
+            # Namespace in which prometheus is running
+          - name: APP_NAMESPACE
+            value: "app-namespace"
+
+        

--- a/apps/prometheus/liveness/prometheus_liveness.yml
+++ b/apps/prometheus/liveness/prometheus_liveness.yml
@@ -54,7 +54,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: prometheus-liveness  
-        image: openebs/prometheus-liveness
+        image : openebs/service-liveness
         imagePullPolicy: Always
         env:
 
@@ -68,6 +68,12 @@ spec:
           - name: LIVENESS_PERIOD_SECONDS
             value: "liveness-period-seconds"
 
+          - name: SERVICE_ENDPOINT
+            value: "service-endpoint"
+
+          - name: PORT
+            value: "port"
+          
             # Namespace in which prometheus is running
           - name: APP_NAMESPACE
             value: "app-namespace"

--- a/apps/prometheus/liveness/run_litmus_test.yml
+++ b/apps/prometheus/liveness/run_litmus_test.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-prometheus-liveness-
+  namespace: litmus
+spec:
+  activeDeadlineSeconds: 5400
+  template:
+    metadata:
+      name: litmus-prometheus-liveness
+      namespace: litmus
+      labels:
+        liveness: litmus-prometheus-liveness
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+ 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "5"
+          
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "5"
+
+          # Namespace in which prometheus is running
+          - name: APP_NAMESPACE
+            value: 'app-prometheus'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./apps/prometheus/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+           
+         
+

--- a/apps/prometheus/liveness/run_litmus_test.yml
+++ b/apps/prometheus/liveness/run_litmus_test.yml
@@ -38,6 +38,10 @@ spec:
           - name: APP_NAMESPACE
             value: 'app-prometheus'
 
+          # Service port
+          - name: PORT
+            value: '9090'
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/prometheus/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/apps/prometheus/liveness/test.yml
+++ b/apps/prometheus/liveness/test.yml
@@ -1,0 +1,74 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Replacing the placeholder for namespace
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "app-namespace"
+            replace: "{{ namespace }}"   
+
+        - name: Replacing the placeholder for liveness-retry-count
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-retry-count"
+            replace: "{{ liveness_retry }}"   
+
+        - name: Replacing the placeholder for liveness-timeout
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-timeout-seconds"
+            replace: "{{ liveness_timeout }}"   
+
+        - name: Replacing the placeholder for liveness-period
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "liveness-period-seconds"
+            replace: "{{ liveness_period }}"   
+
+        - name: Creating prometheus-liveness job
+          shell: kubectl create -f {{ prometheus_liveness }} 
+
+        - name: Verifying whether liveness pod is started successfully  
+          shell: kubectl get pod -n {{ namespace }} -l liveness=prometheus-liveness -o jsonpath={.items[0].status.phase} 
+          register: pod_status
+          until: "'Running' in pod_status.stdout"
+          delay: 60 
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+        

--- a/apps/prometheus/liveness/test.yml
+++ b/apps/prometheus/liveness/test.yml
@@ -48,6 +48,26 @@
             regexp: "liveness-period-seconds"
             replace: "{{ liveness_period }}"   
 
+        - name: Replacing the placeholder for liveness-period
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "port"
+            replace: "{{ port }}"   
+
+        - name : Fetch app service name
+          shell: kubectl get svc -n {{ namespace }} -o jsonpath={.items[0].metadata.name}
+          register: service_name
+        
+        - name : Fetch app service endpoint
+          shell: kubectl get endpoints {{ service_name.stdout }} -n {{ namespace }} -o jsonpath={.subsets[0].addresses[0].ip}
+          register: service_endpoint
+        
+        - name: Replacing the placeholder for service-endpoint
+          replace:
+            path: "{{ prometheus_liveness }}"
+            regexp: "service-endpoint"
+            replace: "{{ service_endpoint.stdout }}"
+
         - name: Creating prometheus-liveness job
           shell: kubectl create -f {{ prometheus_liveness }} 
 
@@ -57,6 +77,8 @@
           until: "'Running' in pod_status.stdout"
           delay: 60 
           retries: 20
+
+        
 
         - set_fact:
             flag: "Pass"

--- a/apps/prometheus/liveness/vars.yml
+++ b/apps/prometheus/liveness/vars.yml
@@ -1,0 +1,7 @@
+test_name: prometheus-liveness
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+prometheus_liveness: prometheus_liveness.yml
+liveness_retry: "{{ lookup('env','LIVENESS_RETRY_COUNT') }}"
+liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
+liveness_period: "{{ lookup('env','LIVENESS_PERIOD_SECONDS') }}"
+liveness_log: "liveness-running"

--- a/apps/prometheus/liveness/vars.yml
+++ b/apps/prometheus/liveness/vars.yml
@@ -1,7 +1,9 @@
 test_name: prometheus-liveness
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+port: "{{ lookup('env','PORT') }}"
 prometheus_liveness: prometheus_liveness.yml
 liveness_retry: "{{ lookup('env','LIVENESS_RETRY_COUNT') }}"
 liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
 liveness_period: "{{ lookup('env','LIVENESS_PERIOD_SECONDS') }}"
+liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
 liveness_log: "liveness-running"


### PR DESCRIPTION
Added following prometheus-liveness litmus job scripts
  - apps/prometheus/liveness/prometheus_liveness.yml
  - apps/prometheus/liveness/run_litmus_test.yml
  - apps/prometheus/liveness/test.yml
  - apps/prometheus/liveness/vars.yml

Here are litmus job logs for your reference:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "19d6cec750cb72d905a4b6a07a3b4ee69232787c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b0286b01826f1a67e12d874303bda641", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1558343753.27-167917124530202/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.338382", "end": "2019-05-20 09:15:56.044547", "rc": 0, "start": "2019-05-20 09:15:54.706165", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.804927", "end": "2019-05-20 09:15:58.156872", "failed_when_result": false, "rc": 0, "start": "2019-05-20 09:15:56.351945", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-liveness unchanged", "stdout_lines": ["litmusresult.litmus.io/prometheus-liveness unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the placeholder for namespace] *********************************
changed: [127.0.0.1] => {"changed": true, "msg": "14 replacements made"}

TASK [Replacing the placeholder for liveness-retry-count] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-timeout] **************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-period] ***************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-period] ***************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Fetch app service name] **************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -n app-prometheus -o jsonpath={.items[0].metadata.name}", "delta": "0:00:01.446757", "end": "2019-05-20 09:16:01.972271", "rc": 0, "start": "2019-05-20 09:16:00.525514", "stderr": "", "stderr_lines": [], "stdout": "openebs-prometheus-service", "stdout_lines": ["openebs-prometheus-service"]}

TASK [Fetch app service endpoint] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get endpoints openebs-prometheus-service -n app-prometheus -o jsonpath={.subsets[0].addresses[0].ip}", "delta": "0:00:01.384422", "end": "2019-05-20 09:16:03.683843", "rc": 0, "start": "2019-05-20 09:16:02.299421", "stderr": "", "stderr_lines": [], "stdout": "172.23.4.85", "stdout_lines": ["172.23.4.85"]}

TASK [Replacing the placeholder for service-endpoint] **************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating prometheus-liveness job] ****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f prometheus_liveness.yml", "delta": "0:00:01.684466", "end": "2019-05-20 09:16:06.059545", "rc": 0, "start": "2019-05-20 09:16:04.375079", "stderr": "", "stderr_lines": [], "stdout": "clusterrole.rbac.authorization.k8s.io/app-prometheus created\nserviceaccount/app-prometheus created\nclusterrolebinding.rbac.authorization.k8s.io/app-prometheus created\njob.batch/prometheus-liveness-flm87 created", "stdout_lines": ["clusterrole.rbac.authorization.k8s.io/app-prometheus created", "serviceaccount/app-prometheus created", "clusterrolebinding.rbac.authorization.k8s.io/app-prometheus created", "job.batch/prometheus-liveness-flm87 created"]}

TASK [Verifying whether liveness pod is started successfully] ******************
FAILED - RETRYING: Verifying whether liveness pod is started successfully (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n app-prometheus -l liveness=prometheus-liveness -o jsonpath={.items[0].status.phase}", "delta": "0:00:01.473639", "end": "2019-05-20 09:17:09.642793", "rc": 0, "start": "2019-05-20 09:17:08.169154", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "0806d167140e699ab9e2229d8a959d82ea669b4c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "12a7a73c256179a94e064b612ec5be59", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1558343830.21-198546671545008/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.156330", "end": "2019-05-20 09:17:14.476875", "rc": 0, "start": "2019-05-20 09:17:13.320545", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.534538", "end": "2019-05-20 09:17:16.305961", "failed_when_result": false, "rc": 0, "start": "2019-05-20 09:17:14.771423", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-liveness configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-liveness configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=20   changed=16   unreachable=0    failed=0  

```

Here are the logs of prometheus liveness pod for your reference:
```
[root@master-1554817485 ~]# kubectl logs -f prometheus-liveness-flm87-ncm5l -n app-prometheus
Service Endpoint: 172.23.4.85
Port: 9090
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
Liveness Running
```


@gprasath @nsathyaseelan 