### PR TITLE
feat[yaml]: Implemeted a LitmusBook to fill the volume capacity

### DIFF
--- a/experiments/functional/volume-capacity/run_litmus_test.yml
+++ b/experiments/functional/volume-capacity/run_litmus_test.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-volume-capacity-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        app: volume-capacity
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-busybox-ns
+
+          - name: APP_LABEL
+            value: app=busybox
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/volume-capacity/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/volume-capacity/test.yml
+++ b/experiments/functional/volume-capacity/test.yml
@@ -1,0 +1,100 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the application PV 
+          shell: kubectl get pvc -n {{ app_ns }} -o jsonpath={.items[0].spec.volumeName}
+          args:
+            executable: /bin/bash
+          register: pv_name
+
+        - name: Obtain the application pod name
+          shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: app_pod
+
+        - name: Obtain the mount path for the application
+          shell: > 
+              kubectl get pods -n {{ app_ns }} -l {{ app_label }} 
+              -o custom-columns=:.spec.containers[].volumeMounts[].mountPath --no-headers
+          args: 
+              executable: /bin/bash
+          register: mount
+
+        - name: Fetch the Storage from PVC using namespace
+          shell: kubectl get pvc -n {{ app_ns }} -o jsonpath={.items[0].spec.resources.requests.storage}
+          args:
+            executable: /bin/bash
+          register: storage_capacity
+
+        - name: Fetch the alphabet(G,M,m,g) from storage capacity
+          shell: echo "{{ storage_capacity.stdout }}" | grep -o -E '[0-9]+'
+          args:
+            executable: /bin/bash
+          register: value_str
+
+        - set_fact:
+            value_num: '{{ ( (value_str.stdout | int ) * 1024) |  int }}'
+
+        - name: Generate the load to fill capacity of volume
+          shell: >
+              kubectl exec -it "{{ app_pod.stdout }}" -n "{{ app_ns }}" 
+              -- sh -c "cd {{ mount.stdout }} && dd if=/dev/urandom of=volume.txt bs={{ value_num }}k count=1024 >> test.txt && cat test.txt | grep test && rm test.txt"
+          args:
+              executable: /bin/bash
+          register: load
+          ignore_errors: true
+
+        - name: Check the volume is successfully filled
+          shell: kubectl logs -f {{ app_pod.stdout }} -n {{ app_ns }} | grep 'No space left on device'
+          args:
+            executable: /bin/bash
+          register: space
+          until: "'No space left on device' in space.stdout"
+          retries: 15
+          delay: 2
+
+        - name: Check the application pod status
+          shell: >
+              kubectl get pods -n {{ app_ns }} -l {{ app_label }} 
+              -o custom-columns=:.status.containerStatuses[].state.waiting.reason --no-headers
+          args: 
+            executable: /bin/bash
+          register: app_status
+          failed_when: "app_status.stdout not in 'CrashLoopBackOff'"   
+         
+          ###############################################################
+          #  TODO:                                                      #
+          #  - Include the recovery tasks to Resize the Volume.         #
+          #  - Check the Application status post recovery steps.        #
+          #  - Generate I/O post successfull recovery of application.   #
+          ###############################################################
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'          

--- a/experiments/functional/volume-capacity/test.yml
+++ b/experiments/functional/volume-capacity/test.yml
@@ -69,14 +69,14 @@
           retries: 15
           delay: 2
 
-        - name: Check the application pod status
-          shell: >
-              kubectl get pods -n {{ app_ns }} -l {{ app_label }} 
-              -o custom-columns=:.status.containerStatuses[].state.waiting.reason --no-headers
-          args: 
-            executable: /bin/bash
-          register: app_status
-          failed_when: "app_status.stdout not in 'CrashLoopBackOff'"   
+        # - name: Check the application pod status
+        #   shell: >
+        #       kubectl get pods -n {{ app_ns }} -l {{ app_label }} 
+        #       -o custom-columns=:.status.containerStatuses[].state.waiting.reason --no-headers
+        #   args: 
+        #     executable: /bin/bash
+        #   register: app_status
+        #   failed_when: "app_status.stdout not in 'CrashLoopBackOff'"   
          
           ###############################################################
           #  TODO:                                                      #

--- a/experiments/functional/volume-capacity/test_vars.yml
+++ b/experiments/functional/volume-capacity/test_vars.yml
@@ -1,0 +1,6 @@
+---
+## TEST-SPECIFIC PARAMS
+test_name: volume-capacity
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+operator_ns: "openebs"
+app_label: "{{ lookup('env','APP_LABEL') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- LitmusBook to fill the volume capacity

```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-06-04T14:33:32.014478 (delta: 0.06487)         elapsed: 0.06487 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-04T14:33:32.032854 (delta: 0.018314)         elapsed: 0.083246 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-04T14:33:41.831447 (delta: 9.79855)         elapsed: 9.881839 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-04T14:33:41.915394 (delta: 0.083899)         elapsed: 9.965786 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-04T14:33:41.992403 (delta: 0.076947)         elapsed: 10.042795 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-04T14:33:42.065804 (delta: 0.073345)         elapsed: 10.116196 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T14:33:42.171860 (delta: 0.105992)         elapsed: 10.222252 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "548e850668d83274b1f15e736ae29aab1e5e2587", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2a80595c92b21e419f4286f3e51c26f6", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1559658822.26-194923514279347/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:33:43.186999 (delta: 1.01507)         elapsed: 11.237391 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.190251", "end": "2019-06-04 14:33:44.790275", "rc": 0, "start": "2019-06-04 14:33:43.600024", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: volume-capacity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: volume-capacity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:33:44.849518 (delta: 1.662431)         elapsed: 12.89991 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.898021", "end": "2019-06-04 14:33:47.028088", "failed_when_result": false, "rc": 0, "start": "2019-06-04 14:33:45.130067", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/volume-capacity configured", "stdout_lines": ["litmusresult.litmus.io/volume-capacity configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T14:33:47.104834 (delta: 2.255248)         elapsed: 15.155226 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:33:47.160412 (delta: 0.05551)         elapsed: 15.210804 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:33:47.215743 (delta: 0.055259)         elapsed: 15.266135 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the application PV] ***********************************************
2019-06-04T14:33:47.272174 (delta: 0.056345)         elapsed: 15.322566 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-percona-ns -o jsonpath={.items[0].spec.volumeName}", "delta": "0:00:01.561717", "end": "2019-06-04 14:33:49.114992", "rc": 0, "start": "2019-06-04 14:33:47.553275", "stderr": "", "stderr_lines": [], "stdout": "pvc-6363c856-86d4-11e9-9a05-005056985c20", "stdout_lines": ["pvc-6363c856-86d4-11e9-9a05-005056985c20"]}

TASK [Obtain the application pod name] *****************************************
2019-06-04T14:33:49.201563 (delta: 1.929325)         elapsed: 17.251955 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.459463", "end": "2019-06-04 14:33:50.949067", "rc": 0, "start": "2019-06-04 14:33:49.489604", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-vjf2g", "stdout_lines": ["percona-cb697f8b4-vjf2g"]}

TASK [Obtain the mount path for the application] *******************************
2019-06-04T14:33:51.019065 (delta: 1.817431)         elapsed: 19.069457 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o custom-columns=:.spec.containers[].volumeMounts[].mountPath --no-headers", "delta": "0:00:01.355044", "end": "2019-06-04 14:33:52.687232", "rc": 0, "start": "2019-06-04 14:33:51.332188", "stderr": "", "stderr_lines": [], "stdout": "/var/lib/mysql", "stdout_lines": ["/var/lib/mysql"]}

TASK [Fetch the Storage from PVC using namespace] ******************************
2019-06-04T14:33:52.749875 (delta: 1.73074)         elapsed: 20.800267 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-percona-ns -o jsonpath={.items[0].spec.resources.requests.storage}", "delta": "0:00:01.381268", "end": "2019-06-04 14:33:54.413756", "rc": 0, "start": "2019-06-04 14:33:53.032488", "stderr": "", "stderr_lines": [], "stdout": "5G", "stdout_lines": ["5G"]}

TASK [Fetch the alphabet(G,M,m,g) from storage capacity] ***********************
2019-06-04T14:33:54.474537 (delta: 1.724594)         elapsed: 22.524929 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"5G\" | grep -o -E '[0-9]+'", "delta": "0:00:01.211472", "end": "2019-06-04 14:33:55.902795", "rc": 0, "start": "2019-06-04 14:33:54.691323", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [set_fact] ****************************************************************
2019-06-04T14:33:55.967115 (delta: 1.492509)         elapsed: 24.017507 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"value_num": "5120"}, "changed": false}

TASK [Generate the load to fill capacity of volume] ****************************
2019-06-04T14:33:56.082709 (delta: 0.115526)         elapsed: 24.133101 ******* 
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl exec -it \"percona-cb697f8b4-vjf2g\" -n \"app-percona-ns\" -- sh -c \"cd /var/lib/mysql && dd if=/dev/urandom of=volume.txt bs=5120k count=1024 >> test.txt && cat test.txt | grep test && rm test.txt\"", "delta": "0:00:01.368477", "end": "2019-06-04 14:33:57.717202", "msg": "non-zero return code", "rc": 1, "start": "2019-06-04 14:33:56.348725", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nerror: unable to upgrade connection: container not found (\"percona\")", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "error: unable to upgrade connection: container not found (\"percona\")"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Check the volume is successfully filled] *********************************
2019-06-04T14:33:57.805772 (delta: 1.722957)         elapsed: 25.856164 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs -f percona-cb697f8b4-vjf2g -n app-percona-ns | grep 'No space left on device'", "delta": "0:00:01.241859", "end": "2019-06-04 14:33:59.357658", "rc": 0, "start": "2019-06-04 14:33:58.115799", "stderr": "", "stderr_lines": [], "stdout": "2019-06-04T14:33:16.112072Z 0 [ERROR] InnoDB: Error number 28 means 'No space left on device'", "stdout_lines": ["2019-06-04T14:33:16.112072Z 0 [ERROR] InnoDB: Error number 28 means 'No space left on device'"]}

TASK [Check the application pod status] ****************************************
2019-06-04T14:33:59.424697 (delta: 1.618834)         elapsed: 27.475089 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o custom-columns=:.status.containerStatuses[].state.waiting.reason --no-headers", "delta": "0:00:01.307727", "end": "2019-06-04 14:34:00.966744", "failed_when_result": false, "rc": 0, "start": "2019-06-04 14:33:59.659017", "stderr": "", "stderr_lines": [], "stdout": "CrashLoopBackOff", "stdout_lines": ["CrashLoopBackOff"]}

TASK [set_fact] ****************************************************************
2019-06-04T14:34:01.040691 (delta: 1.61593)         elapsed: 29.091083 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-04T14:34:01.146221 (delta: 0.10546)         elapsed: 29.196613 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-04T14:34:01.289325 (delta: 0.142997)         elapsed: 29.339717 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:34:01.364755 (delta: 0.075308)         elapsed: 29.415147 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:34:01.447152 (delta: 0.082316)         elapsed: 29.497544 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-04T14:34:01.517538 (delta: 0.070294)         elapsed: 29.56793 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "95f54722d340c7244b12ac74abbfd62375a5da39", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f629117dea075b0847eec54c02b3d050", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1559658841.58-23141955781895/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-04T14:34:04.469243 (delta: 2.951637)         elapsed: 32.519635 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.120793", "end": "2019-06-04 14:34:05.820391", "rc": 0, "start": "2019-06-04 14:34:04.699598", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: volume-capacity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: volume-capacity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-04T14:34:05.878686 (delta: 1.409374)         elapsed: 33.929078 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.603253", "end": "2019-06-04 14:34:07.719735", "failed_when_result": false, "rc": 0, "start": "2019-06-04 14:34:06.116482", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/volume-capacity configured", "stdout_lines": ["litmusresult.litmus.io/volume-capacity configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=20   changed=14   unreachable=0    failed=0   

2019-06-04T14:34:07.768503 (delta: 1.889747)         elapsed: 35.818895 ******* 
=============================================================================== 
```