### PR TITLE
Refactor litmusbook of cstor-pool-delete to include conditional check.

### DIFF
--- a/chaoslib/pumba/pod_failure_by_sigkill.yaml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -1,4 +1,6 @@
+--- 
 - block:
+
     - name: Setup pumba chaos infrastructure
       shell: >
         kubectl apply -f /chaoslib/pumba/pumba_kube.yaml
@@ -21,18 +23,32 @@
       retries: 30
       ignore_errors: true
 
-    - name: Select the app pod
-      shell: >
-        kubectl get pod -l {{ label }} -n {{ namespace }}
-        -o=custom-columns=NAME:".metadata.name" --no-headers
-        | shuf | head -1 
-      args:
-        executable: /bin/bash
-      register: app_pod_ut
+    - block:
+        - name: Select the app pod
+          shell: >
+            kubectl get pod -l {{ label }} -n {{ namespace }}
+            -o=custom-columns=NAME:".metadata.name" --no-headers
+            | shuf | head -1 
+          args:
+            executable: /bin/bash
+          register: pod_name
+
+        - name: Record application pod name
+          set_fact:
+            app_pod_ut: "{{ pod_name.stdout }}"     
+      when: app_pod is undefined
+
+    - block: 
+
+        - name: Record application pod name
+          set_fact: 
+            app_pod_ut: "{{ app_pod }}"
+
+      when: app_pod is defined 
 
     - name: Identify the application node
       shell: >
-        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut }} -n {{ namespace }}
         --no-headers -o custom-columns=:spec.nodeName
       args:
         executable: /bin/bash
@@ -68,7 +84,7 @@
 
     - name: Record restartCount
       shell: >
-        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut }} -n {{ namespace }}
         -o=jsonpath='{.status.containerStatuses[?(@.name=="{{ app_container }}")].restartCount}'
       args:
         executable: /bin/bash
@@ -85,7 +101,7 @@
 
     - name: Verify restartCount
       shell: >
-        kubectl get pod {{ app_pod_ut.stdout }} -n {{ namespace }}
+        kubectl get pod {{ app_pod_ut }} -n {{ namespace }}
         -o=jsonpath='{.status.containerStatuses[?(@.name=="{{ app_container }}")].restartCount}'
       args:
         executable: /bin/bash


### PR DESCRIPTION
- Refactor litmusbook of cstor-pool-delete to include conditional check for getting the pod name.
**Following is log of ansible-test container:**
```
ansible-playbook 2.7.9
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_pool_failure/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:12
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:15
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.388593", "end": "2019-05-23 08:28:41.438055", "rc": 0, "start": "2019-05-23 08:28:40.049462", "stderr": "", "stderr_lines": [], "stdout": "busybox-0\nbusybox-1", "stdout_lines": ["busybox-0", "busybox-1"]}

TASK [Generate unique string for use in dbname] ********************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:23
changed: [127.0.0.1] => {"changed": true, "cmd": "echo $(mktemp) | cut -d '.' -f 2", "delta": "0:00:01.074230", "end": "2019-05-23 08:28:42.913195", "rc": 0, "start": "2019-05-23 08:28:41.838965", "stderr": "", "stderr_lines": [], "stdout": "oiFOAliICm", "stdout_lines": ["oiFOAliICm"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:29
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:40
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_pool_kill.yml"}, "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:45
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:52
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:54
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "9ddf35b64ae0f3b9a88fea5edef725569109e5ae", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2bfe37373405567d5a83ca51f429d50f", "mode": "0644", "owner": "root", "size": 441, "src": "/root/.ansible/tmp/ansible-tmp-1558600123.95-18878281192506/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.130053", "end": "2019-05-23 08:28:46.262946", "rc": 0, "start": "2019-05-23 08:28:45.132893", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-pool-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs-pool-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-pool-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs-pool-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.640397", "end": "2019-05-23 08:28:48.162318", "failed_when_result": false, "rc": 0, "start": "2019-05-23 08:28:46.521921", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-pool-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-pool-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_pool_failure/test.yml:61
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-busybox-ns", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox-busybox-0"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_pool_failure/test.yml:70
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.203838", "end": "2019-05-23 08:28:50.086588", "rc": 0, "start": "2019-05-23 08:28:48.882750", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-05-21T11:59:36Z]]\nmap[running:map[startedAt:2019-05-21T12:00:52Z]]", "stdout_lines": ["map[running:map[startedAt:2019-05-21T11:59:36Z]]", "map[running:map[startedAt:2019-05-21T12:00:52Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.226181", "end": "2019-05-23 08:28:51.598626", "rc": 0, "start": "2019-05-23 08:28:50.372445", "stderr": "", "stderr_lines": [], "stdout": "Running Running", "stdout_lines": ["Running Running"]}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:81
included: /chaoslib/openebs/cstor_pool_kill.yml for 127.0.0.1

TASK [include] *****************************************************************
task path: /chaoslib/openebs/cstor_pool_kill.yml:1
included: /chaoslib/openebs/cstor_kill_and_verify_pool.yml for 127.0.0.1 => (item=0)
included: /chaoslib/openebs/cstor_kill_and_verify_pool.yml for 127.0.0.1 => (item=1)

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-busybox-0 -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.094053", "end": "2019-05-23 08:28:53.255551", "rc": 0, "start": "2019-05-23 08:28:52.161498", "stderr": "", "stderr_lines": [], "stdout": "pvc-b7a8f795-7bbf-11e9-a47c-00505698550d", "stdout_lines": ["pvc-b7a8f795-7bbf-11e9-a47c-00505698550d"]}

TASK [Randomly select the pool deployment from cvr] ****************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-b7a8f795-7bbf-11e9-a47c-00505698550d --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.244028", "end": "2019-05-23 08:28:54.752018", "rc": 0, "start": "2019-05-23 08:28:53.507990", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-fcf2", "stdout_lines": ["cstor-sparse-pool-fcf2"]}

TASK [Get the pod of pool deployment] ******************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:20
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor-sparse-pool-fcf2 | grep -w \"Running\" | awk '{print $1}'", "delta": "0:00:01.228532", "end": "2019-05-23 08:28:56.262484", "rc": 0, "start": "2019-05-23 08:28:55.033952", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-fcf2-6cd49956c-x5psp", "stdout_lines": ["cstor-sparse-pool-fcf2-6cd49956c-x5psp"]}

TASK [Get the runningStatus of pool pod] ***************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:28
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.316804", "end": "2019-05-23 08:28:57.990557", "rc": 0, "start": "2019-05-23 08:28:56.673753", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [include_tasks] ***********************************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:40
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:4
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:01.582571", "end": "2019-05-23 08:29:00.094707", "rc": 0, "start": "2019-05-23 08:28:58.512136", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba unchanged", "stdout_lines": ["daemonset.extensions/pumba unchanged"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:13
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:01.239331", "end": "2019-05-23 08:29:01.762601", "rc": 0, "start": "2019-05-23 08:29:00.523270", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Select the app pod] ******************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43
ok: [127.0.0.1] => {"ansible_facts": {"app_pod_ut": "cstor-sparse-pool-fcf2-6cd49956c-x5psp"}, "changed": false}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.372552", "end": "2019-05-23 08:29:03.933212", "rc": 0, "start": "2019-05-23 08:29:02.560660", "stderr": "", "stderr_lines": [], "stdout": "node2-1554817485.mayalabs.io", "stdout_lines": ["node2-1554817485.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:57
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "node2-1554817485.mayalabs.io"}, "changed": false}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:63
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:70
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:76
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep node2-1554817485.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.291543", "end": "2019-05-23 08:29:06.038563", "rc": 0, "start": "2019-05-23 08:29:04.747020", "stderr": "", "stderr_lines": [], "stdout": "pumba-spds5", "stdout_lines": ["pumba-spds5"]}

TASK [Record restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:85
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:01.475250", "end": "2019-05-23 08:29:07.936201", "rc": 0, "start": "2019-05-23 08:29:06.460951", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:93
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-spds5 -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-pool_;", "delta": "0:00:03.971381", "end": "2019-05-23 08:29:12.328731", "rc": 0, "start": "2019-05-23 08:29:08.357350", "stderr": "time=\"2019-05-23T08:29:10Z\" level=info msg=\"Kill containers\" \ntime=\"2019-05-23T08:29:12Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-disk-pool-7yvd-6dc8b48bf9-qd48j_openebs_b13410a3-7bc5-11e9-a47c-00505698550d_1 (6fc248541cfe867ad8f134ea02f328192a93235e9ad4df571eed48f5ad56e304) with signal SIGKILL\" \ntime=\"2019-05-23T08:29:12Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-fcf2-6cd49956c-x5psp_openebs_0b0659f7-7bc5-11e9-a47c-00505698550d_1 (0f282bc38239a17d6592ff3e8b2a141d2139988406b5c34efb1faad1e378ae61) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-05-23T08:29:10Z\" level=info msg=\"Kill containers\" ", "time=\"2019-05-23T08:29:12Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-disk-pool-7yvd-6dc8b48bf9-qd48j_openebs_b13410a3-7bc5-11e9-a47c-00505698550d_1 (6fc248541cfe867ad8f134ea02f328192a93235e9ad4df571eed48f5ad56e304) with signal SIGKILL\" ", "time=\"2019-05-23T08:29:12Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-fcf2-6cd49956c-x5psp_openebs_0b0659f7-7bc5-11e9-a47c-00505698550d_1 (0f282bc38239a17d6592ff3e8b2a141d2139988406b5c34efb1faad1e378ae61) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}

TASK [Verify restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:102
FAILED - RETRYING: Verify restartCount (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:01.419482", "end": "2019-05-23 08:29:17.828805", "rc": 0, "start": "2019-05-23 08:29:16.409323", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Check if pumba is indeed running] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:117
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:132
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:139
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for pool pod in running state] *************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:47
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:01.263816", "end": "2019-05-23 08:29:19.714229", "rc": 0, "start": "2019-05-23 08:29:18.450413", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Get the runningStatus of pool pod] ***************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:58
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-fcf2-6cd49956c-x5psp -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.427442", "end": "2019-05-23 08:29:21.622573", "rc": 0, "start": "2019-05-23 08:29:20.195131", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-busybox-0 -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.372961", "end": "2019-05-23 08:29:23.323482", "rc": 0, "start": "2019-05-23 08:29:21.950521", "stderr": "", "stderr_lines": [], "stdout": "pvc-b7a8f795-7bbf-11e9-a47c-00505698550d", "stdout_lines": ["pvc-b7a8f795-7bbf-11e9-a47c-00505698550d"]}

TASK [Randomly select the pool deployment from cvr] ****************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-b7a8f795-7bbf-11e9-a47c-00505698550d --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.339335", "end": "2019-05-23 08:29:25.035860", "rc": 0, "start": "2019-05-23 08:29:23.696525", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-dj6k", "stdout_lines": ["cstor-sparse-pool-dj6k"]}

TASK [Get the pod of pool deployment] ******************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:20
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor-sparse-pool-dj6k | grep -w \"Running\" | awk '{print $1}'", "delta": "0:00:01.287602", "end": "2019-05-23 08:29:26.746952", "rc": 0, "start": "2019-05-23 08:29:25.459350", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-dj6k-76cfb764f4-8rms8", "stdout_lines": ["cstor-sparse-pool-dj6k-76cfb764f4-8rms8"]}

TASK [Get the runningStatus of pool pod] ***************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:28
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.370664", "end": "2019-05-23 08:29:28.476154", "rc": 0, "start": "2019-05-23 08:29:27.105490", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [include_tasks] ***********************************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:40
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:4
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:01.494189", "end": "2019-05-23 08:29:30.450837", "rc": 0, "start": "2019-05-23 08:29:28.956648", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba unchanged", "stdout_lines": ["daemonset.extensions/pumba unchanged"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:13
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:01.336758", "end": "2019-05-23 08:29:32.212256", "rc": 0, "start": "2019-05-23 08:29:30.875498", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Select the app pod] ******************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43
ok: [127.0.0.1] => {"ansible_facts": {"app_pod_ut": "cstor-sparse-pool-dj6k-76cfb764f4-8rms8"}, "changed": false}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.173263", "end": "2019-05-23 08:29:34.201597", "rc": 0, "start": "2019-05-23 08:29:33.028334", "stderr": "", "stderr_lines": [], "stdout": "node3-1554817485.mayalabs.io", "stdout_lines": ["node3-1554817485.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:57
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "node3-1554817485.mayalabs.io"}, "changed": false}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:63
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:70
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:76
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep node3-1554817485.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.222258", "end": "2019-05-23 08:29:36.410571", "rc": 0, "start": "2019-05-23 08:29:35.188313", "stderr": "", "stderr_lines": [], "stdout": "pumba-km2ts", "stdout_lines": ["pumba-km2ts"]}

TASK [Record restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:85
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:01.253567", "end": "2019-05-23 08:29:37.966448", "rc": 0, "start": "2019-05-23 08:29:36.712881", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:93
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-km2ts -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-pool_;", "delta": "0:00:02.745006", "end": "2019-05-23 08:29:40.979629", "rc": 0, "start": "2019-05-23 08:29:38.234623", "stderr": "time=\"2019-05-23T08:29:39Z\" level=info msg=\"Kill containers\" \ntime=\"2019-05-23T08:29:40Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-dj6k-76cfb764f4-8rms8_openebs_be8b9571-7bc4-11e9-a47c-00505698550d_2 (cc6a2a9061f28740458ee629c5373d10d8c7726f42e1c24b79acbc17d5ac903e) with signal SIGKILL\" \ntime=\"2019-05-23T08:29:40Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-disk-pool-7hbs-59f649c74b-v2g56_openebs_8df741d6-7bc5-11e9-a47c-00505698550d_2 (bf3737bf09eca469aebf4d7b79a3a833dae3ee3c260f33397e72509270c17e31) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-05-23T08:29:39Z\" level=info msg=\"Kill containers\" ", "time=\"2019-05-23T08:29:40Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-dj6k-76cfb764f4-8rms8_openebs_be8b9571-7bc4-11e9-a47c-00505698550d_2 (cc6a2a9061f28740458ee629c5373d10d8c7726f42e1c24b79acbc17d5ac903e) with signal SIGKILL\" ", "time=\"2019-05-23T08:29:40Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-disk-pool-7hbs-59f649c74b-v2g56_openebs_8df741d6-7bc5-11e9-a47c-00505698550d_2 (bf3737bf09eca469aebf4d7b79a3a833dae3ee3c260f33397e72509270c17e31) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}

TASK [Verify restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:102
FAILED - RETRYING: Verify restartCount (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:01.300430", "end": "2019-05-23 08:29:47.103393", "rc": 0, "start": "2019-05-23 08:29:45.802963", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if pumba is indeed running] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:117
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:132
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:139
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for pool pod in running state] *************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:47
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:01.266989", "end": "2019-05-23 08:29:49.145690", "rc": 0, "start": "2019-05-23 08:29:47.878701", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Get the runningStatus of pool pod] ***************************************
task path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:58
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-dj6k-76cfb764f4-8rms8 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.159477", "end": "2019-05-23 08:29:50.683147", "rc": 0, "start": "2019-05-23 08:29:49.523670", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:90
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.235710", "end": "2019-05-23 08:29:52.494789", "rc": 0, "start": "2019-05-23 08:29:51.259079", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-05-21T11:59:36Z]]\nmap[running:map[startedAt:2019-05-21T12:00:52Z]]", "stdout_lines": ["map[running:map[startedAt:2019-05-21T11:59:36Z]]", "map[running:map[startedAt:2019-05-21T12:00:52Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.224641", "end": "2019-05-23 08:29:54.334780", "rc": 0, "start": "2019-05-23 08:29:53.110139", "stderr": "", "stderr_lines": [], "stdout": "Running Running", "stdout_lines": ["Running Running"]}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:100
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful database delete] ***************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:111
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:123
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:126
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_pool_failure/test.yml:135
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "d38a2cfb176a79ec116adcc296561b124d5b56af", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "731be98362e0ac515780ec98b086145d", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1558600195.53-37109790114168/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.098388", "end": "2019-05-23 08:29:59.388018", "rc": 0, "start": "2019-05-23 08:29:58.289630", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-pool-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-pool-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.604834", "end": "2019-05-23 08:30:01.324846", "failed_when_result": false, "rc": 0, "start": "2019-05-23 08:29:59.720012", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-pool-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-pool-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=56   changed=38   unreachable=0    failed=0
```