### PR TITLE
Refactored litmus books for deployment of Elasticsearch to schedule application pod and target pod in same node

### DIFF
--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -28,10 +28,14 @@ spec:
   selector:
     matchLabels:
       lkey: lvalue
+      #The Label "openebs.io/replica-anti-affinity" 
+      #needs to be added in order to distribute volume replicas.
+      affinity_label: elasticsearch-logging
   template:
     metadata:
       labels:
         lkey: lvalue
+        affinity_label: elasticsearch-logging
         role: elasticsearch
     spec:
       securityContext:

--- a/apps/elasticsearch/deployers/run_litmus_test.yml
+++ b/apps/elasticsearch/deployers/run_litmus_test.yml
@@ -37,6 +37,10 @@ spec:
           - name: APP_LABEL
             value: 'app=elasticsearch'
 
+           # Affinity Label for Application
+          - name: AFFINITY_LABEL
+            value: openebs.io/sts-target-affinity
+
             # Application namespace
           - name: APP_NAMESPACE
             value: app-esearch-ns 

--- a/apps/elasticsearch/deployers/test.yml
+++ b/apps/elasticsearch/deployers/test.yml
@@ -38,7 +38,13 @@
               replace:
                  path: "{{ application_rbac }}"
                  regexp: "nsvalue"
-                 replace: "{{ lookup('env','APP_NAMESPACE') }}"     
+                 replace: "{{ lookup('env','APP_NAMESPACE') }}"  
+
+            - name: Replace the affinity label annotation in statefulset yml
+              replace:
+                 path: "{{ application_deployment }}"
+                 regexp: "affinity_label"
+                 replace: "{{ affinity_label }}"   
 
             - name: Deploying {{ application_name }} rbac.
               shell: kubectl apply -f {{ application_rbac }}

--- a/apps/elasticsearch/deployers/test_vars.yml
+++ b/apps/elasticsearch/deployers/test_vars.yml
@@ -7,6 +7,7 @@ app_replica: "{{ lookup('env','APP_REPLICA') }}"
 application_name: "Elasticsearch"
 action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
+affinity_label: "{{ lookup('env','AFFINITY_LABEL') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 operator_ns: openebs
 capacity: "{{ lookup('env','CAPACITY') }}"


### PR DESCRIPTION
* Volume capacity is taken as environmental variable.
* Target affinity is added in order to schedule both target pod and application pod in same node

Here are the logs:
```
[root@master-1554817485 apps]# kubectl logs litmus-elasticsearch-lsjks-ndkrt -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-06-04T14:01:23.930038 (delta: 0.133463)         elapsed: 0.133463 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-04T14:01:23.968758 (delta: 0.038572)         elapsed: 0.172183 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-04T14:01:48.901689 (delta: 24.932886)         elapsed: 25.105114 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-04T14:01:49.337788 (delta: 0.436037)         elapsed: 25.541213 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-04T14:01:49.487972 (delta: 0.150067)         elapsed: 25.691397 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:01:49.763465 (delta: 0.275404)         elapsed: 25.96689 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T14:01:50.256316 (delta: 0.492724)         elapsed: 26.459741 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "6527a253a359ed86afebe9a5acb7cef1cdd5ceca", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "64d3f3b6a9cafa1258bf4b48430a64d0", "mode": "0644", "owner": "root", "size": 425, "src": "/root/.ansible/tmp/ansible-tmp-1559656910.44-245461846350500/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:01:53.083485 (delta: 2.827091)         elapsed: 29.28691 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:02.316813", "end": "2019-06-04 14:01:56.346681", "rc": 0, "start": "2019-06-04 14:01:54.029868", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: elasticsearch-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: elasticsearch-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:01:56.516245 (delta: 3.432677)         elapsed: 32.71967 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:03.595422", "end": "2019-06-04 14:02:00.454005", "failed_when_result": false, "rc": 0, "start": "2019-06-04 14:01:56.858583", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/elasticsearch-deployment configured", "stdout_lines": ["litmusresult.litmus.io/elasticsearch-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T14:02:00.621689 (delta: 4.105368)         elapsed: 36.825114 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:02:00.763655 (delta: 0.14189)         elapsed: 36.96708 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:02:00.838956 (delta: 0.075228)         elapsed: 37.042381 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:01.029442 (delta: 0.190416)         elapsed: 37.232867 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-06-04T14:02:01.385769 (delta: 0.356248)         elapsed: 37.589194 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse", "delta": "0:00:03.483107", "end": "2019-06-04 14:02:05.533722", "rc": 0, "start": "2019-06-04 14:02:02.050615", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-cstor-sparse   openebs.io/provisioner-iscsi   35d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-cstor-sparse   openebs.io/provisioner-iscsi   35d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-06-04T14:02:05.736922 (delta: 4.351081)         elapsed: 41.940347 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-04T14:02:07.072409 (delta: 1.335412)         elapsed: 43.275834 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:08.531138 (delta: 1.458646)         elapsed: 44.734563 ******* 
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-06-04T14:02:08.755683 (delta: 0.224439)         elapsed: 44.959108 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-06-04T14:02:09.064774 (delta: 0.309014)         elapsed: 45.268199 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
2019-06-04T14:02:10.110946 (delta: 1.046068)         elapsed: 46.314371 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "elasticsearch"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-04T14:02:10.691969 (delta: 0.580945)         elapsed: 46.895394 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "4 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-06-04T14:02:12.401847 (delta: 1.709801)         elapsed: 48.605272 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:12.815799 (delta: 0.413865)         elapsed: 49.019224 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-06-04T14:02:13.735298 (delta: 0.919387)         elapsed: 49.938723 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:03.734816", "end": "2019-06-04 14:02:18.433211", "rc": 0, "start": "2019-06-04 14:02:14.698395", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\napp-cass-ns\napp-cass-ssh\napp-cass-sush1\napp-cass-sushma\napp-esearch-ns\napp-jenkins-ns\napp-jenkins-ns-sush1\napp-jenkins-ns-sushma\napp-mongo-namespace\napp-mongo-ns\napp-mongo-ssh\napp-pgres-ns\napp-pgres-ssh\napp-pgres-sushma\napp-prometheus\ndefault\nheptio-ark\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmaya-system\nmonitor\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["app-busybox-ns", "app-cass-ns", "app-cass-ssh", "app-cass-sush1", "app-cass-sushma", "app-esearch-ns", "app-jenkins-ns", "app-jenkins-ns-sush1", "app-jenkins-ns-sushma", "app-mongo-namespace", "app-mongo-ns", "app-mongo-ssh", "app-pgres-ns", "app-pgres-ssh", "app-pgres-sushma", "app-prometheus", "default", "heptio-ark", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "maya-system", "monitor", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
2019-06-04T14:02:18.608009 (delta: 4.872635)         elapsed: 54.811434 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-esearch-sush1", "delta": "0:00:03.285739", "end": "2019-06-04 14:02:22.326633", "rc": 0, "start": "2019-06-04 14:02:19.040894", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-esearch-sush1 created", "stdout_lines": ["namespace/app-esearch-sush1 created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:22.424697 (delta: 3.816607)         elapsed: 58.628122 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-06-04T14:02:22.681276 (delta: 0.256504)         elapsed: 58.884701 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-esearch-sush1 -o custom-columns=:status.phase --no-headers", "delta": "0:00:02.368983", "end": "2019-06-04 14:02:25.506491", "rc": 0, "start": "2019-06-04 14:02:23.137508", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the application label placeholder in elasticsearch manifest] *****
2019-06-04T14:02:25.631492 (delta: 2.95014)         elapsed: 61.834917 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replace the storage capacity placeholder] ********************************
2019-06-04T14:02:26.211057 (delta: 0.579484)         elapsed: 62.414482 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the namespace placeholder in rbac spec.] *************************
2019-06-04T14:02:26.644539 (delta: 0.433163)         elapsed: 62.847964 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-06-04T14:02:27.043740 (delta: 0.399116)         elapsed: 63.247165 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Deploying Elasticsearch rbac.] *******************************************
2019-06-04T14:02:27.579670 (delta: 0.535842)         elapsed: 63.783095 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f esearch_rbac.yml", "delta": "0:00:02.551662", "end": "2019-06-04 14:02:30.435853", "rc": 0, "start": "2019-06-04 14:02:27.884191", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount/elasticsearch-logging created\nclusterrole.rbac.authorization.k8s.io/elasticsearch-logging unchanged\nclusterrolebinding.rbac.authorization.k8s.io/elasticsearch-logging configured", "stdout_lines": ["serviceaccount/elasticsearch-logging created", "clusterrole.rbac.authorization.k8s.io/elasticsearch-logging unchanged", "clusterrolebinding.rbac.authorization.k8s.io/elasticsearch-logging configured"]}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:30.515413 (delta: 2.935664)         elapsed: 66.718838 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying Elasticsearch] *************************************************
2019-06-04T14:02:30.658545 (delta: 0.143066)         elapsed: 66.86197 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f es-statefulset.yaml -n app-esearch-sush1", "delta": "0:00:02.546521", "end": "2019-06-04 14:02:33.563532", "rc": 0, "start": "2019-06-04 14:02:31.017011", "stderr": "", "stderr_lines": [], "stdout": "service/elasticsearch-logging created\nstatefulset.apps/elasticsearch-logging created", "stdout_lines": ["service/elasticsearch-logging created", "statefulset.apps/elasticsearch-logging created"]}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:33.664502 (delta: 3.005896)         elapsed: 69.867927 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:02:33.776726 (delta: 0.112125)         elapsed: 69.980151 ******* 
included: /utils/scm/openebs/check_replica_count.yml for 127.0.0.1

TASK [Obtain the number of replicas.] ******************************************
2019-06-04T14:02:34.014713 (delta: 0.237901)         elapsed: 70.218138 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-esearch-sush1 --no-headers -l \"app=elasticsearch\" -o custom-columns=:spec.replicas", "delta": "0:00:01.710129", "end": "2019-06-04 14:02:36.090812", "rc": 0, "start": "2019-06-04 14:02:34.380683", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
2019-06-04T14:02:36.193266 (delta: 2.178446)         elapsed: 72.396691 ******* 
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (30 retries left).
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (29 retries left).
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get statefulset -n app-esearch-sush1 -l \"app=elasticsearch\" --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.800205", "end": "2019-06-04 14:05:50.544217", "rc": 0, "start": "2019-06-04 14:05:48.744012", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Deprovisioning the Application] ******************************************
2019-06-04T14:05:50.654517 (delta: 194.461171)         elapsed: 266.857942 **** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-06-04T14:05:50.801171 (delta: 0.146559)         elapsed: 267.004596 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-04T14:05:50.933049 (delta: 0.131795)         elapsed: 267.136474 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T14:05:51.111231 (delta: 0.163886)         elapsed: 267.314656 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:05:51.197632 (delta: 0.086343)         elapsed: 267.401057 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:05:51.283251 (delta: 0.085546)         elapsed: 267.486676 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T14:05:51.356940 (delta: 0.073617)         elapsed: 267.560365 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4da6298723b4228f5cad23ca2155b6dd5f813feb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5822a4984246284d298ea2bfb437d54f", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1559657151.42-252751372243812/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:05:54.788198 (delta: 3.431186)         elapsed: 270.991623 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.325613", "end": "2019-06-04 14:05:56.666858", "rc": 0, "start": "2019-06-04 14:05:55.341245", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: elasticsearch-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: elasticsearch-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:05:56.738416 (delta: 1.95014)         elapsed: 272.941841 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.063525", "end": "2019-06-04 14:05:59.164215", "failed_when_result": false, "rc": 0, "start": "2019-06-04 14:05:57.100690", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/elasticsearch-deployment configured", "stdout_lines": ["litmusresult.litmus.io/elasticsearch-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=22   unreachable=0    failed=0   

2019-06-04T14:05:59.233669 (delta: 2.495187)         elapsed: 275.437094 ****** 
=============================================================================== 
```
Application and target pods are scheduled on the same node
```
[root@master-1554817485 apps]# kubectl get pods -n app-esearch-sush1
NAME                      READY     STATUS    RESTARTS   AGE
elasticsearch-logging-0   1/1       Running   0          41m
elasticsearch-logging-1   1/1       Running   0          40m
[root@master-1554817485 apps]# kubectl get pods -n app-esearch-sush1 -o wide
NAME                      READY     STATUS    RESTARTS   AGE       IP             NODE
elasticsearch-logging-0   1/1       Running   0          41m       172.23.5.40    node2-1554817485.mayalabs.io
elasticsearch-logging-1   1/1       Running   0          40m       172.23.3.203   node1-1554817485.mayalabs.io
[root@master-1554817485 apps]#  kubectl get pvc -n app-esearch-sush1
NAME                                      STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
openebs-esearch-elasticsearch-logging-0   Bound     pvc-66792f6e-86d1-11e9-9a67-00505698550d   8G         RWO            openebs-cstor-sparse   41m
openebs-esearch-elasticsearch-logging-1   Bound     pvc-91e3682e-86d1-11e9-9a67-00505698550d   8G         RWO            openebs-cstor-sparse   40m
[root@master-1554817485 apps]# kubectl get pods -n openebs -o wide|grep -E 'pvc-66792f6e-86d1-11e9-9a67-00505698550d|vc-91e3682e-86d1-11e9-9a67-00505698550d'
pvc-66792f6e-86d1-11e9-9a67-00505698550d-target-5b97fd46d-r8rd6   3/3       Running   1          41m       172.23.5.39    node2-1554817485.mayalabs.io
pvc-91e3682e-86d1-11e9-9a67-00505698550d-target-6c49d6947d5qndf   3/3       Running   1          40m       172.23.3.202   node1-1554817485.mayalabs.io
```