### PR TITLE
Refactor litmusbook for OpenEBS installation using HELM

### DIFF
--- a/providers/openebs/installers/openebs_helm/test.yml
+++ b/providers/openebs/installers/openebs_helm/test.yml
@@ -30,9 +30,6 @@
           args:
             executable: /bin/bash
           register: tiller_out
-          until: "'Happy Helming' in tiller_out.stdout"
-          delay: 30
-          retries: 15
 
         - name: Checking if the tiller pod is created.
           shell: helm version
@@ -41,51 +38,46 @@
           register: tiller_version
           until: "'Server: &version.Version' in tiller_version.stdout"
           delay: 30
-          retries: 30
-       
-        - block:
+          retries: 30 
 
-            - name: Checking if the tiller service account already exists.
-              shell: kubectl get sa -n kube-system | grep tiller
-              args:
-                executable: /bin/bash
-              register: sa
-              until: "'tiller' in sa.stdout"
-              delay: 20
-              retries: 2
-  
-          rescue:
+        - name: Checking if the tiller service account already exists.
+          shell: kubectl get sa tiller -n kube-system 
+          args:
+            executable: /bin/bash
+          register: sa
+          until: "'tiller' in sa.stdout"
+          delay: 20
+          retries: 2
+          ignore_errors: True
 
-            - name: Creating the service account
-              shell: kubectl -n kube-system create sa tiller
-              args:
-                executable: /bin/bash
-              register: tiller
-              until: "'\"tiller\" created' in tiller.stdout"
-              delay: 30
-              retries: 5
+        - name: Creating the service account
+          shell: kubectl create serviceaccount --namespace kube-system tiller | echo $?
+          args:
+            executable: /bin/bash
+          register: tiller
+          until: "'0' in tiller.stdout"
+          delay: 30
+          retries: 5
+          when: "'tiller' not in sa"
 
-        - block:
+        - name: Checking if the tiller cluster role binding already exists.
+          shell: kubectl get clusterrolebinding tiller
+          args:
+            executable: /bin/bash
+          register: cr
+          until: "'tiller' in cr.stdout"
+          delay: 10
+          retries: 2
+          ignore_errors: True
 
-            - name: Checking if the tiller cluster role binding already exists.
-              shell: kubectl get clusterrolebinding | grep tiller
-              args:
-                executable: /bin/bash
-              register: cr
-              until: "'tiller' in cr.stdout"
-              delay: 10
-              retries: 2
-
-          rescue:
-
-            - name: Creating the cluster rolebinding.
-              shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-              args:
-                executable: /bin/bash
-              register: crb
-              until: "'\"tiller\" created' in crb.stdout"
-              delay: 60
-              retries: 5
+        - name: Creating the cluster rolebinding.
+          shell: |
+            kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+            kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
+          args:
+            executable: /bin/bash
+          when: "'tiller' not in cr"
+             
 
         - name: Installing openebs using stable charts.
           shell: >
@@ -94,8 +86,8 @@
             executable: /bin/bash
           register: openebs_out
           until: "'The OpenEBS has been installed' in openebs_out.stdout"
-          delay: 30
-          retries: 20
+          delay: 5
+          retries: 5  
 
         - name: Checking if the openebs-provisioner is up.
           shell: kubectl get pods -n "{{ namespace }}" -l component=provisioner -o custom-columns=:status.phase --no-headers


### PR DESCRIPTION
- Refactor litmusbook for OpenEBS installation using HELM
**Following is the log of ansible-test container:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "b535fae3eed5bd3b3e83fc41ef17480ece72d447", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a943beae22fe87a5a3ede9b9b133f104", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1558938936.23-102376920768663/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.853751", "end": "2019-05-27 06:35:38.426313", "rc": 0, "start": "2019-05-27 06:35:37.572562", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deploy-openebs-helm \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deploy-openebs-helm ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.690392", "end": "2019-05-27 06:35:40.371361", "failed_when_result": false, "rc": 0, "start": "2019-05-27 06:35:38.680969", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deploy-openebs-helm unchanged", "stdout_lines": ["litmusresult.litmus.io/deploy-openebs-helm unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install helm client] *****************************************************
 [WARNING]: Consider using the get_url or uri module rather than running
'curl'.  If you need to use command because get_url or uri is insufficient you
can add 'warn: false' to this command task or set 'command_warnings=False' in
ansible.cfg to get rid of this message.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash", "delta": "0:00:11.423092", "end": "2019-05-27 06:35:52.635406", "rc": 0, "start": "2019-05-27 06:35:41.212314", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0\r100  7028  100  7028    0     0   1232      0  0:00:05  0:00:05 --:--:--  1676", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0", "100  7028  100  7028    0     0   1232      0  0:00:05  0:00:05 --:--:--  1676"], "stdout": "Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.14.0-linux-amd64.tar.gz\nPreparing to install helm and tiller into /usr/local/bin\nhelm installed into /usr/local/bin/helm\ntiller installed into /usr/local/bin/tiller\nRun 'helm init' to configure helm.", "stdout_lines": ["Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.14.0-linux-amd64.tar.gz", "Preparing to install helm and tiller into /usr/local/bin", "helm installed into /usr/local/bin/helm", "tiller installed into /usr/local/bin/tiller", "Run 'helm init' to configure helm."]}

TASK [Setting up tiller.] ******************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "helm init", "delta": "0:00:03.291123", "end": "2019-05-27 06:35:56.325943", "rc": 0, "start": "2019-05-27 06:35:53.034820", "stderr": "", "stderr_lines": [], "stdout": "Creating /root/.helm \nCreating /root/.helm/repository \nCreating /root/.helm/repository/cache \nCreating /root/.helm/repository/local \nCreating /root/.helm/plugins \nCreating /root/.helm/starters \nCreating /root/.helm/cache/archive \nCreating /root/.helm/repository/repositories.yaml \nAdding stable repo with URL: https://kubernetes-charts.storage.googleapis.com \nAdding local repo with URL: http://127.0.0.1:8879/charts \n$HELM_HOME has been configured at /root/.helm.\nWarning: Tiller is already installed in the cluster.\n(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)", "stdout_lines": ["Creating /root/.helm ", "Creating /root/.helm/repository ", "Creating /root/.helm/repository/cache ", "Creating /root/.helm/repository/local ", "Creating /root/.helm/plugins ", "Creating /root/.helm/starters ", "Creating /root/.helm/cache/archive ", "Creating /root/.helm/repository/repositories.yaml ", "Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com ", "Adding local repo with URL: http://127.0.0.1:8879/charts ", "$HELM_HOME has been configured at /root/.helm.", "Warning: Tiller is already installed in the cluster.", "(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)"]}

TASK [Checking if the tiller pod is created.] **********************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "helm version", "delta": "0:00:01.325826", "end": "2019-05-27 06:35:58.098505", "rc": 0, "start": "2019-05-27 06:35:56.772679", "stderr": "", "stderr_lines": [], "stdout": "Client: &version.Version{SemVer:\"v2.14.0\", GitCommit:\"05811b84a3f93603dd6c2fcfe57944dfa7ab7fd0\", GitTreeState:\"clean\"}\nServer: &version.Version{SemVer:\"v2.14.0\", GitCommit:\"05811b84a3f93603dd6c2fcfe57944dfa7ab7fd0\", GitTreeState:\"clean\"}", "stdout_lines": ["Client: &version.Version{SemVer:\"v2.14.0\", GitCommit:\"05811b84a3f93603dd6c2fcfe57944dfa7ab7fd0\", GitTreeState:\"clean\"}", "Server: &version.Version{SemVer:\"v2.14.0\", GitCommit:\"05811b84a3f93603dd6c2fcfe57944dfa7ab7fd0\", GitTreeState:\"clean\"}"]}

TASK [Checking if the tiller service account already exists.] ******************
FAILED - RETRYING: Checking if the tiller service account already exists. (2 retries left).
FAILED - RETRYING: Checking if the tiller service account already exists. (1 retries left).
fatal: [127.0.0.1]: FAILED! => {"attempts": 2, "changed": true, "cmd": "kubectl get sa tiller -n kube-system", "delta": "0:00:01.309416", "end": "2019-05-27 06:36:42.983180", "msg": "non-zero return code", "rc": 1, "start": "2019-05-27 06:36:41.673764", "stderr": "Error from server (NotFound): serviceaccounts \"tiller\" not found", "stderr_lines": ["Error from server (NotFound): serviceaccounts \"tiller\" not found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Creating the service account] ********************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl create serviceaccount --namespace kube-system tiller | echo $?", "delta": "0:00:01.108222", "end": "2019-05-27 06:36:44.543493", "rc": 0, "start": "2019-05-27 06:36:43.435271", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [Checking if the tiller cluster role binding already exists.] *************
FAILED - RETRYING: Checking if the tiller cluster role binding already exists. (2 retries left).
FAILED - RETRYING: Checking if the tiller cluster role binding already exists. (1 retries left).
fatal: [127.0.0.1]: FAILED! => {"attempts": 2, "changed": true, "cmd": "kubectl get clusterrolebinding tiller", "delta": "0:00:01.988994", "end": "2019-05-27 06:37:09.626970", "msg": "non-zero return code", "rc": 1, "start": "2019-05-27 06:37:07.637976", "stderr": "Error from server (NotFound): clusterrolebindings.authorization.openshift.io \"tiller\" not found", "stderr_lines": ["Error from server (NotFound): clusterrolebindings.authorization.openshift.io \"tiller\" not found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Creating the cluster rolebinding.] ***************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller\n kubectl patch deploy --namespace kube-system tiller-deploy -p '{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}'", "delta": "0:00:01.304528", "end": "2019-05-27 06:37:11.183196", "rc": 0, "start": "2019-05-27 06:37:09.878668", "stderr": "", "stderr_lines": [], "stdout": "clusterrolebinding.rbac.authorization.k8s.io/tiller created\ndeployment.extensions/tiller-deploy patched", "stdout_lines": ["clusterrolebinding.rbac.authorization.k8s.io/tiller created", "deployment.extensions/tiller-deploy patched"]}

TASK [Installing openebs using stable charts.] *********************************
FAILED - RETRYING: Installing openebs using stable charts. (5 retries left).
FAILED - RETRYING: Installing openebs using stable charts. (4 retries left).
FAILED - RETRYING: Installing openebs using stable charts. (3 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "helm install stable/openebs --namespace openebs", "delta": "0:00:06.199040", "end": "2019-05-27 06:37:37.788109", "rc": 0, "start": "2019-05-27 06:37:31.589069", "stderr": "", "stderr_lines": [], "stdout": "NAME:   hoping-hedgehog\nLAST DEPLOYED: Mon May 27 06:37:34 2019\nNAMESPACE: openebs\nSTATUS: DEPLOYED\n\nRESOURCES:\n==> v1/ClusterRole\nNAME                     AGE\nhoping-hedgehog-openebs  1s\n\n==> v1/ClusterRoleBinding\nNAME                     AGE\nhoping-hedgehog-openebs  1s\n\n==> v1/ConfigMap\nNAME                                DATA  AGE\nhoping-hedgehog-openebs-ndm-config  1     1s\n\n==> v1/Deployment\nNAME                                         READY  UP-TO-DATE  AVAILABLE  AGE\nhoping-hedgehog-openebs-admission-server     0/1    1           0          0s\nhoping-hedgehog-openebs-apiserver            0/1    1           0          0s\nhoping-hedgehog-openebs-localpv-provisioner  0/1    1           0          0s\nhoping-hedgehog-openebs-provisioner          0/1    1           0          0s\nhoping-hedgehog-openebs-snapshot-operator    0/1    1           0          0s\n\n==> v1/Pod(related)\nNAME                                                          READY  STATUS             RESTARTS  AGE\nhoping-hedgehog-openebs-admission-server-779c795df9-7qx9k     0/1    ContainerCreating  0         0s\nhoping-hedgehog-openebs-apiserver-6b4698696-tb5lg             0/1    ContainerCreating  0         0s\nhoping-hedgehog-openebs-localpv-provisioner-6bc47fcf89-c8m2x  0/1    ContainerCreating  0         0s\nhoping-hedgehog-openebs-provisioner-6659d798bb-psbmg          0/1    ContainerCreating  0         0s\nhoping-hedgehog-openebs-snapshot-operator-7667f57746-5rl6r    0/2    ContainerCreating  0         0s\n\n==> v1/Service\nNAME                                TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE\nadmission-server-svc                ClusterIP  172.24.62.137  <none>       443/TCP   1s\nhoping-hedgehog-openebs-apiservice  ClusterIP  172.24.110.13  <none>       5656/TCP  1s\n\n==> v1/ServiceAccount\nNAME                     SECRETS  AGE\nhoping-hedgehog-openebs  2        1s\n\n==> v1beta1/DaemonSet\nNAME                         DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE\nhoping-hedgehog-openebs-ndm  0        0        0      0           0          <none>         0s\n\n==> v1beta1/ValidatingWebhookConfiguration\nNAME                            AGE\nopenebs-validation-webhook-cfg  0s\n\n\nNOTES:\nThe OpenEBS has been installed. Check its status by running:\n$ kubectl get pods -n openebs\n\nFor dynamically creating OpenEBS Volumes, you can either create a new StorageClass or\nuse one of the default storage classes provided by OpenEBS.\n\nUse `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample\nPVC spec using `openebs-jiva-default` StorageClass is given below:\"\n\n---\nkind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: demo-vol-claim\nspec:\n  storageClassName: openebs-jiva-default\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 5G\n---\n\nFor more information, please visit http://docs.openebs.io/.\n\nPlease note that, OpenEBS uses iSCSI for connecting applications with the\nOpenEBS Volumes and your nodes should have the iSCSI initiator installed.", "stdout_lines": ["NAME:   hoping-hedgehog", "LAST DEPLOYED: Mon May 27 06:37:34 2019", "NAMESPACE: openebs", "STATUS: DEPLOYED", "", "RESOURCES:", "==> v1/ClusterRole", "NAME                     AGE", "hoping-hedgehog-openebs  1s", "", "==> v1/ClusterRoleBinding", "NAME                     AGE", "hoping-hedgehog-openebs  1s", "", "==> v1/ConfigMap", "NAME                                DATA  AGE", "hoping-hedgehog-openebs-ndm-config  1     1s", "", "==> v1/Deployment", "NAME                                         READY  UP-TO-DATE  AVAILABLE  AGE", "hoping-hedgehog-openebs-admission-server     0/1    1           0          0s", "hoping-hedgehog-openebs-apiserver            0/1    1           0          0s", "hoping-hedgehog-openebs-localpv-provisioner  0/1    1           0          0s", "hoping-hedgehog-openebs-provisioner          0/1    1           0          0s", "hoping-hedgehog-openebs-snapshot-operator    0/1    1           0          0s", "", "==> v1/Pod(related)", "NAME                                                          READY  STATUS             RESTARTS  AGE", "hoping-hedgehog-openebs-admission-server-779c795df9-7qx9k     0/1    ContainerCreating  0         0s", "hoping-hedgehog-openebs-apiserver-6b4698696-tb5lg             0/1    ContainerCreating  0         0s", "hoping-hedgehog-openebs-localpv-provisioner-6bc47fcf89-c8m2x  0/1    ContainerCreating  0         0s", "hoping-hedgehog-openebs-provisioner-6659d798bb-psbmg          0/1    ContainerCreating  0         0s", "hoping-hedgehog-openebs-snapshot-operator-7667f57746-5rl6r    0/2    ContainerCreating  0         0s", "", "==> v1/Service", "NAME                                TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE", "admission-server-svc                ClusterIP  172.24.62.137  <none>       443/TCP   1s", "hoping-hedgehog-openebs-apiservice  ClusterIP  172.24.110.13  <none>       5656/TCP  1s", "", "==> v1/ServiceAccount", "NAME                     SECRETS  AGE", "hoping-hedgehog-openebs  2        1s", "", "==> v1beta1/DaemonSet", "NAME                         DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE", "hoping-hedgehog-openebs-ndm  0        0        0      0           0          <none>         0s", "", "==> v1beta1/ValidatingWebhookConfiguration", "NAME                            AGE", "openebs-validation-webhook-cfg  0s", "", "", "NOTES:", "The OpenEBS has been installed. Check its status by running:", "$ kubectl get pods -n openebs", "", "For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or", "use one of the default storage classes provided by OpenEBS.", "", "Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample", "PVC spec using `openebs-jiva-default` StorageClass is given below:\"", "", "---", "kind: PersistentVolumeClaim", "apiVersion: v1", "metadata:", "  name: demo-vol-claim", "spec:", "  storageClassName: openebs-jiva-default", "  accessModes:", "    - ReadWriteOnce", "  resources:", "    requests:", "      storage: 5G", "---", "", "For more information, please visit http://docs.openebs.io/.", "", "Please note that, OpenEBS uses iSCSI for connecting applications with the", "OpenEBS Volumes and your nodes should have the iSCSI initiator installed."]}

TASK [Checking if the openebs-provisioner is up.] ******************************
FAILED - RETRYING: Checking if the openebs-provisioner is up. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n \"openebs\" -l component=provisioner -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.166171", "end": "2019-05-27 06:38:10.780693", "rc": 0, "start": "2019-05-27 06:38:09.614522", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking if the openebs-apiserver is up.] ********************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n \"openebs\" -l component=apiserver -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.195788", "end": "2019-05-27 06:38:12.260065", "rc": 0, "start": "2019-05-27 06:38:11.064277", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking if the snapshot-operator is up.] ********************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l component=snapshot-operator -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.223050", "end": "2019-05-27 06:38:13.741964", "rc": 0, "start": "2019-05-27 06:38:12.518914", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "964688e8d0a8123d8185b241b1b2650a93114cdb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5944eb82a511c07940304578509b112e", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1558939094.62-216830300077493/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.953933", "end": "2019-05-27 06:38:18.348833", "rc": 0, "start": "2019-05-27 06:38:17.394900", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deploy-openebs-helm \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deploy-openebs-helm ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.608059", "end": "2019-05-27 06:38:20.389358", "failed_when_result": false, "rc": 0, "start": "2019-05-27 06:38:18.781299", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deploy-openebs-helm configured", "stdout_lines": ["litmusresult.litmus.io/deploy-openebs-helm configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=22   changed=17   unreachable=0    failed=0
```