### PR TITLE
Refactored litmus books for deployment of Postgres to take capacity as env and added target affinity in playbooks

### DIFF
--- a/apps/crunchy-postgres/deployers/postgres_statefulset.yml
+++ b/apps/crunchy-postgres/deployers/postgres_statefulset.yml
@@ -65,6 +65,7 @@ spec:
     metadata:
       labels:
         lkey: lvalue
+        affinity_label: pgset
     spec:
       securityContext:
         fsGroup: 26
@@ -108,4 +109,4 @@ spec:
       storageClassName: testclass
       resources:
         requests:
-          storage: 5G
+          storage: volume-capacity

--- a/apps/crunchy-postgres/deployers/run_litmus_test.yml
+++ b/apps/crunchy-postgres/deployers/run_litmus_test.yml
@@ -35,6 +35,10 @@ spec:
           - name: APP_LABEL
             value: 'app=pgset'
 
+            # Affinity Label for Application
+          - name: AFFINITY_LABEL
+            value: openebs.io/sts-target-affinity
+
             # Application namespace
           - name: APP_NAMESPACE
             value: app-pgres-ns
@@ -45,6 +49,10 @@ spec:
             # Use 'deprovision' for app-clean up
           - name: ACTION
             value: provision
+
+            # define a variable CAPACITY to accept the size given by user
+          - name: CAPACITY
+            value: 5G 
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/crunchy-postgres/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/crunchy-postgres/deployers/test.yml
+++ b/apps/crunchy-postgres/deployers/test.yml
@@ -15,12 +15,25 @@
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:
             status: 'SOT'
-
+          
+         
         - block:
 
          ## Actual test
          ## Creating namespaces and making the application for deployment
             - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+            
+            - name: Replace the storage capacity placeholder
+              replace:
+                 path: "{{ application_deployment }}"
+                 regexp: "volume-capacity"
+                 replace: "{{ capacity }}" 
+
+            - name: Replace the affinity label annotation in statefulset yml
+              replace:
+                 path: "{{ application_deployment }}"
+                 regexp: "affinity_label"
+                 replace: "{{ affinity_label }}"
 
          ## Deploying the application
             - include_tasks: /utils/k8s/deploy_single_app.yml
@@ -34,8 +47,8 @@
               args:
                 executable: /bin/bash
               register: result_service
-              failed_when: "'pgset-primary' and 'pgset-replica' not in result_service.stdout"
-
+              failed_when: "'pgset-primary' and 'pgset-replica' not in result_service.stdout"        
+       
           when: "'deprovision' not in action"
 
         - block:

--- a/apps/crunchy-postgres/deployers/test_vars.yml
+++ b/apps/crunchy-postgres/deployers/test_vars.yml
@@ -5,4 +5,6 @@ test_name: postgres-deployment
 application_name: "postgres statefulset and services"
 action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
+affinity_label: "{{ lookup('env','AFFINITY_LABEL') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+capacity: "{{ lookup('env','CAPACITY') }}"


### PR DESCRIPTION
* Volume capacity is taken as environmental variable.
* Target affinity is added in order to schedule both target pod and application pod in same node
* These files are modified
     	modified:   apps/crunchy-postgres/deployers/postgres_statefulset.yml
	modified:   apps/crunchy-postgres/deployers/run_litmus_test.yml
	modified:   apps/crunchy-postgres/deployers/test.yml
	modified:   apps/crunchy-postgres/deployers/test_vars.yml

Here are the logs :
```
[root@master-1554817485 deployers]# kubectl logs litmus-pgset-l7qzq-42jpf -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-06-04T13:10:23.861520 (delta: 0.067895)         elapsed: 0.067895 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-04T13:10:23.880725 (delta: 0.019142)         elapsed: 0.0871 ********** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:34.191944 (delta: 10.311171)         elapsed: 10.398319 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-04T13:10:34.341009 (delta: 0.148987)         elapsed: 10.547384 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-04T13:10:34.425543 (delta: 0.084434)         elapsed: 10.631918 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:34.545813 (delta: 0.120194)         elapsed: 10.752188 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T13:10:34.663615 (delta: 0.117714)         elapsed: 10.86999 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "83ced95f54adf9b703f212a376db2880db377cbf", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "ec0a233fe3c0a64265dea059f6e1aae6", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1559653834.75-53080489138243/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T13:10:35.785709 (delta: 1.122027)         elapsed: 11.992084 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.245792", "end": "2019-06-04 13:10:37.553448", "rc": 0, "start": "2019-06-04 13:10:36.307656", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: postgres-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: postgres-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T13:10:37.614667 (delta: 1.82887)         elapsed: 13.821042 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.129134", "end": "2019-06-04 13:10:39.998047", "failed_when_result": false, "rc": 0, "start": "2019-06-04 13:10:37.868913", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/postgres-deployment configured", "stdout_lines": ["litmusresult.litmus.io/postgres-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T13:10:40.073330 (delta: 2.458598)         elapsed: 16.279705 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T13:10:40.136531 (delta: 0.063131)         elapsed: 16.342906 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T13:10:40.222716 (delta: 0.086109)         elapsed: 16.429091 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:40.289578 (delta: 0.066787)         elapsed: 16.495953 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-06-04T13:10:40.418920 (delta: 0.129265)         elapsed: 16.625295 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk", "delta": "0:00:01.366234", "end": "2019-06-04 13:10:42.070165", "rc": 0, "start": "2019-06-04 13:10:40.703931", "stderr": "", "stderr_lines": [], "stdout": "NAME                 PROVISIONER                    AGE\nopenebs-cstor-disk   openebs.io/provisioner-iscsi   25d", "stdout_lines": ["NAME                 PROVISIONER                    AGE", "openebs-cstor-disk   openebs.io/provisioner-iscsi   25d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-06-04T13:10:42.139593 (delta: 1.7206)         elapsed: 18.345968 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-04T13:10:42.881205 (delta: 0.741543)         elapsed: 19.08758 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:43.274432 (delta: 0.393139)         elapsed: 19.480807 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2019-06-04T13:10:43.363078 (delta: 0.088556)         elapsed: 19.569453 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "pgset"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-04T13:10:43.480050 (delta: 0.116884)         elapsed: 19.686425 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-06-04T13:10:43.875780 (delta: 0.395659)         elapsed: 20.082155 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:43.978616 (delta: 0.102725)         elapsed: 20.184991 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-06-04T13:10:44.153089 (delta: 0.174405)         elapsed: 20.359464 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.491216", "end": "2019-06-04 13:10:45.919844", "rc": 0, "start": "2019-06-04 13:10:44.428628", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\napp-cass-ns\napp-cass-ssh\napp-cass-sushma\napp-esearch-ns\napp-jenkins-ns\napp-jenkins-ns-sushma\napp-mongo-ns\napp-pgres-ns\napp-pgres-ssh\napp-prometheus\ndefault\nheptio-ark\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmaya-system\nmonitor\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["app-busybox-ns", "app-cass-ns", "app-cass-ssh", "app-cass-sushma", "app-esearch-ns", "app-jenkins-ns", "app-jenkins-ns-sushma", "app-mongo-ns", "app-pgres-ns", "app-pgres-ssh", "app-prometheus", "default", "heptio-ark", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "maya-system", "monitor", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
2019-06-04T13:10:46.004077 (delta: 1.850918)         elapsed: 22.210452 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-pgres-sushma", "delta": "0:00:01.298671", "end": "2019-06-04 13:10:47.616847", "rc": 0, "start": "2019-06-04 13:10:46.318176", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-pgres-sushma created", "stdout_lines": ["namespace/app-pgres-sushma created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:47.688886 (delta: 1.684742)         elapsed: 23.895261 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-06-04T13:10:47.832223 (delta: 0.143268)         elapsed: 24.038598 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-pgres-sushma -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.383789", "end": "2019-06-04 13:10:49.458003", "rc": 0, "start": "2019-06-04 13:10:48.074214", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the storage capacity placeholder] ********************************
2019-06-04T13:10:49.549536 (delta: 1.717223)         elapsed: 25.755911 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-06-04T13:10:49.881070 (delta: 0.331465)         elapsed: 26.087445 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:50.287858 (delta: 0.406716)         elapsed: 26.494233 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying postgres statefulset and services] *****************************
2019-06-04T13:10:50.407005 (delta: 0.119075)         elapsed: 26.61338 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f postgres_statefulset.yml -n app-pgres-sushma", "delta": "0:00:02.917781", "end": "2019-06-04 13:10:53.601994", "rc": 0, "start": "2019-06-04 13:10:50.684213", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount/pgset-sa created\nservice/pgset created\nservice/pgset-primary created\nservice/pgset-replica created\nstatefulset.apps/pgset created", "stdout_lines": ["serviceaccount/pgset-sa created", "service/pgset created", "service/pgset-primary created", "service/pgset-replica created", "statefulset.apps/pgset created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T13:10:53.671475 (delta: 3.264407)         elapsed: 29.87785 ******** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-06-04T13:10:53.837408 (delta: 0.165859)         elapsed: 30.043783 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
changed: [127.0.0.1] => {"attempts": 10, "changed": true, "cmd": "kubectl get pod -n app-pgres-sushma -l app=\"pgset\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:02.064934", "end": "2019-06-04 13:11:31.098575", "rc": 0, "start": "2019-06-04 13:11:29.033641", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-06-04T13:11:30Z]]", "stdout_lines": ["map[running:map[startedAt:2019-06-04T13:11:30Z]]"]}

TASK [Checking postgres statefulset and services pod is in running state] ******
2019-06-04T13:11:31.274641 (delta: 37.43714)         elapsed: 67.481016 ******* 
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (100 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (99 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (98 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (97 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (96 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (95 retries left).
FAILED - RETRYING: Checking postgres statefulset and services pod is in running state (94 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl get pods -n app-pgres-sushma -o jsonpath='{.items[?(@.metadata.labels.app==\"pgset\")].status.phase}'", "delta": "0:00:01.414563", "end": "2019-06-04 13:12:56.533365", "rc": 0, "start": "2019-06-04 13:12:55.118802", "stderr": "", "stderr_lines": [], "stdout": "Running Running", "stdout_lines": ["Running Running"]}

TASK [include_tasks] ***********************************************************
2019-06-04T13:12:56.614095 (delta: 85.339388)         elapsed: 152.82047 ****** 
included: /utils/scm/openebs/check_replica_count.yml for 127.0.0.1

TASK [Obtain the number of replicas.] ******************************************
2019-06-04T13:12:56.809200 (delta: 0.195037)         elapsed: 153.015575 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-pgres-sushma --no-headers -l \"app=pgset\" -o custom-columns=:spec.replicas", "delta": "0:00:01.401364", "end": "2019-06-04 13:12:58.468870", "rc": 0, "start": "2019-06-04 13:12:57.067506", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
2019-06-04T13:12:58.560920 (delta: 1.751591)         elapsed: 154.767295 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-pgres-sushma -l \"app=pgset\" --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.466369", "end": "2019-06-04 13:13:00.324789", "rc": 0, "start": "2019-06-04 13:12:58.858420", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Verify that the postgres master and replica are available as cluster services] ***
2019-06-04T13:13:00.408975 (delta: 1.847991)         elapsed: 156.61535 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -n app-pgres-sushma", "delta": "0:00:01.585210", "end": "2019-06-04 13:13:02.295242", "failed_when_result": false, "rc": 0, "start": "2019-06-04 13:13:00.710032", "stderr": "", "stderr_lines": [], "stdout": "NAME            TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE\npgset           ClusterIP   None          <none>        5432/TCP   2m\npgset-primary   ClusterIP   172.24.3.36   <none>        5432/TCP   2m\npgset-replica   ClusterIP   172.24.3.65   <none>        5432/TCP   2m", "stdout_lines": ["NAME            TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE", "pgset           ClusterIP   None          <none>        5432/TCP   2m", "pgset-primary   ClusterIP   172.24.3.36   <none>        5432/TCP   2m", "pgset-replica   ClusterIP   172.24.3.65   <none>        5432/TCP   2m"]}

TASK [Deprovisioning the Application] ******************************************
2019-06-04T13:13:02.387621 (delta: 1.978577)         elapsed: 158.593996 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-06-04T13:13:02.519479 (delta: 0.131769)         elapsed: 158.725854 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-04T13:13:02.650265 (delta: 0.130709)         elapsed: 158.85664 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T13:13:02.782251 (delta: 0.131871)         elapsed: 158.988626 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T13:13:02.863473 (delta: 0.081105)         elapsed: 159.069848 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T13:13:02.948143 (delta: 0.084588)         elapsed: 159.154518 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T13:13:03.034580 (delta: 0.086337)         elapsed: 159.240955 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2f1bffa856a9d5a08b8640eb013f9bbe74dfdaee", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cc95581195cfc7512f1abe8e541bcbdb", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1559653983.13-4162509877784/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T13:13:06.507056 (delta: 3.472393)         elapsed: 162.713431 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.221144", "end": "2019-06-04 13:13:07.978875", "rc": 0, "start": "2019-06-04 13:13:06.757731", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: postgres-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: postgres-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T13:13:08.067378 (delta: 1.560237)         elapsed: 164.273753 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.740553", "end": "2019-06-04 13:13:10.075893", "failed_when_result": false, "rc": 0, "start": "2019-06-04 13:13:08.335340", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/postgres-deployment configured", "stdout_lines": ["litmusresult.litmus.io/postgres-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=33   changed=21   unreachable=0    failed=0   

2019-06-04T13:13:10.135660 (delta: 2.068184)         elapsed: 166.342035 ****** 
=============================================================================== 
```





Application and target pods are scheduled in same node:
```
[root@master-1554817485 deployers]# kubectl get pods -n app-pgres-sushma -o wide
NAME      READY     STATUS    RESTARTS   AGE       IP             NODE
pgset-0   1/1       Running   0          12m       172.23.3.198   node1-1554817485.mayalabs.io
pgset-1   1/1       Running   0          12m       172.23.6.79    node3-1554817485.mayalabs.io
[root@master-1554817485 deployers]# kubectl get pvc -n app-pgres-sushma
NAME                   STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
pgdata-claim-pgset-0   Bound     pvc-2eb61e75-86ca-11e9-9a67-00505698550d   5G         RWO            openebs-cstor-disk   12m
pgdata-claim-pgset-1   Bound     pvc-44bcd37e-86ca-11e9-9a67-00505698550d   5G         RWO            openebs-cstor-disk   12m
[root@master-1554817485 deployers]# kubectl get pods -n openebs -o wide|grep -E 'pvc-2eb61e75-86ca-11e9-9a67-00505698550d|pvc-44bcd37e-86ca-11e9-9a67-00505698550d'
pvc-2eb61e75-86ca-11e9-9a67-00505698550d-target-5ccfb95864r258s   3/3       Running   1          13m       172.23.3.197   node1-1554817485.mayalabs.io
pvc-44bcd37e-86ca-11e9-9a67-00505698550d-target-84949686f8mxnrb   3/3       Running   1          12m       172.23.6.78    node3-1554817485.mayalabs.io
```
