### PR TITLE
Refactored litmus books for deployment of cassandra to take capacity as env and added target affinity in playbooks

### DIFF
--- a/apps/cassandra/deployers/cassandra_statefulset.yml
+++ b/apps/cassandra/deployers/cassandra_statefulset.yml
@@ -25,12 +25,12 @@ spec:
   selector:
     matchLabels:
       lkey: lvalue
-      affinity_label: lvalue
+      affinity_label: cassandra
   template:
     metadata:
       labels:
         lkey: lvalue
-        affinity_label: lvalue
+        affinity_label: cassandra
     spec:
       containers:
       - name: cassandra

--- a/apps/cassandra/deployers/cassandra_statefulset.yml
+++ b/apps/cassandra/deployers/cassandra_statefulset.yml
@@ -25,10 +25,12 @@ spec:
   selector:
     matchLabels:
       lkey: lvalue
+      affinity_label: lvalue
   template:
     metadata:
       labels:
         lkey: lvalue
+        affinity_label: lvalue
     spec:
       containers:
       - name: cassandra
@@ -98,6 +100,6 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 5G
+          storage: volume-capacity
 
 

--- a/apps/cassandra/deployers/run_litmus_test.yml
+++ b/apps/cassandra/deployers/run_litmus_test.yml
@@ -36,6 +36,10 @@ spec:
           - name: APP_LABEL
             value: 'app=cassandra'
 
+            # Affinity Label for Application
+          - name: AFFINITY_LABEL
+            value: openebs.io/sts-target-affinity
+
             # Application namespace
           - name: APP_NAMESPACE
             value: app-cass-ns 
@@ -49,6 +53,9 @@ spec:
           # Use 'deprovision' for app-clean up
           - name: ACTION
             value: provision
+
+          - name: CAPACITY
+            value: 5G
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/cassandra/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/cassandra/deployers/test.yml
+++ b/apps/cassandra/deployers/test.yml
@@ -26,20 +26,8 @@
           replace:
              path: "{{ application_deployment }}"
              regexp: "affinity_label"
-             replace: "{{ affinity_label }}"
-
-        - name: Get the application label values from env
-          set_fact:
-             app_lkey: "{{ app_label.split('=')[0] }}"
-             app_lvalue: "{{ app_label.split('=')[1] }}"
-
-        - name: Replace the application label placeholder in deployment spec
-          replace:
-             path: "{{ application_deployment }}"
-             regexp: "lvalue"
-             replace: "{{ app_lvalue }}"
-
-
+             replace: "{{ affinity_label }}"              
+       
         - block:
          ## Actual test
          ## Creating namespaces and making the application for deployment

--- a/apps/cassandra/deployers/test.yml
+++ b/apps/cassandra/deployers/test.yml
@@ -16,8 +16,31 @@
           vars:
             status: 'SOT'
 
-        - block:
+        - name: Replace the storage capacity placeholder
+          replace:
+             path: "{{ application_deployment }}"
+             regexp: "volume-capacity"
+             replace: "{{ lookup('env','CAPACITY') }}" 
 
+        - name: Replace the affinity label annotation in statefulset yml
+          replace:
+             path: "{{ application_deployment }}"
+             regexp: "affinity_label"
+             replace: "{{ affinity_label }}"
+
+        - name: Get the application label values from env
+          set_fact:
+             app_lkey: "{{ app_label.split('=')[0] }}"
+             app_lvalue: "{{ app_label.split('=')[1] }}"
+
+        - name: Replace the application label placeholder in deployment spec
+          replace:
+             path: "{{ application_deployment }}"
+             regexp: "lvalue"
+             replace: "{{ app_lvalue }}"
+
+
+        - block:
          ## Actual test
          ## Creating namespaces and making the application for deployment
             - include_tasks: /utils/k8s/pre_create_app_deploy.yml
@@ -28,7 +51,7 @@
                 regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
                 replace: 'cassandra-0.cassandra.{{ app_ns }}.svc.cluster.local'
 
-         ## Deploying the application
+             ## Deploying the application
             - include_tasks: /utils/k8s/deploy_single_app.yml
               vars:
                 check_app_pod: 'no'

--- a/apps/cassandra/deployers/test_vars.yml
+++ b/apps/cassandra/deployers/test_vars.yml
@@ -6,5 +6,7 @@ app_replica: "{{ lookup('env','APP_REPLICA') }}"
 application_name: "Cassandra statefulset"
 action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
+affinity_label: "{{ lookup('env','AFFINITY_LABEL') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 operator_ns: openebs
+capacity: "{{ lookup('env','CAPACITY') }}"


### PR DESCRIPTION
* Volume capacity is taken as environmental variable.
* Target affinity is added in order to schedule both target pod and application pod in same node
* These files are modified
        	* apps/cassandra/deployers/cassandra_statefulset.yml  
                * apps/cassandra/deployers/run_litmus_test.yml
                * apps/cassandra/deployers/test.yml
	        * apps/cassandra/deployers/test_vars.yml

Here are the logs
```
[root@master-1554817485 deployers]# kubectl logs litmus-cassandra-z5jj2-smqqb -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-06-04T10:45:53.021567 (delta: 0.07087)         elapsed: 0.07087 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-04T10:45:53.037066 (delta: 0.015436)         elapsed: 0.086369 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:03.824233 (delta: 10.787132)         elapsed: 10.873536 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-04T10:46:03.915914 (delta: 0.09161)         elapsed: 10.965217 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-04T10:46:03.986661 (delta: 0.070681)         elapsed: 11.035964 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:04.065363 (delta: 0.078635)         elapsed: 11.114666 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T10:46:04.171467 (delta: 0.10603)         elapsed: 11.22077 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "38787597096f09ac9463f7445e4fb6f836dfca14", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2a7b7dd790b0b1b1d3b233a2df27adbc", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1559645164.24-217881554476921/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T10:46:05.053705 (delta: 0.882164)         elapsed: 12.103008 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.180408", "end": "2019-06-04 10:46:06.643376", "rc": 0, "start": "2019-06-04 10:46:05.462968", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cassandra-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cassandra-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T10:46:06.707050 (delta: 1.653274)         elapsed: 13.756353 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.948922", "end": "2019-06-04 10:46:08.884255", "failed_when_result": false, "rc": 0, "start": "2019-06-04 10:46:06.935333", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cassandra-deployment configured", "stdout_lines": ["litmusresult.litmus.io/cassandra-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T10:46:08.966094 (delta: 2.258976)         elapsed: 16.015397 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T10:46:09.027048 (delta: 0.060886)         elapsed: 16.076351 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T10:46:09.086630 (delta: 0.059517)         elapsed: 16.135933 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the storage capacity placeholder] ********************************
2019-06-04T10:46:09.153692 (delta: 0.066989)         elapsed: 16.202995 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-06-04T10:46:09.710717 (delta: 0.556958)         elapsed: 16.76002 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Get the application label values from env] *******************************
2019-06-04T10:46:10.015694 (delta: 0.304907)         elapsed: 17.064997 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "cassandra"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-04T10:46:10.118366 (delta: 0.102602)         elapsed: 17.167669 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:10.411978 (delta: 0.293545)         elapsed: 17.461281 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-06-04T10:46:10.568475 (delta: 0.156401)         elapsed: 17.617778 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk", "delta": "0:00:02.515495", "end": "2019-06-04 10:46:13.326497", "rc": 0, "start": "2019-06-04 10:46:10.811002", "stderr": "", "stderr_lines": [], "stdout": "NAME                 PROVISIONER                    AGE\nopenebs-cstor-disk   openebs.io/provisioner-iscsi   25d", "stdout_lines": ["NAME                 PROVISIONER                    AGE", "openebs-cstor-disk   openebs.io/provisioner-iscsi   25d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-06-04T10:46:13.419129 (delta: 2.850581)         elapsed: 20.468432 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-04T10:46:13.799148 (delta: 0.379907)         elapsed: 20.848451 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:14.134823 (delta: 0.335597)         elapsed: 21.184126 ******* 
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-06-04T10:46:14.284316 (delta: 0.149421)         elapsed: 21.333619 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "1"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-06-04T10:46:14.458055 (delta: 0.173639)         elapsed: 21.507358 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
2019-06-04T10:46:14.786876 (delta: 0.328749)         elapsed: 21.836179 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "cassandra"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-04T10:46:14.912101 (delta: 0.125145)         elapsed: 21.961404 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-06-04T10:46:15.215341 (delta: 0.303167)         elapsed: 22.264644 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:15.304459 (delta: 0.089032)         elapsed: 22.353762 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-06-04T10:46:15.433189 (delta: 0.12866)         elapsed: 22.482492 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.431099", "end": "2019-06-04 10:46:17.188920", "rc": 0, "start": "2019-06-04 10:46:15.757821", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\napp-esearch-ns\napp-jenkins-ns\napp-mongo-ns\napp-pgres-ns\napp-prometheus\ndefault\nheptio-ark\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmaya-system\nmonitor\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["app-busybox-ns", "app-esearch-ns", "app-jenkins-ns", "app-mongo-ns", "app-pgres-ns", "app-prometheus", "default", "heptio-ark", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "maya-system", "monitor", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
2019-06-04T10:46:17.256809 (delta: 1.823545)         elapsed: 24.306112 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-cass-ns", "delta": "0:00:01.468065", "end": "2019-06-04 10:46:19.033267", "rc": 0, "start": "2019-06-04 10:46:17.565202", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-cass-ns created", "stdout_lines": ["namespace/app-cass-ns created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:19.127164 (delta: 1.870281)         elapsed: 26.176467 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-06-04T10:46:19.249171 (delta: 0.121937)         elapsed: 26.298474 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-cass-ns -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.477851", "end": "2019-06-04 10:46:21.000117", "rc": 0, "start": "2019-06-04 10:46:19.522266", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the default namespace in cassandra statefulset yaml] *************
2019-06-04T10:46:21.089038 (delta: 1.839772)         elapsed: 28.138341 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:21.424236 (delta: 0.335106)         elapsed: 28.473539 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying Cassandra statefulset] *****************************************
2019-06-04T10:46:21.569035 (delta: 0.144708)         elapsed: 28.618338 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cassandra_statefulset.yml -n app-cass-ns", "delta": "0:00:01.635270", "end": "2019-06-04 10:46:23.496201", "rc": 0, "start": "2019-06-04 10:46:21.860931", "stderr": "", "stderr_lines": [], "stdout": "service/cassandra created\nstatefulset.apps/cassandra created", "stdout_lines": ["service/cassandra created", "statefulset.apps/cassandra created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:23.584662 (delta: 2.01556)         elapsed: 30.633965 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T10:46:23.698534 (delta: 0.11378)         elapsed: 30.747837 ******** 
included: /utils/scm/openebs/check_replica_count.yml for 127.0.0.1

TASK [Obtain the number of replicas.] ******************************************
2019-06-04T10:46:23.855008 (delta: 0.156381)         elapsed: 30.904311 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-cass-ns --no-headers -l \"app=cassandra\" -o custom-columns=:spec.replicas", "delta": "0:00:01.664888", "end": "2019-06-04 10:46:25.792866", "rc": 0, "start": "2019-06-04 10:46:24.127978", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
2019-06-04T10:46:25.866061 (delta: 2.010971)         elapsed: 32.915364 ******* 
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (30 retries left).
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get statefulset -n app-cass-ns -l \"app=cassandra\" --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.373417", "end": "2019-06-04 10:48:30.987001", "rc": 0, "start": "2019-06-04 10:48:29.613584", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Deprovisioning the Application] ******************************************
2019-06-04T10:48:31.068305 (delta: 125.202169)         elapsed: 158.117608 **** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-06-04T10:48:31.152070 (delta: 0.083687)         elapsed: 158.201373 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-04T10:48:31.254005 (delta: 0.101862)         elapsed: 158.303308 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T10:48:31.393744 (delta: 0.139669)         elapsed: 158.443047 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T10:48:31.475969 (delta: 0.082125)         elapsed: 158.525272 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T10:48:31.545491 (delta: 0.069421)         elapsed: 158.594794 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T10:48:31.608930 (delta: 0.063354)         elapsed: 158.658233 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "84ef08e246da9e078d47c97d427f8a8f1cda7bb1", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "93830d6eb39e3d876341beaaeda4a0f2", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1559645311.76-186598403124229/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T10:48:34.954338 (delta: 3.345336)         elapsed: 162.003641 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.188895", "end": "2019-06-04 10:48:36.371865", "rc": 0, "start": "2019-06-04 10:48:35.182970", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cassandra-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cassandra-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T10:48:36.440666 (delta: 1.486255)         elapsed: 163.489969 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.410387", "end": "2019-06-04 10:48:38.130317", "failed_when_result": false, "rc": 0, "start": "2019-06-04 10:48:36.719930", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cassandra-deployment configured", "stdout_lines": ["litmusresult.litmus.io/cassandra-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=20   unreachable=0    failed=0   

2019-06-04T10:48:38.184413 (delta: 1.743675)         elapsed: 165.233716 ****** 
=============================================================================== 
```
Application and target pods are scheduled in same node 
```
[root@master-1554817485 deployers]# kubectl get pods -n app-cass-ns -o wide
NAME          READY     STATUS    RESTARTS   AGE       IP            NODE
cassandra-0   1/1       Running   0          24m       172.23.5.33   node2-1554817485.mayalabs.io
[root@master-1554817485 deployers]# kubectl get pvc -n app-cass-ns
NAME                            STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
openebs-cassandra-cassandra-0   Bound     pvc-fef272f9-86b5-11e9-9a67-00505698550d   5G         RWO            openebs-cstor-disk   24m
[root@master-1554817485 deployers]# kubectl get pods -n openebs -o wide| grep pvc-fef272f9-86b5-11e9-9a67-00505698550d 
pvc-fef272f9-86b5-11e9-9a67-00505698550d-target-7558d94df6z9cv4   3/3       Running   1          24m       172.23.5.32    node2-1554817485.mayalabs.io
```

      