### PR TITLE
test(yaml):Implement litmusbook to check pool pod behavior when the node is running out of space

### DIFF
--- a/experiments/chaos/node_storage_fill/busybox_deployment.yml
+++ b/experiments/chaos/node_storage_fill/busybox_deployment.yml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: rogue-busybox
+  labels:
+    app: rogue-busybox 
+    affinity_label: rogue-busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: rogue-busybox
+        affinity_label: rogue-busybox
+    spec:
+      containers:
+      - name: rogue-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: testclaim
+      nodeSelector:
+        kubernetes.io/hostname: k8shostname
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+  labels:
+    affinity_label: rogue-busybox
+spec:
+  storageClassName: k8sstorageclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10G

--- a/experiments/chaos/node_storage_fill/busybox_deployment.yml
+++ b/experiments/chaos/node_storage_fill/busybox_deployment.yml
@@ -4,13 +4,11 @@ metadata:
   name: rogue-busybox
   labels:
     app: rogue-busybox 
-    affinity_label: rogue-busybox
 spec:
   template:
     metadata:
       labels:
         app: rogue-busybox
-        affinity_label: rogue-busybox
     spec:
       containers:
       - name: rogue-busybox
@@ -34,7 +32,7 @@ apiVersion: v1
 metadata:
   name: testclaim
   labels:
-    affinity_label: rogue-busybox
+    app: busybox
 spec:
   storageClassName: k8sstorageclass
   accessModes:

--- a/experiments/chaos/node_storage_fill/run_litmus_test.yml
+++ b/experiments/chaos/node_storage_fill/run_litmus_test.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: node-storage-fill-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: node-storage-fill
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-cstor-sparse
+
+          - name: APP_NAMESPACE
+            value: app-busybox-ns 
+
+          - name: APP_LABEL
+            value: 'app=busybox'
+
+          - name: SPC_NAME
+            value: cstor-sparse-pool
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/node_storage_fill/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/chaos/node_storage_fill/run_litmus_test.yml
+++ b/experiments/chaos/node_storage_fill/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
@@ -26,9 +26,6 @@ spec:
 
           - name: APP_NAMESPACE
             value: app-busybox-ns 
-
-          - name: APP_LABEL
-            value: 'app=busybox'
 
           - name: SPC_NAME
             value: cstor-sparse-pool

--- a/experiments/chaos/node_storage_fill/test.yml
+++ b/experiments/chaos/node_storage_fill/test.yml
@@ -1,0 +1,130 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ test_name }}"
+
+        ## DISPLAY APP INFORMATION 
+ 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ app_ns }}"
+              - "Label        : {{ app_label }}"
+              - "Storage pool claim : {{ spc }}"  
+  
+        - name: Obtaining the CSP name using SPC label and randomly picking one
+          shell: >
+            kubectl get csp --no-headers -l openebs.io/storage-pool-claim={{ spc }} 
+            -o custom-columns=:.metadata.name | shuf -n 1
+          args:
+            executable: /bin/bash
+          register: csp_name
+
+        - name: Obtaining pool pod corresponding to the above csp
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool={{ csp_name.stdout }} 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: pool_pod
+
+        - name: Obtaining node name where the above pool pod is scheduled
+          shell: >
+            kubectl get pods {{ pool_pod.stdout }} -n {{ operator_ns }} --no-headers 
+            -o wide -o custom-columns=:.spec.nodeName
+          args:
+            executable: /bin/bash
+          register: node_name
+
+        - name: Replace the node name placeholder in rogue pod spec
+          replace:
+            path: busybox_deployment.yml
+            regexp: "k8shostname"
+            replace: "{{ node_name.stdout }}"
+
+        - name: Replace the storage class placeholder in rogue pod spec
+          replace:
+            path: busybox_deployment.yml
+            regexp: "k8sstorageclass"
+            replace: "{{ storage_class }}"
+
+        - name: Deploy rogue busybox application
+          shell: >
+            kubectl apply -f busybox_deployment.yml -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+
+        - name: Ensure that the rogue pod is running
+          shell: >
+            kubectl get pods -n {{ app_ns }} --no-headers -l app=rogue-busybox 
+            -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: pod_status
+          until: "'Running' in pod_status.stdout"
+          delay: 10
+          retries: 30
+
+        - name: Obtain the rogue application name
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l app=rogue-busybox --no-headers 
+            -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: rogue_pod
+
+        - name: Fill the root directory of rogue pod using fallocate.
+          shell: > 
+            kubectl exec -ti {{ rogue_pod.stdout }} -n {{ app_ns }} -- fallocate 
+            -l 500G /test.img
+          args:
+            executable: /bin/bash
+          ignore_errors: yes
+
+        - name: Ensure that the application pod is evicted
+          shell: > 
+            kubectl get pods {{ rogue_pod.stdout }} -n {{ app_ns }} 
+            --no-headers -o custom-columns=:.status.reason
+          args:
+            executable: /bin/bash
+          register: status
+          until: "'Evicted' in status.stdout"
+          delay: 10
+          retries: 30
+
+        - name: Check if the pool pod is running.
+          shell: >
+            kubectl get pods {{ pool_pod.stdout }} -n {{ operator_ns }} --no-headers 
+            -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: pool_status
+          failed_when: "'Running' not in pool_status.stdout"
+        
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+         ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/chaos/node_storage_fill/test.yml
+++ b/experiments/chaos/node_storage_fill/test.yml
@@ -24,7 +24,6 @@
             msg: 
               - "The application info is as follows:"
               - "Namespace    : {{ app_ns }}"
-              - "Label        : {{ app_label }}"
               - "Storage pool claim : {{ spc }}"  
   
         - name: Obtaining the CSP name using SPC label and randomly picking one

--- a/experiments/chaos/node_storage_fill/test_vars.yml
+++ b/experiments/chaos/node_storage_fill/test_vars.yml
@@ -1,0 +1,15 @@
+---
+#Test-specific parameters
+
+test_name: node-storage-filler
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+spc: "{{ lookup('env','SPC_NAME') }}"
+
+operator_ns: openebs
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+

--- a/experiments/chaos/node_storage_fill/test_vars.yml
+++ b/experiments/chaos/node_storage_fill/test_vars.yml
@@ -5,8 +5,6 @@ test_name: node-storage-filler
 
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 
-app_label: "{{ lookup('env','APP_LABEL') }}"
-
 spc: "{{ lookup('env','SPC_NAME') }}"
 
 operator_ns: openebs


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:

- Deploying an application which consumes the node space completely.
- Obtaining SPC as env. Through SPC label, finding out a csp. Based on csp label, getting the corresponding pool pod. Scheduled the above application on the node where pool pod is running.
- Filling the node space using fallocate.
- Once the application pod is evicted, checking the corresponding pool pod's status. If it is unknown/evicted , failing the test.

```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/node_storage_fill/test.yml

PLAY [localhost] ***************************************************************
2019-06-06T04:36:25.019689 (delta: 0.040919)         elapsed: 0.040919 ********
===============================================================================

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/node_storage_fill/test.yml:2
2019-06-06T04:36:25.030446 (delta: 0.010722)         elapsed: 0.051676 ********
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_storage_fill/test.yml:13
2019-06-06T04:36:28.610281 (delta: 3.579805)         elapsed: 3.631511 ********
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-06-06T04:36:28.669591 (delta: 0.059271)         elapsed: 3.690821 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-06-06T04:36:28.730337 (delta: 0.060695)         elapsed: 3.751567 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_storage_fill/test.yml:15
2019-06-06T04:36:28.779110 (delta: 0.04869)         elapsed: 3.80034 **********
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-06-06T04:36:28.840499 (delta: 0.061341)         elapsed: 3.861729 ********
changed: [127.0.0.1] => {"changed": true, "checksum": "a5ea4edc1d22d8bdeed1a1d4afcae1ab7322e3a9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f1c50810dcffca9688498e0cbb3503ef", "mode": "0644", "owner": "root", "size": 439, "src": "/root/.ansible/tmp/ansible-tmp-1559795788.89-38608412934681/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-06-06T04:36:29.328837 (delta: 0.48829)         elapsed: 4.350067 *********
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.376511", "end": "2019-06-06 04:36:29.964256", "rc": 0, "start": "2019-06-06 04:36:29.587745", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-storage-filler \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-storage-filler \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-storage-filler ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-storage-filler ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-06-06T04:36:30.001412 (delta: 0.672485)         elapsed: 5.022642 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.975247", "end": "2019-06-06 04:36:31.119275", "failed_when_result": false, "rc": 0, "start": "2019-06-06 04:36:30.144028", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-storage-filler unchanged", "stdout_lines": ["litmusresult.litmus.io/node-storage-filler unchanged"]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-06-06T04:36:31.237487 (delta: 0.036678)         elapsed: 6.258717 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/node_storage_fill/test.yml:22
2019-06-06T04:36:31.274652 (delta: 0.037109)         elapsed: 6.295882 ********
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:",
        "Namespace    : app-busybox-ns",
        "Label        : app=busybox",
        "Storage pool claim : cstor-sparse-pool"
    ]
}

TASK [Obtaining the CSP name using SPC label and randomly picking one] *********
task path: /experiments/chaos/node_storage_fill/test.yml:30
2019-06-06T04:36:31.339781 (delta: 0.065074)         elapsed: 6.361011 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp --no-headers -l openebs.io/storage-pool-claim=cstor-sparse-pool -o custom-columns=:.metadata.name | shuf -n 1", "delta": "0:00:00.475125", "end": "2019-06-06 04:36:31.968857", "rc": 0, "start": "2019-06-06 04:36:31.493732", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-0a0m", "stdout_lines": ["cstor-sparse-pool-0a0m"]}

TASK [Obtaining pool pod corresponding to the above csp] ***********************
task path: /experiments/chaos/node_storage_fill/test.yml:38
2019-06-06T04:36:32.006551 (delta: 0.666557)         elapsed: 7.027781 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool=cstor-sparse-pool-0a0m --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.501186", "end": "2019-06-06 04:36:32.651893", "rc": 0, "start": "2019-06-06 04:36:32.150707", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-0a0m-74f75bdbb9-swwhm", "stdout_lines": ["cstor-sparse-pool-0a0m-74f75bdbb9-swwhm"]}

TASK [Obtaining node name where the above pool pod is scheduled] ***************
task path: /experiments/chaos/node_storage_fill/test.yml:46
2019-06-06T04:36:32.689677 (delta: 0.683075)         elapsed: 7.710907 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-sparse-pool-0a0m-74f75bdbb9-swwhm -n openebs --no-headers -o wide -o custom-columns=:.spec.nodeName", "delta": "0:00:00.467020", "end": "2019-06-06 04:36:33.301893", "rc": 0, "start": "2019-06-06 04:36:32.834873", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-2-default-pool-4ba8b47d-cp0g", "stdout_lines": ["gke-e2e-cluster-2-default-pool-4ba8b47d-cp0g"]}

TASK [Replace the node name placeholder in rogue pod spec] *********************
task path: /experiments/chaos/node_storage_fill/test.yml:54
2019-06-06T04:36:33.340571 (delta: 0.650817)         elapsed: 8.361801 ********
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storage class placeholder in rogue pod spec] *****************
task path: /experiments/chaos/node_storage_fill/test.yml:60
2019-06-06T04:36:33.630453 (delta: 0.289827)         elapsed: 8.651683 ********
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy rogue busybox application] ****************************************
task path: /experiments/chaos/node_storage_fill/test.yml:66
2019-06-06T04:36:33.814915 (delta: 0.18438)         elapsed: 8.836145 *********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox_deployment.yml -n app-busybox-ns", "delta": "0:00:00.658563", "end": "2019-06-06 04:36:34.623194", "rc": 0, "start": "2019-06-06 04:36:33.964631", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/rogue-busybox created\npersistentvolumeclaim/testclaim created", "stdout_lines": ["deployment.apps/rogue-busybox created", "persistentvolumeclaim/testclaim created"]}
TASK [Ensure that the rogue pod is running] ************************************
task path: /experiments/chaos/node_storage_fill/test.yml:72
2019-06-06T04:36:34.660631 (delta: 0.845631)         elapsed: 9.681861 ********
FAILED - RETRYING: Ensure that the rogue pod is running (30 retries left).
FAILED - RETRYING: Ensure that the rogue pod is running (29 retries left).
FAILED - RETRYING: Ensure that the rogue pod is running (28 retries left).
FAILED - RETRYING: Ensure that the rogue pod is running (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns --no-headers -l app=rogue-busybox -o custom-columns=:.status.phase", "delta": "0:00:00.479427", "end": "2019-06-06 04:37:17.998956", "rc": 0, "start": "2019-06-06 04:37:17.519529", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the rogue application name] ***************************************
task path: /experiments/chaos/node_storage_fill/test.yml:83
2019-06-06T04:37:18.043927 (delta: 43.383247)         elapsed: 53.065157 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=rogue-busybox --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.473078", "end": "2019-06-06 04:37:18.673586", "rc": 0, "start": "2019-06-06 04:37:18.200508", "stderr": "", "stderr_lines": [], "stdout": "rogue-busybox-6df6dc6bdd-rbdm2", "stdout_lines": ["rogue-busybox-6df6dc6bdd-rbdm2"]}

TASK [Fill the root directory of rogue pod using fallocate.] *******************
task path: /experiments/chaos/node_storage_fill/test.yml:91
2019-06-06T04:37:18.717857 (delta: 0.673311)         elapsed: 53.739087 *******
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl exec -ti rogue-busybox-6df6dc6bdd-rbdm2 -n app-busybox-ns -- fallocate -l 500G /test.img", "delta": "0:00:00.710887", "end": "2019-06-06 04:37:19.602451", "msg": "non-zero return code", "rc": 1, "start": "2019-06-06 04:37:18.891564", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nfallocate: fallocate '/test.img': No space left on device\ncommand terminated with exit code 1", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "fallocate: fallocate '/test.img': No space left on device", "command terminated with exit code 1"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Ensure that the application pod is evicted] ******************************
task path: /experiments/chaos/node_storage_fill/test.yml:99
2019-06-06T04:37:19.640712 (delta: 0.922725)         elapsed: 54.661942 *******
FAILED - RETRYING: Ensure that the application pod is evicted (30 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (29 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (28 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (27 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (26 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (25 retries left).
FAILED - RETRYING: Ensure that the application pod is evicted (24 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl get pods rogue-busybox-6df6dc6bdd-rbdm2 -n app-busybox-ns --no-headers -o custom-columns=:.status.reason", "delta": "0:00:00.541297", "end": "2019-06-06 04:38:36.392557", "rc": 0, "start": "2019-06-06 04:38:35.851260", "stderr": "", "stderr_lines": [], "stdout": "Evicted", "stdout_lines": ["Evicted"]}

TASK [Check if the pool pod is running.] ***************************************
task path: /experiments/chaos/node_storage_fill/test.yml:110
2019-06-06T04:38:36.442257 (delta: 76.801497)         elapsed: 131.463487 *****
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl get pods cstor-sparse-pool-0a0m-74f75bdbb9-swwhm -n openebs --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.472835", "end": "2019-06-06 04:38:37.075396", "failed_when_result": true, "rc": 0, "start": "2019-06-06 04:38:36.602561", "stderr": "", "stderr_lines": [], "stdout": "Failed", "stdout_lines": ["Failed"]}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/node_storage_fill/test.yml:123
2019-06-06T04:38:37.126661 (delta: 0.684362)         elapsed: 132.147891 ******
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}
TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_storage_fill/test.yml:128
2019-06-06T04:38:37.187254 (delta: 0.06055)         elapsed: 132.208484 *******
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-06-06T04:38:37.244866 (delta: 0.057555)         elapsed: 132.266096 ******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-06-06T04:38:37.290520 (delta: 0.045613)         elapsed: 132.31175 *******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-06-06T04:38:37.338931 (delta: 0.048025)         elapsed: 132.360161 ******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-06-06T04:38:37.391060 (delta: 0.052081)         elapsed: 132.41229 *******
changed: [127.0.0.1] => {"changed": true, "checksum": "5edb21aee29b5b4673916924789d80ee792b89eb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "21ec1cbdf18ef9023fbc4593da274c20", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1559795917.44-126329136047614/source", "state": "file", "uid": 0}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-06-06T04:38:37.391060 (delta: 0.052081)         elapsed: 132.41229 *******
changed: [127.0.0.1] => {"changed": true, "checksum": "5edb21aee29b5b4673916924789d80ee792b89eb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "21ec1cbdf18ef9023fbc4593da274c20", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1559795917.44-126329136047614/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-06-06T04:38:38.437322 (delta: 1.046219)         elapsed: 133.458552 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.393382", "end": "2019-06-06 04:38:38.977800", "rc": 0, "start": "2019-06-06 04:38:38.584418", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-storage-filler \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-storage-filler ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-06-06T04:38:39.022133 (delta: 0.584733)         elapsed: 134.043363 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.606278", "end": "2019-06-06 04:38:39.780510", "failed_when_result": false, "rc": 0, "start": "2019-06-06 04:38:39.174232", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-storage-filler configured", "stdout_lines": ["litmusresult.litmus.io/node-storage-filler configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=22   changed=16   unreachable=0    failed=1

2019-06-06T04:38:39.815215 (delta: 0.793022)         elapsed: 134.836445 ******
```
