### PR TITLE
(feat)(chaos executor): add an executor to run chaos experiments

### DIFF
--- a/chaoslib/chaoskube/pod_failure_by_chaoskube.yaml
+++ b/chaoslib/chaoskube/pod_failure_by_chaoskube.yaml
@@ -13,8 +13,8 @@
     executable: /bin/bash
   register: chaoskube
   until: "'Running' in chaoskube.stdout"
-  delay: 20
-  retries: 15
+  delay: 2
+  retries: 90
 
 - name: Set the chaoskube pod name to variable
   set_fact:
@@ -68,3 +68,10 @@
   debug:
     msg: "Verified replica pods were restarted by chaoskube"
   failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"
+
+- name: Tear down chaoskube infrastructure
+  shell: |
+    kubectl delete -f /chaoslib/chaoskube/chaoskube.yaml -n {{ namespace }}
+    kubectl delete -f /chaoslib/chaoskube/rbac.yaml -n {{ namespace }}
+  args:
+    executable: /bin/bash

--- a/chaoslib/pumba/pod_failure_by_sigkill.yaml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -21,9 +21,18 @@
       retries: 30
       ignore_errors: true
 
+    - name: Select the app pod
+      shell: >
+        kubectl get pod -l {{ label }} -n {{ namespace }}
+        -o=custom-columns=NAME:".metadata.name" --no-headers
+        | shuf | head -1 
+      args:
+        executable: /bin/bash
+      register: app_pod_ut
+
     - name: Identify the application node
       shell: >
-        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
         --no-headers -o custom-columns=:spec.nodeName
       args:
         executable: /bin/bash
@@ -59,7 +68,7 @@
 
     - name: Record restartCount
       shell: >
-        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
         -o=jsonpath='{.status.containerStatuses[?(@.name=="{{ app_container }}")].restartCount}'
       args:
         executable: /bin/bash
@@ -76,7 +85,7 @@
 
     - name: Verify restartCount
       shell: >
-        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
         -o=jsonpath='{.status.containerStatuses[?(@.name=="{{ app_container }}")].restartCount}'
       args:
         executable: /bin/bash
@@ -88,22 +97,40 @@
   when: action == "killapp"
 
 - block:
-    - name: Delete the pumba daemonset
-      shell: >
-        kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ namespace }}
-      args:
-        executable: /bin/bash
-      register: result
 
-    - name: Confirm that the pumba ds is deleted successfully
+    - name: Check if pumba is indeed running
       shell: >
         kubectl get pod -l app=pumba
-        --no-headers -n {{ namespace }}
+        --no-headers -o custom-columns=:status.phase
+        -n {{ namespace }} | sort | uniq
       args:
         executable: /bin/bash
       register: result
-      until: "'Running' not in result.stdout"
+      until: "result.stdout == 'Running'"
       delay: 2
-      retries: 150
+      retries: 30
+      ignore_errors: true
+
+    - block: 
+
+        - name: Delete the pumba daemonset
+          shell: >
+            kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Confirm that the pumba ds is deleted successfully
+          shell: >
+            kubectl get pod -l app=pumba
+            --no-headers -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' not in result.stdout"
+          delay: 2
+          retries: 150
+
+      when: result.stdout == "Running"
 
   when: action == "deletepumba"

--- a/executor/README.md
+++ b/executor/README.md
@@ -1,5 +1,5 @@
 ### Litmus Chaos Executor
 
-- The executor runs the litmus jobs & monitors them. Typically invoked by of the litmuschaos operator to run
+- The executor runs the litmus jobs & monitors them. Typically invoked by the litmuschaos operator to run
   experiments listed in the chaosengine
 - To learn more about the chaosengine & chaosexperiment resources, see [chaos operator](https://github.com/litmuschaos/chaos-operator)

--- a/executor/README.md
+++ b/executor/README.md
@@ -1,0 +1,5 @@
+### Litmus Chaos Executor
+
+- The executor runs the litmus jobs & monitors them. Typically invoked by of the litmuschaos operator to run
+  experiments listed in the chaosengine
+- To learn more about the chaosengine & chaosexperiment resources, see [chaos operator](https://github.com/litmuschaos/chaos-operator)

--- a/executor/chaos_executor.yml
+++ b/executor/chaos_executor.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chaos-runner
+  labels:
+    name: chaos-runner
+spec:
+  serviceAccountName: chaos-operator
+  restartPolicy: Never
+  containers:
+  - name: ansibletest
+    image: openebs/ansible-runner:ci
+    imagePullPolicy: Always
+    env:
+      - name: ANSIBLE_STDOUT_CALLBACK
+        value: default
+
+      - name: APP_NAMESPACE
+        value: default 
+
+      - name: APP_LABEL
+        value: 'app=nginx'
+
+      - name: CHAOSENGINE
+        value: "engine-nginx"
+
+      - name: EXPERIMENT_LIST
+        value: "pod-delete,container-kill"
+
+    command: ["/bin/bash"]
+    args: ["-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/executor/executor.yml
+++ b/executor/executor.yml
@@ -55,8 +55,7 @@
 - name: Monitoring the litmus chaos job for completion
   shell: >
     kubectl get job -n litmus -l experiment={{ c_job_label.stdout }}
-    --no-headers -o custom-columns=:status.conditions[].type 
-    | sort | uniq
+    --no-headers -o custom-columns=:status.conditions[].type | sort | uniq
   args:
    executable: /bin/bash
   register: c_job_status

--- a/executor/executor.yml
+++ b/executor/executor.yml
@@ -1,0 +1,66 @@
+---
+- name: Verify if ChaosExperiment CR is available 
+  shell: >
+    kubectl get chaosexperiment {{ item }} 
+    --no-headers -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  register: c_exp_name
+  failed_when: "item not in c_exp_name.stdout"
+
+- name: Derive chaos job path from spec of experiment
+  shell: >
+    kubectl get chaosexperiment {{ item }}
+    --no-headers -o custom-columns=:spec.definition.litmusbook
+  args:
+   executable: /bin/bash
+  register: c_job
+
+- name: Check if the experiment params match the default values
+  shell: >
+    kubectl set env -f {{ c_job.stdout }} APP_LABEL={{ c_app_label }} 
+    APP_NAMESPACE={{ c_app_ns }} CHAOSENGINE={{ c_engine }} --dry-run -o yaml
+  args:
+   executable: /bin/bash
+  register: diff
+
+- name: Patch the job spec if passed experiment params are non-default 
+  shell: >
+    kubectl set env -f {{ c_job.stdout }} APP_LABEL={{ c_app_label }} 
+    APP_NAMESPACE={{ c_app_ns }} CHAOSENGINE={{ c_engine }} --dry-run -o yaml
+    > tmp.yml; cp {{ item.yml }} > {{ c_job.stdout }}; rm tmp.yml
+  args:
+   executable: /bin/bash
+  when: diff.stdout != ""
+
+- name: Get litmus chaos job label to monitor its progress
+  shell: >
+    kubectl create -f {{ c_job.stdout }} 
+    --dry-run -o jsonpath='{.spec.template.metadata.labels.experiment}'
+  args:
+   executable: /bin/bash
+  register: c_job_label
+
+- debug:
+    msg: "Triggering chaos experiment: item"
+
+- name: Run the chaos experiment job
+  shell:
+    kubectl create -f {{ c_job.stdout }}
+  args:
+   executable: /bin/bash
+  register: c_trigger
+  failed_when: "c_trigger.rc != 0"
+  
+- name: Monitoring the litmus chaos job for completion
+  shell: >
+    kubectl get job -n litmus -l experiment={{ c_job_label.stdout }}
+    --no-headers -o custom-columns=:status.conditions[].type 
+    | sort | uniq
+  args:
+   executable: /bin/bash
+  register: c_job_status
+  until: c_job_status.stdout == "Complete"
+  delay: 2
+  retries: 150
+

--- a/executor/test.yml
+++ b/executor/test.yml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_engine: "{{ lookup('env','CHAOSENGINE') }}"
+    c_experiment_list: "{{ lookup('env','EXPERIMENT_LIST').split(',')}}"
+    c_app_label: "{{ lookup('env','APP_LABEL') }}"
+    c_app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+   
+  tasks:
+    - debug:
+        msg: 
+          - "List of Chaos Experiments: {{ c_experiment_list }}"
+          - "Each experiment will be launched & monitored by the executor"
+          - "Beginning Execution, view experiment logs on respective job"
+       
+    - include: executor.yml 
+      with_items: "{{ c_experiment_list }}"
+
+
+

--- a/experiments/chaos/kubernetes/container_kill/run_litmus_test.yml
+++ b/experiments/chaos/kubernetes/container_kill/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: ksatchit/ansible-runner:operator
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK

--- a/experiments/chaos/kubernetes/container_kill/run_litmus_test.yml
+++ b/experiments/chaos/kubernetes/container_kill/run_litmus_test.yml
@@ -1,0 +1,37 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: container-kill-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: container-kill
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: ksatchit/ansible-runner:operator
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: default 
+
+          - name: APP_LABEL
+            value: 'app=nginx'
+
+          - name: TARGET_CONTAINER
+            value: "nginx"
+
+          - name: CHAOSENGINE 
+            value: "engine-nginx"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/kubernetes/container_kill/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/chaos/kubernetes/container_kill/test.yml
+++ b/experiments/chaos/kubernetes/container_kill/test.yml
@@ -1,0 +1,81 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "container-kill"
+    c_container: "{{ lookup('env','TARGET_CONTAINER') }}"
+    c_util: "/chaoslib/pumba/pod_failure_by_sigkill.yaml"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+
+  tasks:
+    - block:
+
+        ## GENERATE EXP RESULT NAME
+        - block:
+
+            - name: Construct chaos result name (experiment_name)
+              set_fact:
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+
+          when: lookup('env','CHAOSENGINE')    
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: /utils/k8s/status_app_pod.yml
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90
+
+        ## FAULT INJECTION 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            namespace: "{{ a_ns }}"
+            label: "{{ a_label }}"
+            app_container: "{{ c_container }}"
+            action: "killapp"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: /utils/k8s/status_app_pod.yml
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90        
+
+        - set_fact:
+            flag: "pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+
+      always: 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            namespace: "{{ a_ns }}"
+            label: "{{ a_label }}"
+            app_container: ""
+            action: "deletepumba"
+
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"

--- a/experiments/chaos/kubernetes/pod_delete/run_litmus_test.yml
+++ b/experiments/chaos/kubernetes/pod_delete/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: ksatchit/ansible-runner:operator
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK

--- a/experiments/chaos/kubernetes/pod_delete/run_litmus_test.yml
+++ b/experiments/chaos/kubernetes/pod_delete/run_litmus_test.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pod-delete-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: pod-delete
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: ksatchit/ansible-runner:operator
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: default 
+
+          - name: APP_LABEL
+            value: 'app=nginx'
+
+          - name: TOTAL_CHAOS_DURATION
+            value: "15"
+
+          - name: CHAOS_INTERVAL
+            value: "5"
+
+          - name: CHAOSENGINE
+            value: "engine-nginx"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/kubernetes/pod_delete/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/chaos/kubernetes/pod_delete/test.yml
+++ b/experiments/chaos/kubernetes/pod_delete/test.yml
@@ -1,0 +1,76 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "pod-delete"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
+    c_util: "/chaoslib/chaoskube/pod_failure_by_chaoskube.yaml"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+
+  tasks:
+    - block:
+
+        ## GENERATE EXP RESULT NAME
+        - block:
+
+            - name: Construct chaos result name (experiment_name)
+              set_fact:
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+
+          when: lookup('env','CHAOSENGINE')    
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90
+
+        ## FAULT INJECTION 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            namespace: "{{ a_ns }}"
+            label: "{{ a_label }}"
+            chaos_duration: "{{ c_duration }}"
+            chaos_interval: "{{ c_interval }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90        
+
+        - set_fact:
+            flag: "pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+ 
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"

--- a/hack/chaos-result.j2
+++ b/hack/chaos-result.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosResult
+metadata:
+  # name of the litmus testcase
+  name: {{ c_experiment }} 
+spec:
+  # holds the state of testcase,  manually updated by json merge patch
+  # result is the useful value today, but anticipate phase use in future 
+  experimentstatus: 
+    phase: {{ phase }}  
+    verdict: {{ verdict }} 
+

--- a/hack/crds.yaml
+++ b/hack/crds.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: litmusresults.litmus.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: litmus.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: litmusresults
+    # singular name to be used as an alias on the CLI and for display
+    singular: litmusresult
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: LitmusResult
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - lr
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosresults.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosResult
+    listKind: ChaosResultList
+    plural: chaosresults
+    singular: chaosresult
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/hack/litmus-prerequisites.sh
+++ b/hack/litmus-prerequisites.sh
@@ -21,6 +21,10 @@ echo "Applying the litmus RBAC.."
 kubectl apply -f rbac.yaml; retcode=$?
 error_handler $retcode msg="Unable to setup litmus RBAC, exiting" action="exit"
 
+echo "Applying the litmus(chaos) experiment result CRDs.."
+kubectl apply -f crds.yaml; retcode=$?
+error_handler $retcode msg="Unable to create result CRDs, exiting" action="exit"
+
 cp $answer admin.conf; retcode=$?
 error_handler $retcode msg="Unable to find the kubeconfig file, exiting" action="exit"
 

--- a/hack/rbac.yaml
+++ b/hack/rbac.yaml
@@ -37,26 +37,3 @@ subjects:
 - kind: ServiceAccount
   name: litmus
   namespace: litmus
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: litmusresults.litmus.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: litmus.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Cluster
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: litmusresults
-    # singular name to be used as an alias on the CLI and for display
-    singular: litmusresult
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: LitmusResult
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - lr

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -24,13 +24,11 @@ RUN mkdir /etc/ansible/ /ansible && \
     echo "127.0.0.1" >> /etc/ansible/hosts
 
 #Copying Necessary Files
-#Copying OpenEBS installation playbooks
 COPY providers/ ./providers
-#Copying Application deployers
 COPY ./apps/ ./apps
 COPY ./chaoslib ./chaoslib/
 COPY ./funclib ./funclib/
-COPY ./hack/litmus-result.j2 ./
+COPY ./hack/*.j2 ./
 COPY ./utils ./utils/
-#Copying functional and chaos litmusbooks
 COPY experiments ./experiments
+COPY executor ./executor

--- a/utils/fcm/update_chaos_result_resource.yml
+++ b/utils/fcm/update_chaos_result_resource.yml
@@ -1,0 +1,38 @@
+---
+- block:
+   - name: Generate the litmus result CR to reflect SOT (Start of Test)
+     template:
+       src: /chaos-result.j2
+       dest: chaos-result.yaml
+     vars:
+       test: "{{ c_experiment }}"
+       phase: ""
+       verdict: running
+
+   - name: Apply the litmus result CR
+     shell: kubectl apply -f chaos-result.yaml -n {{ namespace }}
+     args:
+       executable: /bin/bash
+     register: cr_status
+     failed_when: "cr_status.rc != 0"
+
+  when: status == "SOT"
+
+- block:
+   - name: Update the litmus result CR to reflect EOT (End of Test)
+     template:
+       src: /chaos-result.j2
+       dest: chaos-result.yaml
+     vars:
+       test: "{{ c_experiment }}"
+       phase: "" 
+       verdict: "{{ flag }}"
+
+   - name: Apply the litmus result CR
+     shell: kubectl apply -f chaos-result.yaml -n {{ namespace }}
+     args:
+       executable: /bin/bash
+     register: cr_status
+     failed_when: "cr_status.rc != 0"
+
+  when: status == "EOT"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

### Context

Litmus is being enhanced to function as a generic chaos framework that developers can use both in their CI pipelines as well as in their deploy environments (staging/pre-prod/prod).  A [Chaos Operator](https://github.com/litmuschaos/chaos-operator) project has been created to that effect, with the aim of enhancing the current framework to include: 

- Scheduled batch Run of Chaos (ref: [chaosengine](https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine.yaml))
- Intuitive monitoring (ref: [chaos-exporter](https://github.com/litmuschaos/chaos-exporter/pull/1)) 
- Standardised chaos experiment spec (ref: [chaos-charts](https://github.com/litmuschaos/chaos-charts))
- Categorized chaos bundles for stateless/stateful/vendor-specific 
- Test-Run resiliency
- Ability to chaos run as a background service based on annotations/tunables 

### Executor 

- This PR introduces an alpha version of the Chaos-Executor, which runs the Chaos Experiments that are listed by the ChaosEngine. 
- The executor is expected to evolve, along with the ChaosEngine & ChaosExperiment CR specifications. Currently, it uses a playbook to derive path of litmusbooks & patches it with app info obtained as ENV before executing it (default chaos params present in the job are used)
- The executor will be typically invoked by the engine-runner pod, which in turn is a secondary resource of the Chaos Operator

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

### Misc Changes

- This PR includes a few minor changes to facilitate integration of the executor. These include: 
  - A new result resource called ChaosResult along with a util to update it (very similar to litmus-result. It was created keeping in mind the naming-convention of the operator resources. Litmus result will have to be deprecated over time) 
  - Minor fixes in the chaoskube & pumba utils to make it more generic/cleaner
  - Two general chaos experiments to perform pod-delete & container-kill (in the experiments/chaos/kubernetes). The idea here is to breakdown tests to their lowest/simplest & not have a single test.yml perform multiple things based on external args
  