### PR TITLE
Add litmus for cstor-pool provision using BD(block device)

### DIFF
--- a/providers/cstor/cstor-block-device-pool/block_device_claim.yml
+++ b/providers/cstor/cstor-block-device-pool/block_device_claim.yml
@@ -1,0 +1,12 @@
+apiVersion: openebs.io/v1alpha1
+kind: BlockDeviceClaim
+metadata:
+  name: cstor-claim-device-name
+  namespace: openebs
+spec:
+  driveType: ""
+  blockDeviceName: "device-name"
+  hostName: "host-name"
+  requirements:
+    requests:
+      capacity: device-capacity

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -1,0 +1,39 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-block-device-pool-provision-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cstor-block-device-pool-provision
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide name POOL_NAME for the cstor-pool
+          - name: POOL_NAME
+            value: cstor-block-disk-pool
+
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: DEVICE_CAPACITY
+            value: "20Gi"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test.yml -i /etc/ansible/hosts -v; exit 0"]
+

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -31,6 +31,9 @@ spec:
           - name: OPERATOR_NS
             value: openebs
 
+          - name: NODE_LABEL
+            value: "node-role.kubernetes.io/compute=true"
+
           - name: DEVICE_CAPACITY
             value: "20Gi"
 

--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -9,3 +9,23 @@ spec:
     poolType: striped
   blockDevices:
     blockDeviceList:
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-disk
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: pool-name
+      - name: ReplicaCount
+        value: "3"
+#      - name: VolumeControllerImage
+#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
+#      - name: VolumeTargetImage
+#        value: openebs/cstor-istgt:{{ cstor_image }}
+#      - name: VolumeMonitorImage
+#        value: openebs/m-exporter:{{ cstor_image }}
+provisioner: openebs.io/provisioner-iscsi

--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -1,0 +1,11 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: pool-name
+spec:
+  name: pool-name
+  type: blockdevice
+  poolSpec:
+    poolType: striped
+  blockDevices:
+    blockDeviceList:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -1,0 +1,109 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+      ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Getting the compute node name
+          shell: kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
+          register: nodes
+
+        - name: Getting the Unclaimed block-device from each node
+          shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
+          register: blockDevice
+          with_items: "{{ nodes.stdout_lines }}"
+
+        - set_fact:
+             device_count: "{{ blockDevice|length}}"
+
+        - name: Fetching and Replacing device capacity from ENV
+          replace:
+            path: ./block_device_claim.yml
+            regexp: "device-capacity"
+            replace: "{{ device_capacity }}"
+
+        - name: Creating Block-Device-Claim
+          shell: |
+            cat ./block_device_claim.yml > tmp_block_device_claim.yml
+            sed -i -e 's/device-name/{{item.1.stdout}}/g' -e 's/host-name/{{item.0}}/g' ./tmp_block_device_claim.yml
+            kubectl apply -f tmp_block_device_claim.yml
+            rm ./tmp_block_device_claim.yml
+          with_together: 
+            - "{{ nodes.stdout_lines }}"
+            - "{{ blockDevice.results }}" 
+
+        - name: Adding discovered block device into SPC spec
+          lineinfile:
+            path: "./spc.yml"
+            insertafter: 'blockDeviceList:'
+            line: '    - {{ item.stdout }}'
+          with_items: "{{ blockDevice.results }}"
+
+        - name: Replacing the pool name in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "pool-name"
+            replace: "{{ pool_name }}"
+
+        - name: Create cstor disk pool
+          shell: kubectl apply -f spc.yml
+          args:
+            executable: /bin/bash
+
+        - name: Verify if cStor Disk Pool are Running
+          shell: >
+             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+             --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pool_count
+          until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
+          retries: 30
+          delay: 10
+
+        - name: Get cStor Disk Pool names to verify the container statuses
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+            --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: cstor_pool_pod
+
+        - name: Get the runningStatus of pool pod
+          shell: >
+            kubectl get pod {{ item }} -n {{ operator_ns }}
+            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+            grep -w running | wc -l
+          args:
+            executable: /bin/bash
+          register: runningStatusCount
+          with_items: "{{ cstor_pool_pod.stdout_lines }}"
+          until: "runningStatusCount.stdout == device_count"
+          delay: 30
+          retries: 10
+
+        - set_fact:
+            flag: "Pass"
+    
+      rescue:
+          - set_fact:
+              flag: "Fail"
+  
+      always:
+              ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'  
+        

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -17,7 +17,7 @@
             status: 'SOT'
 
         - name: Getting the compute node name
-          shell: kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
+          shell: kubectl get nodes -l {{ node_label }} -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
           register: nodes
 
         - name: Getting the Unclaimed block-device from each node

--- a/providers/cstor/cstor-block-device-pool/test_vars.yml
+++ b/providers/cstor/cstor-block-device-pool/test_vars.yml
@@ -1,0 +1,7 @@
+# Test-specific parametres
+device_capacity: "{{ lookup('env', 'DEVICE_CAPACITY') }}"
+pool_name: cstor-block-disk
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: cstor-block-device-pool-provision
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+

--- a/providers/cstor/cstor-block-device-pool/test_vars.yml
+++ b/providers/cstor/cstor-block-device-pool/test_vars.yml
@@ -1,7 +1,7 @@
-# Test-specific parametres
+# Test-specific parameters
 device_capacity: "{{ lookup('env', 'DEVICE_CAPACITY') }}"
-pool_name: cstor-block-disk
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 test_name: cstor-block-device-pool-provision
 pool_name: "{{ lookup('env','POOL_NAME') }}"
+node_label: "{{ lookup('env','NODE_LABEL') }}"
 


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

**What this PR does / why we need it**:
- Includes litmusbook `run_litmus_test.yml` which takes *POOL_NAME*(name of pool to be provisioned), *OPERATOR_NS*(namespace in which openebs gets deployed) and *DEVICE_CAPACITY*(storage capacity of disk attached to each node) as env-var.
- This litmusbook filters unclaimed disks present in the cluster and creates corresponding BDC(Block-device claim), then creates the storage pool using the unused(i.e: which have not participated in cstor-pool provision) **block-devices**.

**Special notes for your reviewer**:
- Currently this litmusbook is designed to work for striped pool-type only.

**Following is the log of ansible test container:**
```

PLAY [localhost] ***************************************************************
2019-06-05T00:08:52.230317 (delta: 0.063349)         elapsed: 0.063349 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-05T00:08:52.245294 (delta: 0.014888)         elapsed: 0.078326 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-05T00:09:01.331763 (delta: 9.086442)         elapsed: 9.164795 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-05T00:09:01.412581 (delta: 0.080767)         elapsed: 9.245613 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-05T00:09:01.469701 (delta: 0.057053)         elapsed: 9.302733 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-05T00:09:01.536382 (delta: 0.066616)         elapsed: 9.369414 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-05T00:09:01.641141 (delta: 0.104696)         elapsed: 9.474173 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1559693341.73-213383243638288/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-05T00:09:02.531451 (delta: 0.890242)         elapsed: 10.364483 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.129447", "end": "2019-06-05 00:09:04.058337", "rc": 0, "start": "2019-06-05 00:09:02.928890", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-05T00:09:04.116207 (delta: 1.584688)         elapsed: 11.949239 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.026054", "end": "2019-06-05 00:09:06.378460", "failed_when_result": false, "rc": 0, "start": "2019-06-05 00:09:04.352406", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision unchanged", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-05T00:09:06.494095 (delta: 2.377803)         elapsed: 14.327127 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-05T00:09:06.567973 (delta: 0.073776)         elapsed: 14.401005 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-05T00:09:06.619576 (delta: 0.051534)         elapsed: 14.452608 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-06-05T00:09:06.670108 (delta: 0.050465)         elapsed: 14.50314 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.351931", "end": "2019-06-05 00:09:08.269755", "rc": 0, "start": "2019-06-05 00:09:06.917824", "stderr": "", "stderr_lines": [], "stdout": "node1-1558702621.mayalabs.io\nnode2-1558702621.mayalabs.io\nnode3-1558702621.mayalabs.io", "stdout_lines": ["node1-1558702621.mayalabs.io", "node2-1558702621.mayalabs.io", "node3-1558702621.mayalabs.io"]}

TASK [Getting the Unclaimed block-device from each node] ***********************
2019-06-05T00:09:08.330944 (delta: 1.660765)         elapsed: 16.163976 ******* 
changed: [127.0.0.1] => (item=node1-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.340141", "end": "2019-06-05 00:09:09.915493", "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:08.575352", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "stdout_lines": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}
changed: [127.0.0.1] => (item=node2-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.253817", "end": "2019-06-05 00:09:11.369391", "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:10.115574", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "stdout_lines": ["blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}
changed: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.194713", "end": "2019-06-05 00:09:12.805085", "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:11.610372", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "stdout_lines": ["blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}

TASK [set_fact] ****************************************************************
2019-06-05T00:09:12.903418 (delta: 4.5724)         elapsed: 20.73645 ********** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Fetching and Replacing device capacity from ENV] *************************
2019-06-05T00:09:13.018086 (delta: 0.114543)         elapsed: 20.851118 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating Block-Device-Claim] *********************************************
2019-06-05T00:09:13.572635 (delta: 0.554479)         elapsed: 21.405667 ******* 
changed: [127.0.0.1] => (item=[u'node1-1558702621.mayalabs.io', {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-02e3b9154843d37193dfca5c9b57898b', '_ansible_item_result': True, u'delta': u'0:00:01.340141', 'stdout_lines': [u'blockdevice-02e3b9154843d37193dfca5c9b57898b'], '_ansible_item_label': u'node1-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:09.915493', '_ansible_no_log': False, u'start': u'2019-06-05 00:09:08.575352', 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node1-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}]) => {"changed": true, "cmd": "cat ./block_device_claim.yml > tmp_block_device_claim.yml\n sed -i -e 's/device-name/blockdevice-02e3b9154843d37193dfca5c9b57898b/g' -e 's/host-name/node1-1558702621.mayalabs.io/g' ./tmp_block_device_claim.yml\n kubectl apply -f tmp_block_device_claim.yml\n rm ./tmp_block_device_claim.yml", "delta": "0:00:01.408593", "end": "2019-06-05 00:09:15.196346", "item": ["node1-1558702621.mayalabs.io", {"_ansible_ignore_errors": null, "_ansible_item_label": "node1-1558702621.mayalabs.io", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.340141", "end": "2019-06-05 00:09:09.915493", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:08.575352", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "stdout_lines": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}], "rc": 0, "start": "2019-06-05 00:09:13.787753", "stderr": "", "stderr_lines": [], "stdout": "blockdeviceclaim.openebs.io/cstor-claim-blockdevice-02e3b9154843d37193dfca5c9b57898b created", "stdout_lines": ["blockdeviceclaim.openebs.io/cstor-claim-blockdevice-02e3b9154843d37193dfca5c9b57898b created"]}
changed: [127.0.0.1] => (item=[u'node2-1558702621.mayalabs.io', {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-90f2c077b9a006599c5b0392c29c01f0', '_ansible_item_result': True, u'delta': u'0:00:01.253817', 'stdout_lines': [u'blockdevice-90f2c077b9a006599c5b0392c29c01f0'], '_ansible_item_label': u'node2-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:11.369391', '_ansible_no_log': False, u'start': u'2019-06-05 00:09:10.115574', 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node2-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}]) => {"changed": true, "cmd": "cat ./block_device_claim.yml > tmp_block_device_claim.yml\n sed -i -e 's/device-name/blockdevice-90f2c077b9a006599c5b0392c29c01f0/g' -e 's/host-name/node2-1558702621.mayalabs.io/g' ./tmp_block_device_claim.yml\n kubectl apply -f tmp_block_device_claim.yml\n rm ./tmp_block_device_claim.yml", "delta": "0:00:01.339878", "end": "2019-06-05 00:09:16.738168", "item": ["node2-1558702621.mayalabs.io", {"_ansible_ignore_errors": null, "_ansible_item_label": "node2-1558702621.mayalabs.io", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.253817", "end": "2019-06-05 00:09:11.369391", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:10.115574", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "stdout_lines": ["blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}], "rc": 0, "start": "2019-06-05 00:09:15.398290", "stderr": "", "stderr_lines": [], "stdout": "blockdeviceclaim.openebs.io/cstor-claim-blockdevice-90f2c077b9a006599c5b0392c29c01f0 created", "stdout_lines": ["blockdeviceclaim.openebs.io/cstor-claim-blockdevice-90f2c077b9a006599c5b0392c29c01f0 created"]}
changed: [127.0.0.1] => (item=[u'node3-1558702621.mayalabs.io', {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0', '_ansible_item_result': True, u'delta': u'0:00:01.194713', 'stdout_lines': [u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0'], '_ansible_item_label': u'node3-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:12.805085', '_ansible_no_log': False, u'start': u'2019-06-05 00:09:11.610372', 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node3-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}]) => {"changed": true, "cmd": "cat ./block_device_claim.yml > tmp_block_device_claim.yml\n sed -i -e 's/device-name/blockdevice-bc4fe53d881d0e06c41ba19db67b20d0/g' -e 's/host-name/node3-1558702621.mayalabs.io/g' ./tmp_block_device_claim.yml\n kubectl apply -f tmp_block_device_claim.yml\n rm ./tmp_block_device_claim.yml", "delta": "0:00:01.500269", "end": "2019-06-05 00:09:18.514998", "item": ["node3-1558702621.mayalabs.io", {"_ansible_ignore_errors": null, "_ansible_item_label": "node3-1558702621.mayalabs.io", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.194713", "end": "2019-06-05 00:09:12.805085", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:11.610372", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "stdout_lines": ["blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}], "rc": 0, "start": "2019-06-05 00:09:17.014729", "stderr": "", "stderr_lines": [], "stdout": "blockdeviceclaim.openebs.io/cstor-claim-blockdevice-bc4fe53d881d0e06c41ba19db67b20d0 created", "stdout_lines": ["blockdeviceclaim.openebs.io/cstor-claim-blockdevice-bc4fe53d881d0e06c41ba19db67b20d0 created"]}

TASK [Adding discovered block device into SPC spec] ****************************
2019-06-05T00:09:18.583735 (delta: 5.011021)         elapsed: 26.416767 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-02e3b9154843d37193dfca5c9b57898b', '_ansible_item_result': True, u'delta': u'0:00:01.340141', 'stdout_lines': [u'blockdevice-02e3b9154843d37193dfca5c9b57898b'], '_ansible_item_label': u'node1-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:09.915493', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node1-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-06-05 00:09:08.575352', '_ansible_ignore_errors': None}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.340141", "end": "2019-06-05 00:09:09.915493", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:08.575352", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "stdout_lines": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}, "msg": "line added"}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-90f2c077b9a006599c5b0392c29c01f0', '_ansible_item_result': True, u'delta': u'0:00:01.253817', 'stdout_lines': [u'blockdevice-90f2c077b9a006599c5b0392c29c01f0'], '_ansible_item_label': u'node2-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:11.369391', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node2-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-06-05 00:09:10.115574', '_ansible_ignore_errors': None}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.253817", "end": "2019-06-05 00:09:11.369391", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:10.115574", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "stdout_lines": ["blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}, "msg": "line added"}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0', '_ansible_item_result': True, u'delta': u'0:00:01.194713', 'stdout_lines': [u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0'], '_ansible_item_label': u'node3-1558702621.mayalabs.io', u'end': u'2019-06-05 00:09:12.805085', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node3-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-06-05 00:09:11.610372', '_ansible_ignore_errors': None}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.194713", "end": "2019-06-05 00:09:12.805085", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-06-05 00:09:11.610372", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "stdout_lines": ["blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}, "msg": "line added"}

TASK [Replacing the pool name in SPC spec] *************************************
2019-06-05T00:09:19.613568 (delta: 1.029756)         elapsed: 27.4466 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Create cstor disk pool] **************************************************
2019-06-05T00:09:19.886156 (delta: 0.27249)         elapsed: 27.719188 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.396612", "end": "2019-06-05 00:09:21.504712", "rc": 0, "start": "2019-06-05 00:09:20.108100", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-block-disk-pool created", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-block-disk-pool created"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-06-05T00:09:21.566936 (delta: 1.680679)         elapsed: 29.399968 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.132028", "end": "2019-06-05 00:09:34.420335", "rc": 0, "start": "2019-06-05 00:09:33.288307", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-06-05T00:09:34.503299 (delta: 12.936291)         elapsed: 42.336331 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.154058", "end": "2019-06-05 00:09:35.959620", "rc": 0, "start": "2019-06-05 00:09:34.805562", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-5xud-68bb7db86b-klhwh\ncstor-block-disk-pool-8rbp-6cb7f69b95-dl7sl\ncstor-block-disk-pool-ebo5-d754b59b5-49jz7", "stdout_lines": ["cstor-block-disk-pool-5xud-68bb7db86b-klhwh", "cstor-block-disk-pool-8rbp-6cb7f69b95-dl7sl", "cstor-block-disk-pool-ebo5-d754b59b5-49jz7"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-06-05T00:09:36.020061 (delta: 1.516664)         elapsed: 43.853093 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-5xud-68bb7db86b-klhwh) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-5xud-68bb7db86b-klhwh -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.463372", "end": "2019-06-05 00:09:37.737513", "item": "cstor-block-disk-pool-5xud-68bb7db86b-klhwh", "rc": 0, "start": "2019-06-05 00:09:36.274141", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-8rbp-6cb7f69b95-dl7sl) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-8rbp-6cb7f69b95-dl7sl -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.186806", "end": "2019-06-05 00:09:39.275873", "item": "cstor-block-disk-pool-8rbp-6cb7f69b95-dl7sl", "rc": 0, "start": "2019-06-05 00:09:38.089067", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ebo5-d754b59b5-49jz7) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-ebo5-d754b59b5-49jz7 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.239627", "end": "2019-06-05 00:09:40.758843", "item": "cstor-block-disk-pool-ebo5-d754b59b5-49jz7", "rc": 0, "start": "2019-06-05 00:09:39.519216", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-06-05T00:09:40.863981 (delta: 4.843849)         elapsed: 48.697013 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-05T00:09:40.952911 (delta: 0.088821)         elapsed: 48.785943 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-05T00:09:41.039507 (delta: 0.086525)         elapsed: 48.872539 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-05T00:09:41.095611 (delta: 0.056035)         elapsed: 48.928643 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-05T00:09:41.162927 (delta: 0.067226)         elapsed: 48.995959 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-05T00:09:41.226414 (delta: 0.063407)         elapsed: 49.059446 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1559693381.3-150484856593332/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-05T00:09:44.007487 (delta: 2.780998)         elapsed: 51.840519 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.151361", "end": "2019-06-05 00:09:45.460026", "rc": 0, "start": "2019-06-05 00:09:44.308665", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-05T00:09:45.517787 (delta: 1.510209)         elapsed: 53.350819 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.274849", "end": "2019-06-05 00:09:48.037502", "failed_when_result": false, "rc": 0, "start": "2019-06-05 00:09:45.762653", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=22   changed=16   unreachable=0    failed=0  
```
