### PR TITLE
feat[litmusbook]: Included litmusbook to check the jiva pods scheduled on openebs namespace

### DIFF
--- a/experiments/functional/jiva-pods-openebs-ns/run_litmus_test.yml
+++ b/experiments/functional/jiva-pods-openebs-ns/run_litmus_test.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-openebs-ns-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-jiva-openebs-ns
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns
+
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/jiva-pods-openebs-ns/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/jiva-pods-openebs-ns/test.yml
+++ b/experiments/functional/jiva-pods-openebs-ns/test.yml
@@ -1,0 +1,59 @@
+---
+#Description: Checking JIVA caontroller pod and Replica pods are scheduled on OpenEBS namespace.
+#
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Obtain the PVC name by using application label                                     #
+#3) Checking if the Application and Target scheduled on same node.                     #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the pv name of the application.
+          shell: >
+            kubectl get pvc -n "{{ app_ns }}" -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv_name
+
+        - name: Check if the pvc scheduled on operator namespace
+          shell: >
+            kubectl get pods --all-namespaces -l openebs.io/persistent-volume="{{ item }}"  
+            -o custom-columns=:.metadata.namespace --no-headers
+          args:
+            executable: /bin/bash
+          register: ctrl_rep_namespace
+          with_items:
+             - "{{ pv_name.stdout_lines }}"
+          until: "((ctrl_rep_namespace.stdout_lines|unique)|length) == 1 and operator_ns in ctrl_rep_namespace.stdout"
+          delay: 5
+          retries: 6
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/jiva-pods-openebs-ns/test.yml
+++ b/experiments/functional/jiva-pods-openebs-ns/test.yml
@@ -4,8 +4,8 @@
 ########################################################################################
 #Steps:                                                                                #
 #1) Creating LitmusResult CR for updating test result.                                 #
-#2) Obtain the PVC name by using application label                                     #
-#3) Checking if the Application and Target scheduled on same node.                     #
+#2) Obtain the PV name by using application namespace via PVC.                        #
+#3) Checking if the jiva controller and replicas scheduled on operator namespace.      #
 ########################################################################################
 
 - hosts: localhost

--- a/experiments/functional/jiva-pods-openebs-ns/test_vars.yml
+++ b/experiments/functional/jiva-pods-openebs-ns/test_vars.yml
@@ -1,0 +1,6 @@
+---
+test_name: jiva-pods-openebs-ns
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"

--- a/providers/cstor-storage-policies/jiva-openebs-ns.yml
+++ b/providers/cstor-storage-policies/jiva-openebs-ns.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jiva-openebs-ns
+  annotations:
+    openebs.io/cas-type: jiva
+    cas.openebs.io/config: |
+      - name: DeployInOpenEBSNamespace
+        enabled: "true"
+      - name: ReplicaCount
+        value: "1"
+provisioner: openebs.io/provisioner-iscsi

--- a/providers/cstor-storage-policies/test.yml
+++ b/providers/cstor-storage-policies/test.yml
@@ -52,6 +52,7 @@
                 - openebs-jiva-standalone
                 - local-pv-hostpath
                 - cstor-performance-config
+                - jiva-openebs-ns
 
           when: lookup('env','ACTION') == 'create'
 
@@ -79,6 +80,8 @@
                 - local-pv-hostpath
                 - cstor-disk-standalone
                 - openebs-jiva-standalone
+                - cstor-performance-config                
+                - jiva-openebs-ns
 
           when: lookup('env','ACTION') == 'delete'
 

--- a/providers/cstor-storage-policies/test_vars.yml
+++ b/providers/cstor-storage-policies/test_vars.yml
@@ -12,4 +12,4 @@ storage_policies:
   - jiva-standalone.yml
   - local-pv-hostpath.yml
   - cstor-perf-parameters.yml
-
+  - jiva-openebs-ns.yml


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included litmusbook to check the jiva pods scheduled on openebs namespace
- created storage class to deploy jiva in openebs namespace 

```
ansible-playbook 2.7.8
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/jiva-pods-openebs-ns/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:11
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:21
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:24
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "95ba66afc0e6a4b940f3c376de234b175ffccc99", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5102182e4975f4198a059686a73669fb", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1558687576.12-68618321938110/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.071351", "end": "2019-05-24 08:46:18.505998", "rc": 0, "start": "2019-05-24 08:46:17.434647", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-pods-openebs-ns \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-pods-openebs-ns ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.221099", "end": "2019-05-24 08:46:21.061170", "failed_when_result": false, "rc": 0, "start": "2019-05-24 08:46:18.840071", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/jiva-pods-openebs-ns configured", "stdout_lines": ["litmusresult.litmus.io/jiva-pods-openebs-ns configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the pv name of the application.] **********************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:28
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n \"jiva-openebs\" -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.376540", "end": "2019-05-24 08:46:23.054990", "rc": 0, "start": "2019-05-24 08:46:21.678450", "stderr": "", "stderr_lines": [], "stdout": "pvc-6d1884c2-7d4c-11e9-83e4-005056985c20", "stdout_lines": ["pvc-6d1884c2-7d4c-11e9-83e4-005056985c20"]}

TASK [Check if the pvc scheduled on operator namespace] ************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:35
changed: [127.0.0.1] => (item=pvc-6d1884c2-7d4c-11e9-83e4-005056985c20) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --all-namespaces -l openebs.io/persistent-volume=\"pvc-6d1884c2-7d4c-11e9-83e4-005056985c20\" -o custom-columns=:.metadata.namespace --no-headers", "delta": "0:00:01.692494", "end": "2019-05-24 08:46:25.123784", "item": "pvc-6d1884c2-7d4c-11e9-83e4-005056985c20", "rc": 0, "start": "2019-05-24 08:46:23.431290", "stderr": "", "stderr_lines": [], "stdout": "openebs\nopenebs", "stdout_lines": ["openebs", "openebs"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:48
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-pods-openebs-ns/test.yml:57
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "9c66e8963b349bf0828dea8d89250c8beb1dad8c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a36ae6275b4653205a3e8d8f264a0aa3", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1558687585.86-240523252118764/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.341783", "end": "2019-05-24 08:46:30.543528", "rc": 0, "start": "2019-05-24 08:46:29.201745", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-pods-openebs-ns \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-pods-openebs-ns ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.720966", "end": "2019-05-24 08:46:32.569100", "failed_when_result": false, "rc": 0, "start": "2019-05-24 08:46:30.848134", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/jiva-pods-openebs-ns configured", "stdout_lines": ["litmusresult.litmus.io/jiva-pods-openebs-ns configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=13   changed=8    unreachable=0    failed=0
```