### PR TITLE
Include disk format and mount task in packet cluster setup script

### DIFF
--- a/k8s/packet/packet-storage/README.md
+++ b/k8s/packet/packet-storage/README.md
@@ -30,6 +30,11 @@ c5bb635c-2fd8-4394-bbd3-10ceb81c0876
 ansible-playbook create-volume.yml -vv --extra-vars "packet_api=<packet-api-token>"
 ```
 
+--extra-vars
+```bash
+ansible-playbook create-volume.yml -vv --extra-vars "packet_api=<packet-api-token> disk_action=format
+```
+
 ### Detach and delete packet Volume
 
 - `delete-volume`, will detach and delete `Datera` volume using the volume id present in (/tmp/packet/volume_id).

--- a/k8s/packet/packet-storage/create-volume.yml
+++ b/k8s/packet/packet-storage/create-volume.yml
@@ -80,9 +80,45 @@
         - name: Executing volume attach command in nodes
           args:
             executable: /bin/bash
-          shell: packet-block-storage-attach
+          shell: sleep 60 && packet-block-storage-attach
           delegate_to: "root@{{ item.json.ip_addresses[0].address }}"
           with_items: "{{ device_ip.results }}"
+          register: result
+          retries: 3
+          delay: 10
+          until: result is not failed
+
+        - block:
+            - name: Creating mount directory
+              file:
+                path: "{{ mount_path }}"
+                state: directory
+              delegate_to: "root@{{ item.json.ip_addresses[0].address }}"
+              with_items: "{{ device_ip.results }}"
+
+            - name: Create ext4 filesystem
+              filesystem:
+                fstype: ext4
+                dev: "/dev/mapper/{{ item.1.json.name }}"
+              become: true
+              delegate_to: "root@{{ item.0.json.ip_addresses[0].address }}"
+              with_together: 
+                 - "{{ device_ip.results }}"
+                 - "{{ volume_id.results }}"
+
+            - name: mounting disk to Nodes
+              mount:
+                path: "{{ mount_path }}"
+                src: "/dev/mapper/{{ item.1.json.name }}"
+                fstype: ext4
+                state: mounted
+              become: true
+              delegate_to: "root@{{ item.0.json.ip_addresses[0].address }}"
+              with_together: 
+                 - "{{ device_ip.results }}"
+                 - "{{ volume_id.results }}"
+
+          when: disk_action == 'format'
 
         - name: Set Test Status
           set_fact:
@@ -92,4 +128,3 @@
         - name: Set Test Status
           set_fact:
             flag: "Test Failed"
-

--- a/k8s/packet/packet-storage/vars.yml
+++ b/k8s/packet/packet-storage/vars.yml
@@ -2,7 +2,7 @@ base_url: https://api.packet.net # base url for access packet api
 performance_tier: storage_1 # storage_1=Performance tier: Standard & storage_2 = Performance tier: Performance
 location: ams1 # location available: ams1, ewr1, nrt1 & sjc1
 billing_cycle: hourly
-size: 10 # size in GB
+size: 50 # size in GB
 device_id_location: /tmp/packet/device_id # file location where cluster device id stored
 project_id: bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2 # project id of packet cloud
 mount_path: /var/openebs

--- a/k8s/packet/packet-storage/vars.yml
+++ b/k8s/packet/packet-storage/vars.yml
@@ -2,6 +2,7 @@ base_url: https://api.packet.net # base url for access packet api
 performance_tier: storage_1 # storage_1=Performance tier: Standard & storage_2 = Performance tier: Performance
 location: ams1 # location available: ams1, ewr1, nrt1 & sjc1
 billing_cycle: hourly
-size: 50 # size in GB
+size: 10 # size in GB
 device_id_location: /tmp/packet/device_id # file location where cluster device id stored
 project_id: bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2 # project id of packet cloud
+mount_path: /var/openebs


### PR DESCRIPTION
- Include disk format and mount task in packet cluster setup script.
- Define a variable called `mount_path`(the path where disk will be mounted) in vars.yml, by default it is `/var/openebs`.
- Include a task in `create-volume.yml` to format the disk in **ext4**.
**Following is the log:**
```
PLAY [localhost] **************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************
ok: [localhost]

TASK [Create a volume in packet cloud] ****************************************************************************************************************************
ok: [localhost] => (item=afc936b1-f272-4d6b-aadc-253986aaddb4)
ok: [localhost] => (item=f558a96f-17bf-42a4-9600-9d60f75ccab4)

TASK [Create a file for store volume Ids] *************************************************************************************************************************
changed: [localhost] => (item={u'content_length': u'745', u'status': 201, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932287.907999,VS0,VE1357', u'x_cache': u'MISS', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'x_request_id': u'59040d29-daf7-4891-81e9-474fb283e447', 'failed': False, u'json': {u'access': {}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'created_at': u'2019-06-07T18:31:27Z', u'customdata': {}, u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:27Z', u'snapshots': [], u'name': u'volume-2dc746eb', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'state': u'queued', u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'plan': {u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'slug': u'storage_1', u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'line': u'storage', u'specs': {}, u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'2dc746eb-6f00-45ee-9e3b-f440b9456434', u'attachments': []}, u'etag': u'W/"47cfd30b580911e2ffe5433a35d14a76"', u'location': u'https://api.packet.net/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'size': u'50', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'facility': u'ams1'}, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20741-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:28 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'changed': False, u'x_cache_hits': u'0', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'connection': u'close', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None})
changed: [localhost] => (item={u'content_length': u'745', u'status': 201, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932290.360129,VS0,VE2111', u'x_cache': u'MISS', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'x_request_id': u'a2e3b9b8-6b96-4852-b0c8-38fbd3a11305', 'failed': False, u'json': {u'access': {}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'created_at': u'2019-06-07T18:31:30Z', u'customdata': {}, u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:30Z', u'snapshots': [], u'name': u'volume-fd0bb8fc', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'state': u'queued', u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'plan': {u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'slug': u'storage_1', u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'line': u'storage', u'specs': {}, u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'attachments': []}, u'etag': u'W/"a7139a46256982c4314fd3d3cedbcbbe"', u'location': u'https://api.packet.net/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'size': u'50', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'facility': u'ams1'}, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20742-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:32 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'x_instana_s': u'b82340971af33a80', u'changed': False, u'x_instana_t': u'b82340971af33a80', u'x_cache_hits': u'0', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'connection': u'close', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None})

TASK [get the Device ID from file] ********************************************************************************************************************************
changed: [localhost]

TASK [Attach volume to device] ************************************************************************************************************************************
ok: [localhost] => (item=[{u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932287.907999,VS0,VE1357', u'x_cache_hits': u'0', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'created_at': u'2019-06-07T18:31:27Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:27Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'2dc746eb-6f00-45ee-9e3b-f440b9456434', u'name': u'volume-2dc746eb'}, u'etag': u'W/"47cfd30b580911e2ffe5433a35d14a76"', u'location': u'https://api.packet.net/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20741-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:28 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'changed': False, u'x_cache': u'MISS', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_request_id': u'59040d29-daf7-4891-81e9-474fb283e447', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}, u'afc936b1-f272-4d6b-aadc-253986aaddb4'])
ok: [localhost] => (item=[{u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932290.360129,VS0,VE2111', u'x_cache_hits': u'0', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'created_at': u'2019-06-07T18:31:30Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:30Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'name': u'volume-fd0bb8fc'}, u'etag': u'W/"a7139a46256982c4314fd3d3cedbcbbe"', u'location': u'https://api.packet.net/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20742-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:32 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'x_instana_s': u'b82340971af33a80', u'changed': False, u'x_instana_t': u'b82340971af33a80', u'x_cache': u'MISS', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_request_id': u'a2e3b9b8-6b96-4852-b0c8-38fbd3a11305', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}, u'f558a96f-17bf-42a4-9600-9d60f75ccab4'])

TASK [Fetch device detail using device id] ************************************************************************************************************************
ok: [localhost] => (item=afc936b1-f272-4d6b-aadc-253986aaddb4)
ok: [localhost] => (item=f558a96f-17bf-42a4-9600-9d60f75ccab4)

TASK [Executing volume attach command in nodes] *******************************************************************************************************************
FAILED - RETRYING: Executing volume attach command in nodes (3 retries left).
changed: [localhost -> root@147.75.84.93] => (item={u'status': 200, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932304.671737,VS0,VE585', u'x_cache_hits': u'0', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'x_request_id': u'd914444a-6694-42b8-bf3e-cb2444270380', 'failed': False, u'json': {u'hostname': u'master-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'53a6065b-9db7-440c-ab27-b096146a64c2', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/53a6065b-9db7-440c-ab27-b096146a64c2', u'gateway': u'147.75.84.92', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'147.75.84.93', u'network': u'147.75.84.92'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'a91c4956-3411-429b-aabc-87be8e3e064e', u'project': {}, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/a91c4956-3411-429b-aabc-87be8e3e064e', u'gateway': u'2604:1380:2001:2900::4e', u'details': None, u'cidr': 127, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'2604:1380:2001:2900::4f', u'network': u'2604:1380:2001:2900::4e'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'5d9ef644-3b94-4474-b870-dbc86ed77064', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/5d9ef644-3b94-4474-b870-dbc86ed77064', u'gateway': u'10.80.77.190', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': False, u'address': u'10.80.77.191', u'network': u'10.80.77.190'}], u'updated_at': u'2019-06-07T18:31:37Z', u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'id': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'root_password': u'A87lL4P%bg', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'afc936b1', u'customdata': {}, u'storage': None, u'state': u'active', u'iqn': u'iqn.2019-06.net.packet:device.afc936b1', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'data': {u'bonded': True}, u'network_type': u'layer3', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9', u'native_virtual_network': None, u'type': u'NetworkBondPort', u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'data': {u'mac': u'0c:c4:7a:20:5a:20', u'bonded': True}, u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'native_virtual_network': None, u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'connected_port': {u'href': u'/ports/a085619b-d3ac-48f8-8993-0bd83503d746'}}, {u'virtual_networks': [], u'name': u'eth1', u'data': {u'mac': u'0c:c4:7a:20:5a:21', u'bonded': True}, u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'native_virtual_network': None, u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'connected_port': {u'href': u'/ports/faf9c0c6-73c9-4811-9ae9-d976f85d755f'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'slug': u't1.small.x86', u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'line': u'baremetal', u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'memory': {u'total': u'8GB'}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}}, u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'slug': u'ubuntu_16_04', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'6e7bdb0e', u'created_at': u'2019-06-07T17:39:22Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'billing_cycle': u'hourly', u'image_url': None, u'volumes': [{u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434'}, {u'href': u'/storage/7e290a7d-338b-46a8-99c3-58bed0e80bcb'}, {u'href': u'/storage/a6f8f1ee-12d0-4069-b749-2d19b7651985'}, {u'href': u'/storage/440eca67-3604-4697-b357-eed59a631fc0'}, {u'href': u'/storage/65034777-8f8c-4549-b533-aeb86d924ce7'}, {u'href': u'/storage/3ebf113b-2e97-4fb6-8108-7a1186a1aabd'}], u'user': u'root'}, u'etag': u'"3a39f44a61ed4766cf1d8969d9352ce4"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:37 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:44 GMT', u'x_frame_options': u'SAMEORIGIN', u'age': u'0, 0', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'transfer_encoding': u'chunked', u'changed': False, u'x_instana_t': u'72321758657fc156', u'cookies_string': u'', u'x_cache': u'MISS', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'connection': u'close', u'redirected': False, u'x_instana_s': u'72321758657fc156', '_ansible_ignore_errors': None})


FAILED - RETRYING: Executing volume attach command in nodes (3 retries left).
changed: [localhost -> root@147.75.81.119] => (item={u'status': 200, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932307.539260,VS0,VE583', u'x_cache_hits': u'0', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'x_request_id': u'504209f8-acfa-4f71-ac45-caa15cbbae4c', 'failed': False, u'json': {u'hostname': u'node-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:47Z', u'customdata': {}, u'enabled': True, u'id': u'48a67332-5b3e-4ea5-be37-f103d854b232', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/48a67332-5b3e-4ea5-be37-f103d854b232', u'gateway': u'147.75.81.118', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'147.75.81.119', u'network': u'147.75.81.118'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'id': u'8e46a36b-788e-49fe-913d-bc0e563dfadf', u'project': {}, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/8e46a36b-788e-49fe-913d-bc0e563dfadf', u'gateway': u'2604:1380:2001:2900::44', u'details': None, u'cidr': 127, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'2604:1380:2001:2900::45', u'network': u'2604:1380:2001:2900::44'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'id': u'1ff454ad-a708-421f-8846-4f8a851707eb', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/1ff454ad-a708-421f-8846-4f8a851707eb', u'gateway': u'10.80.77.180', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': False, u'address': u'10.80.77.181', u'network': u'10.80.77.180'}], u'updated_at': u'2019-06-07T18:31:41Z', u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'id': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'root_password': u'{926,ukIVa', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'f558a96f', u'customdata': {}, u'storage': None, u'state': u'active', u'iqn': u'iqn.2019-06.net.packet:device.f558a96f', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'data': {u'bonded': True}, u'network_type': u'layer3', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'native_virtual_network': None, u'type': u'NetworkBondPort', u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'data': {u'mac': u'0c:c4:7a:54:0e:a0', u'bonded': True}, u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'native_virtual_network': None, u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'connected_port': {u'href': u'/ports/03ab3332-e217-41c5-830d-b7080c8cd052'}}, {u'virtual_networks': [], u'name': u'eth1', u'data': {u'mac': u'0c:c4:7a:54:0e:a1', u'bonded': True}, u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'native_virtual_network': None, u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'connected_port': {u'href': u'/ports/cbf9936c-b1b6-4e89-90ed-91ac52c01259'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'slug': u't1.small.x86', u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'line': u'baremetal', u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'memory': {u'total': u'8GB'}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}}, u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'slug': u'ubuntu_16_04', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'5834e961', u'created_at': u'2019-06-07T17:39:42Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'billing_cycle': u'hourly', u'image_url': None, u'volumes': [{u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86'}, {u'href': u'/storage/9437ec17-1666-440e-bf97-18af637d5245'}, {u'href': u'/storage/221fadf5-af27-404f-bcb4-4f3d7c711869'}, {u'href': u'/storage/d043d206-5774-4af3-8c98-ab321c1dc0a7'}, {u'href': u'/storage/3b3dae4e-4e4e-43a2-ad30-a18eb35197b8'}, {u'href': u'/storage/63590eba-7ce0-41b6-81d3-e1eef8d61ed9'}], u'user': u'root'}, u'etag': u'"4ba991c9c01bce8bf419046a387c43d6"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:41 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:47 GMT', u'x_frame_options': u'SAMEORIGIN', u'age': u'0, 0', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'transfer_encoding': u'chunked', u'changed': False, u'x_instana_t': u'61912cff5072e9cd', u'cookies_string': u'', u'x_cache': u'MISS', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'connection': u'close', u'redirected': False, u'x_instana_s': u'61912cff5072e9cd', '_ansible_ignore_errors': None})

TASK [Creating mount directory] ***********************************************************************************************************************************
changed: [localhost -> root@147.75.84.93] => (item={u'status': 200, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932304.671737,VS0,VE585', u'x_cache_hits': u'0', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'x_request_id': u'd914444a-6694-42b8-bf3e-cb2444270380', 'failed': False, u'json': {u'hostname': u'master-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'53a6065b-9db7-440c-ab27-b096146a64c2', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/53a6065b-9db7-440c-ab27-b096146a64c2', u'gateway': u'147.75.84.92', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'147.75.84.93', u'network': u'147.75.84.92'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'a91c4956-3411-429b-aabc-87be8e3e064e', u'project': {}, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/a91c4956-3411-429b-aabc-87be8e3e064e', u'gateway': u'2604:1380:2001:2900::4e', u'details': None, u'cidr': 127, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'2604:1380:2001:2900::4f', u'network': u'2604:1380:2001:2900::4e'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'id': u'5d9ef644-3b94-4474-b870-dbc86ed77064', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/5d9ef644-3b94-4474-b870-dbc86ed77064', u'gateway': u'10.80.77.190', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'global_ip': None, u'manageable': True, u'public': False, u'address': u'10.80.77.191', u'network': u'10.80.77.190'}], u'updated_at': u'2019-06-07T18:31:37Z', u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'id': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'root_password': u'A87lL4P%bg', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'afc936b1', u'customdata': {}, u'storage': None, u'state': u'active', u'iqn': u'iqn.2019-06.net.packet:device.afc936b1', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'data': {u'bonded': True}, u'network_type': u'layer3', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9', u'native_virtual_network': None, u'type': u'NetworkBondPort', u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'data': {u'mac': u'0c:c4:7a:20:5a:20', u'bonded': True}, u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'native_virtual_network': None, u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'connected_port': {u'href': u'/ports/a085619b-d3ac-48f8-8993-0bd83503d746'}}, {u'virtual_networks': [], u'name': u'eth1', u'data': {u'mac': u'0c:c4:7a:20:5a:21', u'bonded': True}, u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'native_virtual_network': None, u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'connected_port': {u'href': u'/ports/faf9c0c6-73c9-4811-9ae9-d976f85d755f'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'slug': u't1.small.x86', u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'line': u'baremetal', u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'memory': {u'total': u'8GB'}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}}, u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'slug': u'ubuntu_16_04', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'6e7bdb0e', u'created_at': u'2019-06-07T17:39:22Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'billing_cycle': u'hourly', u'image_url': None, u'volumes': [{u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434'}, {u'href': u'/storage/7e290a7d-338b-46a8-99c3-58bed0e80bcb'}, {u'href': u'/storage/a6f8f1ee-12d0-4069-b749-2d19b7651985'}, {u'href': u'/storage/440eca67-3604-4697-b357-eed59a631fc0'}, {u'href': u'/storage/65034777-8f8c-4549-b533-aeb86d924ce7'}, {u'href': u'/storage/3ebf113b-2e97-4fb6-8108-7a1186a1aabd'}], u'user': u'root'}, u'etag': u'"3a39f44a61ed4766cf1d8969d9352ce4"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:37 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:44 GMT', u'x_frame_options': u'SAMEORIGIN', u'age': u'0, 0', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'transfer_encoding': u'chunked', u'changed': False, u'x_instana_t': u'72321758657fc156', u'cookies_string': u'', u'x_cache': u'MISS', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'connection': u'close', u'redirected': False, u'x_instana_s': u'72321758657fc156', '_ansible_ignore_errors': None})
changed: [localhost -> root@147.75.81.119] => (item={u'status': 200, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932307.539260,VS0,VE583', u'x_cache_hits': u'0', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'x_request_id': u'504209f8-acfa-4f71-ac45-caa15cbbae4c', 'failed': False, u'json': {u'hostname': u'node-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:47Z', u'customdata': {}, u'enabled': True, u'id': u'48a67332-5b3e-4ea5-be37-f103d854b232', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/48a67332-5b3e-4ea5-be37-f103d854b232', u'gateway': u'147.75.81.118', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'147.75.81.119', u'network': u'147.75.81.118'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'id': u'8e46a36b-788e-49fe-913d-bc0e563dfadf', u'project': {}, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/8e46a36b-788e-49fe-913d-bc0e563dfadf', u'gateway': u'2604:1380:2001:2900::44', u'details': None, u'cidr': 127, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': True, u'address': u'2604:1380:2001:2900::45', u'network': u'2604:1380:2001:2900::44'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'name': u'Amsterdam, NL', u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2']}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'id': u'1ff454ad-a708-421f-8846-4f8a851707eb', u'project': {}, u'netmask': u'255.255.255.254', u'href': u'/ips/1ff454ad-a708-421f-8846-4f8a851707eb', u'gateway': u'10.80.77.180', u'details': None, u'cidr': 31, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'global_ip': None, u'manageable': True, u'public': False, u'address': u'10.80.77.181', u'network': u'10.80.77.180'}], u'updated_at': u'2019-06-07T18:31:41Z', u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'id': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'root_password': u'{926,ukIVa', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'f558a96f', u'customdata': {}, u'storage': None, u'state': u'active', u'iqn': u'iqn.2019-06.net.packet:device.f558a96f', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'data': {u'bonded': True}, u'network_type': u'layer3', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'native_virtual_network': None, u'type': u'NetworkBondPort', u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'data': {u'mac': u'0c:c4:7a:54:0e:a0', u'bonded': True}, u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'native_virtual_network': None, u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'connected_port': {u'href': u'/ports/03ab3332-e217-41c5-830d-b7080c8cd052'}}, {u'virtual_networks': [], u'name': u'eth1', u'data': {u'mac': u'0c:c4:7a:54:0e:a1', u'bonded': True}, u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'native_virtual_network': None, u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}, u'type': u'NetworkPort', u'id': u'e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'connected_port': {u'href': u'/ports/cbf9936c-b1b6-4e89-90ed-91ac52c01259'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'slug': u't1.small.x86', u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'line': u'baremetal', u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'memory': {u'total': u'8GB'}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}}, u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'slug': u'ubuntu_16_04', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'5834e961', u'created_at': u'2019-06-07T17:39:42Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'billing_cycle': u'hourly', u'image_url': None, u'volumes': [{u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86'}, {u'href': u'/storage/9437ec17-1666-440e-bf97-18af637d5245'}, {u'href': u'/storage/221fadf5-af27-404f-bcb4-4f3d7c711869'}, {u'href': u'/storage/d043d206-5774-4af3-8c98-ab321c1dc0a7'}, {u'href': u'/storage/3b3dae4e-4e4e-43a2-ad30-a18eb35197b8'}, {u'href': u'/storage/63590eba-7ce0-41b6-81d3-e1eef8d61ed9'}], u'user': u'root'}, u'etag': u'"4ba991c9c01bce8bf419046a387c43d6"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'timeout': 30, u'url_password': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'src': None, u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'url_username': None, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', '_ansible_parsed': True, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:41 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:47 GMT', u'x_frame_options': u'SAMEORIGIN', u'age': u'0, 0', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'transfer_encoding': u'chunked', u'changed': False, u'x_instana_t': u'61912cff5072e9cd', u'cookies_string': u'', u'x_cache': u'MISS', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'connection': u'close', u'redirected': False, u'x_instana_s': u'61912cff5072e9cd', '_ansible_ignore_errors': None})

TASK [Create ext4 filesystem] *************************************************************************************************************************************
changed: [localhost -> root@147.75.84.93] => (item=[{'_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932304.671737,VS0,VE585', u'x_cache': u'MISS', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'hostname': u'master-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'147.75.84.92', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/53a6065b-9db7-440c-ab27-b096146a64c2', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 31, u'manageable': True, u'id': u'53a6065b-9db7-440c-ab27-b096146a64c2', u'address': u'147.75.84.93', u'network': u'147.75.84.92'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'2604:1380:2001:2900::4e', u'project': {}, u'global_ip': None, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/a91c4956-3411-429b-aabc-87be8e3e064e', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 127, u'manageable': True, u'id': u'a91c4956-3411-429b-aabc-87be8e3e064e', u'address': u'2604:1380:2001:2900::4f', u'network': u'2604:1380:2001:2900::4e'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'10.80.77.190', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/5d9ef644-3b94-4474-b870-dbc86ed77064', u'details': None, u'public': False, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 31, u'manageable': True, u'id': u'5d9ef644-3b94-4474-b870-dbc86ed77064', u'address': u'10.80.77.191', u'network': u'10.80.77.190'}], u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:37Z', u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'id': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'afc936b1', u'user': u'root', u'customdata': {}, u'storage': None, u'state': u'active', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'type': u'NetworkBondPort', u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9', u'native_virtual_network': None, u'data': {u'bonded': True}, u'network_type': u'layer3', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/a085619b-d3ac-48f8-8993-0bd83503d746'}, u'data': {u'mac': u'0c:c4:7a:20:5a:20', u'bonded': True}, u'id': u'5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}}, {u'virtual_networks': [], u'name': u'eth1', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/faf9c0c6-73c9-4811-9ae9-d976f85d755f'}, u'data': {u'mac': u'0c:c4:7a:20:5a:21', u'bonded': True}, u'id': u'a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'slug': u't1.small.x86', u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'memory': {u'total': u'8GB'}}, u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'line': u'baremetal', u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'slug': u'ubuntu_16_04', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'6e7bdb0e', u'created_at': u'2019-06-07T17:39:22Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'iqn': u'iqn.2019-06.net.packet:device.afc936b1', u'image_url': None, u'volumes': [{u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434'}, {u'href': u'/storage/7e290a7d-338b-46a8-99c3-58bed0e80bcb'}, {u'href': u'/storage/a6f8f1ee-12d0-4069-b749-2d19b7651985'}, {u'href': u'/storage/440eca67-3604-4697-b357-eed59a631fc0'}, {u'href': u'/storage/65034777-8f8c-4549-b533-aeb86d924ce7'}, {u'href': u'/storage/3ebf113b-2e97-4fb6-8108-7a1186a1aabd'}], u'root_password': u'A87lL4P%bg'}, u'etag': u'"3a39f44a61ed4766cf1d8969d9352ce4"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 200, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:37 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:44 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'transfer_encoding': u'chunked', u'age': u'0, 0', u'changed': False, u'x_instana_t': u'72321758657fc156', u'cookies_string': u'', u'x_cache_hits': u'0', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_request_id': u'd914444a-6694-42b8-bf3e-cb2444270380', u'redirected': False, u'x_instana_s': u'72321758657fc156', '_ansible_ignore_errors': None}, {u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932287.907999,VS0,VE1357', u'x_cache_hits': u'0', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'created_at': u'2019-06-07T18:31:27Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:27Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'2dc746eb-6f00-45ee-9e3b-f440b9456434', u'name': u'volume-2dc746eb'}, u'etag': u'W/"47cfd30b580911e2ffe5433a35d14a76"', u'location': u'https://api.packet.net/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20741-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:28 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'changed': False, u'x_cache': u'MISS', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_request_id': u'59040d29-daf7-4891-81e9-474fb283e447', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}])
changed: [localhost -> root@147.75.81.119] => (item=[{'_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932307.539260,VS0,VE583', u'x_cache': u'MISS', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'hostname': u'node-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:47Z', u'customdata': {}, u'enabled': True, u'gateway': u'147.75.81.118', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/48a67332-5b3e-4ea5-be37-f103d854b232', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 31, u'manageable': True, u'id': u'48a67332-5b3e-4ea5-be37-f103d854b232', u'address': u'147.75.81.119', u'network': u'147.75.81.118'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'gateway': u'2604:1380:2001:2900::44', u'project': {}, u'global_ip': None, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/8e46a36b-788e-49fe-913d-bc0e563dfadf', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 127, u'manageable': True, u'id': u'8e46a36b-788e-49fe-913d-bc0e563dfadf', u'address': u'2604:1380:2001:2900::45', u'network': u'2604:1380:2001:2900::44'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'gateway': u'10.80.77.180', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/1ff454ad-a708-421f-8846-4f8a851707eb', u'details': None, u'public': False, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 31, u'manageable': True, u'id': u'1ff454ad-a708-421f-8846-4f8a851707eb', u'address': u'10.80.77.181', u'network': u'10.80.77.180'}], u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:41Z', u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'id': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'f558a96f', u'user': u'root', u'customdata': {}, u'storage': None, u'state': u'active', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'type': u'NetworkBondPort', u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'native_virtual_network': None, u'data': {u'bonded': True}, u'network_type': u'layer3', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/03ab3332-e217-41c5-830d-b7080c8cd052'}, u'data': {u'mac': u'0c:c4:7a:54:0e:a0', u'bonded': True}, u'id': u'44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}}, {u'virtual_networks': [], u'name': u'eth1', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/cbf9936c-b1b6-4e89-90ed-91ac52c01259'}, u'data': {u'mac': u'0c:c4:7a:54:0e:a1', u'bonded': True}, u'id': u'e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'slug': u't1.small.x86', u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'memory': {u'total': u'8GB'}}, u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'line': u'baremetal', u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'slug': u'ubuntu_16_04', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'5834e961', u'created_at': u'2019-06-07T17:39:42Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'iqn': u'iqn.2019-06.net.packet:device.f558a96f', u'image_url': None, u'volumes': [{u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86'}, {u'href': u'/storage/9437ec17-1666-440e-bf97-18af637d5245'}, {u'href': u'/storage/221fadf5-af27-404f-bcb4-4f3d7c711869'}, {u'href': u'/storage/d043d206-5774-4af3-8c98-ab321c1dc0a7'}, {u'href': u'/storage/3b3dae4e-4e4e-43a2-ad30-a18eb35197b8'}, {u'href': u'/storage/63590eba-7ce0-41b6-81d3-e1eef8d61ed9'}], u'root_password': u'{926,ukIVa'}, u'etag': u'"4ba991c9c01bce8bf419046a387c43d6"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 200, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:41 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:47 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'transfer_encoding': u'chunked', u'age': u'0, 0', u'changed': False, u'x_instana_t': u'61912cff5072e9cd', u'cookies_string': u'', u'x_cache_hits': u'0', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_request_id': u'504209f8-acfa-4f71-ac45-caa15cbbae4c', u'redirected': False, u'x_instana_s': u'61912cff5072e9cd', '_ansible_ignore_errors': None}, {u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932290.360129,VS0,VE2111', u'x_cache_hits': u'0', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'created_at': u'2019-06-07T18:31:30Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:30Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'name': u'volume-fd0bb8fc'}, u'etag': u'W/"a7139a46256982c4314fd3d3cedbcbbe"', u'location': u'https://api.packet.net/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20742-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:32 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'x_instana_s': u'b82340971af33a80', u'changed': False, u'x_instana_t': u'b82340971af33a80', u'x_cache': u'MISS', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_request_id': u'a2e3b9b8-6b96-4852-b0c8-38fbd3a11305', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}])

TASK [mounting disk to Nodes] *************************************************************************************************************************************
changed: [localhost -> root@147.75.84.93] => (item=[{'_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932304.671737,VS0,VE585', u'x_cache': u'MISS', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'hostname': u'master-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'147.75.84.92', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/53a6065b-9db7-440c-ab27-b096146a64c2', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 31, u'manageable': True, u'id': u'53a6065b-9db7-440c-ab27-b096146a64c2', u'address': u'147.75.84.93', u'network': u'147.75.84.92'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'2604:1380:2001:2900::4e', u'project': {}, u'global_ip': None, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/a91c4956-3411-429b-aabc-87be8e3e064e', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 127, u'manageable': True, u'id': u'a91c4956-3411-429b-aabc-87be8e3e064e', u'address': u'2604:1380:2001:2900::4f', u'network': u'2604:1380:2001:2900::4e'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:24Z', u'customdata': {}, u'enabled': True, u'gateway': u'10.80.77.190', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/5d9ef644-3b94-4474-b870-dbc86ed77064', u'details': None, u'public': False, u'assigned_to': {u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4'}, u'interface': {u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9'}, u'cidr': 31, u'manageable': True, u'id': u'5d9ef644-3b94-4474-b870-dbc86ed77064', u'address': u'10.80.77.191', u'network': u'10.80.77.190'}], u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:37Z', u'href': u'/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'id': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'afc936b1', u'user': u'root', u'customdata': {}, u'storage': None, u'state': u'active', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'type': u'NetworkBondPort', u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/59909f3c-facf-4b76-9a4c-244e755174b9', u'native_virtual_network': None, u'data': {u'bonded': True}, u'network_type': u'layer3', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/a085619b-d3ac-48f8-8993-0bd83503d746'}, u'data': {u'mac': u'0c:c4:7a:20:5a:20', u'bonded': True}, u'id': u'5cda772d-297f-4d2a-b563-4dd0c7843ca3', u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}}, {u'virtual_networks': [], u'name': u'eth1', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/d1efce4c-5e47-4e7d-9fbb-da6ec8188cc8'}, u'href': u'/ports/a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/faf9c0c6-73c9-4811-9ae9-d976f85d755f'}, u'data': {u'mac': u'0c:c4:7a:20:5a:21', u'bonded': True}, u'id': u'a16aabc1-d6bb-4483-bb12-494ee868dbe0', u'bond': {u'id': u'59909f3c-facf-4b76-9a4c-244e755174b9', u'name': u'bond0'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'slug': u't1.small.x86', u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'memory': {u'total': u'8GB'}}, u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'line': u'baremetal', u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'slug': u'ubuntu_16_04', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'6e7bdb0e', u'created_at': u'2019-06-07T17:39:22Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'iqn': u'iqn.2019-06.net.packet:device.afc936b1', u'image_url': None, u'volumes': [{u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434'}, {u'href': u'/storage/7e290a7d-338b-46a8-99c3-58bed0e80bcb'}, {u'href': u'/storage/a6f8f1ee-12d0-4069-b749-2d19b7651985'}, {u'href': u'/storage/440eca67-3604-4697-b357-eed59a631fc0'}, {u'href': u'/storage/65034777-8f8c-4549-b533-aeb86d924ce7'}, {u'href': u'/storage/3ebf113b-2e97-4fb6-8108-7a1186a1aabd'}], u'root_password': u'A87lL4P%bg'}, u'etag': u'"3a39f44a61ed4766cf1d8969d9352ce4"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 200, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:37 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:44 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/afc936b1-f272-4d6b-aadc-253986aaddb4', u'transfer_encoding': u'chunked', u'age': u'0, 0', u'changed': False, u'x_instana_t': u'72321758657fc156', u'cookies_string': u'', u'x_cache_hits': u'0', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_request_id': u'd914444a-6694-42b8-bf3e-cb2444270380', u'redirected': False, u'x_instana_s': u'72321758657fc156', '_ansible_ignore_errors': None}, {u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932287.907999,VS0,VE1357', u'x_cache_hits': u'0', '_ansible_item_label': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'created_at': u'2019-06-07T18:31:27Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:27Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'2dc746eb-6f00-45ee-9e3b-f440b9456434', u'name': u'volume-2dc746eb'}, u'etag': u'W/"47cfd30b580911e2ffe5433a35d14a76"', u'location': u'https://api.packet.net/storage/2dc746eb-6f00-45ee-9e3b-f440b9456434', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20741-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:28 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'changed': False, u'x_cache': u'MISS', 'item': u'afc936b1-f272-4d6b-aadc-253986aaddb4', u'x_request_id': u'59040d29-daf7-4891-81e9-474fb283e447', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}])
changed: [localhost -> root@147.75.81.119] => (item=[{'_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932307.539260,VS0,VE583', u'x_cache': u'MISS', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'hostname': u'node-test-1', u'ipxe_script_url': None, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'ip_addresses': [{u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:47Z', u'customdata': {}, u'enabled': True, u'gateway': u'147.75.81.118', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/48a67332-5b3e-4ea5-be37-f103d854b232', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 31, u'manageable': True, u'id': u'48a67332-5b3e-4ea5-be37-f103d854b232', u'address': u'147.75.81.119', u'network': u'147.75.81.118'}, {u'project_lite': {}, u'management': True, u'address_family': 6, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'gateway': u'2604:1380:2001:2900::44', u'project': {}, u'global_ip': None, u'netmask': u'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe', u'href': u'/ips/8e46a36b-788e-49fe-913d-bc0e563dfadf', u'details': None, u'public': True, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 127, u'manageable': True, u'id': u'8e46a36b-788e-49fe-913d-bc0e563dfadf', u'address': u'2604:1380:2001:2900::45', u'network': u'2604:1380:2001:2900::44'}, {u'project_lite': {}, u'management': True, u'address_family': 4, u'facility': {u'code': u'ams1', u'features': [u'baremetal', u'storage', u'global_ipv4', u'backend_transfer', u'layer_2'], u'ip_ranges': [u'2604:1380:2000::/36', u'147.75.204.0/23', u'147.75.100.0/22', u'147.75.80.0/22', u'147.75.32.0/23'], u'address': {u'href': u'#0688e909-647e-4b21-bdf2-fc056d993fc5'}, u'id': u'8e6470b3-b75e-47d1-bb93-45b225750975', u'name': u'Amsterdam, NL'}, u'created_at': u'2019-06-07T17:39:46Z', u'customdata': {}, u'enabled': True, u'gateway': u'10.80.77.180', u'project': {}, u'global_ip': None, u'netmask': u'255.255.255.254', u'href': u'/ips/1ff454ad-a708-421f-8846-4f8a851707eb', u'details': None, u'public': False, u'assigned_to': {u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4'}, u'interface': {u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9'}, u'cidr': 31, u'manageable': True, u'id': u'1ff454ad-a708-421f-8846-4f8a851707eb', u'address': u'10.80.77.181', u'network': u'10.80.77.180'}], u'billing_cycle': u'hourly', u'updated_at': u'2019-06-07T18:31:41Z', u'href': u'/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'id': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'userdata': u'', u'ssh_keys': [{u'href': u'/ssh-keys/c9ea0535-6aee-4711-8e33-6460a12e3efd'}, {u'href': u'/ssh-keys/8b6c18d8-adeb-4233-b3a0-97cb10777410'}, {u'href': u'/ssh-keys/93e15f6b-d45a-4704-9732-4748ad13eae6'}, {u'href': u'/ssh-keys/bfa3dbf1-1f48-41b1-9e29-e3ceda891232'}, {u'href': u'/ssh-keys/60f04f19-f108-4a26-aed2-624c18cf5b7d'}, {u'href': u'/ssh-keys/15794e6f-f970-4a44-8a07-f8304e648cc6'}, {u'href': u'/ssh-keys/7068cffb-c241-4099-b223-780ebffa0241'}, {u'href': u'/ssh-keys/5e4d264a-2a19-4615-bd5f-b2cdbc1c58c2'}, {u'href': u'/ssh-keys/e2a345f0-6a3a-44c6-a8e9-4dd8035f51df'}, {u'href': u'/ssh-keys/15fb2f9f-1be8-4586-bda4-01ca7823a376'}, {u'href': u'/ssh-keys/d54db1c3-65f5-4cf8-a81b-446e9df7f0e3'}, {u'href': u'/ssh-keys/0a863317-2b48-43ec-a634-4074c0ee0b38'}, {u'href': u'/ssh-keys/04c56ace-6401-41e4-b6f6-e042ba39510d'}, {u'href': u'/ssh-keys/c8ead40c-ed13-4b9b-bfda-6228fd0de531'}, {u'href': u'/ssh-keys/835deb86-1e28-4b13-8f79-a1c594531fd2'}, {u'href': u'/ssh-keys/0f729a5d-d9de-4a15-9d8b-cb9e31359572'}, {u'href': u'/ssh-keys/30a27e68-d221-4343-a622-1946108260a7'}, {u'href': u'/ssh-keys/24d4f01b-09e5-44e1-88b3-1dc08beed0f7'}, {u'href': u'/ssh-keys/96b75f13-d056-4bf0-9317-3f11d347060d'}, {u'href': u'/ssh-keys/3918a529-4f61-4552-a311-5820f53ad641'}, {u'href': u'/ssh-keys/b987031f-e016-435b-a70b-95d0314c3b2d'}, {u'href': u'/ssh-keys/33ce01ed-6215-4b1f-be36-317c6086d828'}, {u'href': u'/ssh-keys/7f56fbe9-929c-41f4-a92d-2be7c6fdfec5'}, {u'href': u'/ssh-keys/be075045-8f1c-45b7-b839-8e7a191ad612'}, {u'href': u'/ssh-keys/e75280fc-6b48-45e1-87a4-974195231071'}, {u'href': u'/ssh-keys/f7ac98bf-d239-45db-bb77-3ba0b738334d'}, {u'href': u'/ssh-keys/0140e002-8edc-468c-85fb-0d28e0d21b7e'}, {u'href': u'/ssh-keys/5fc58ce8-f848-4d08-8c70-a645b4c0da7a'}, {u'href': u'/ssh-keys/04f37228-42fb-4f08-b2cf-722c3e6fdf32'}, {u'href': u'/ssh-keys/de0c1d74-96ce-40eb-8fab-5be6171e45ca'}, {u'href': u'/ssh-keys/ed01bf6a-a7c7-48bf-9c4b-3abe59ebf27b'}, {u'href': u'/ssh-keys/244e15a2-9458-4212-a09a-dab97eb98975'}, {u'href': u'/ssh-keys/d0797fc5-c9d9-4760-9bb6-fbe56bd45b99'}, {u'href': u'/ssh-keys/268a7f4e-1bb2-4f77-bf67-e89358ce9b48'}, {u'href': u'/ssh-keys/6cb0f1e6-0170-4aa7-b9f8-4ff15e418556'}, {u'href': u'/ssh-keys/72baf1ae-5ffe-468f-8c70-b7ec841320c1'}, {u'href': u'/ssh-keys/08c1df2e-6fea-4572-9d51-96af2dcc30f4'}, {u'href': u'/ssh-keys/fb5cc202-3cc3-4179-a49e-9bcd59f094e7'}, {u'href': u'/ssh-keys/6ae6be52-3a67-4db8-bc03-586c28785a81'}, {u'href': u'/ssh-keys/e4c2d818-c7d3-486e-ba1e-8aa166dedfcb'}, {u'href': u'/ssh-keys/ffcd57bd-d06b-4c71-83b3-c2f9ee4b7b06'}, {u'href': u'/ssh-keys/26d9c175-be31-4b1e-9157-4c3fa1cef4bd'}, {u'href': u'/ssh-keys/191bfe1f-ca4a-4172-9544-ac6f000634b2'}, {u'href': u'/ssh-keys/8d84b43c-c5a9-49b0-94f5-825198445354'}, {u'href': u'/ssh-keys/5b7a8fd9-bf49-4b31-ba6d-d10d84fb0fde'}, {u'href': u'/ssh-keys/ecd60e31-52a0-4a61-9e8d-6d21e35d32db'}, {u'href': u'/ssh-keys/508d0fb8-8f51-4287-a1e7-4fe850740423'}, {u'href': u'/ssh-keys/7ed472cc-bc55-4e8e-9da0-52d7c0c5b46f'}, {u'href': u'/ssh-keys/6f59ed34-0a4d-463e-adeb-16d7e37a6566'}, {u'href': u'/ssh-keys/3df24db8-005b-498d-88ac-aad87a7ef058'}, {u'href': u'/ssh-keys/82603a58-5eec-4acc-be00-233605a1b4d7'}, {u'href': u'/ssh-keys/8915669f-4561-4ae5-9b0a-66f986d98b0b'}, {u'href': u'/ssh-keys/a9adb3ed-ef12-4f6c-9682-b106fd567313'}, {u'href': u'/ssh-keys/084c5dcc-4243-4687-a378-f415581ac6ef'}, {u'href': u'/ssh-keys/09ce5da9-a62e-4ba5-8328-4c8434fe4156'}, {u'href': u'/ssh-keys/9fae8e9d-ff1a-47d1-b3a5-5dd770852fdb'}, {u'href': u'/ssh-keys/a2dd27d6-8a26-40bd-a75d-30684b352962'}, {u'href': u'/ssh-keys/90bcacbf-5f33-4e3c-826b-0e667ddfbb26'}, {u'href': u'/ssh-keys/b00c1731-28e9-4eb4-bce8-095f7aff3899'}, {u'href': u'/ssh-keys/0ef91243-bd6c-4a47-a1e0-92eb2b097cd1'}], u'short_id': u'f558a96f', u'user': u'root', u'customdata': {}, u'storage': None, u'state': u'active', u'network_ports': [{u'virtual_networks': [], u'name': u'bond0', u'type': u'NetworkBondPort', u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'native_virtual_network': None, u'data': {u'bonded': True}, u'network_type': u'layer3', u'connected_port': None}, {u'virtual_networks': [], u'name': u'eth0', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/03ab3332-e217-41c5-830d-b7080c8cd052'}, u'data': {u'mac': u'0c:c4:7a:54:0e:a0', u'bonded': True}, u'id': u'44f7c483-7f15-4e3a-b52b-bd24c1a89d1e', u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}}, {u'virtual_networks': [], u'name': u'eth1', u'type': u'NetworkPort', u'hardware': {u'href': u'/hardware/39279bdf-52a9-4311-a464-a31a2485b5c7'}, u'href': u'/ports/e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'native_virtual_network': None, u'connected_port': {u'href': u'/ports/cbf9936c-b1b6-4e89-90ed-91ac52c01259'}, u'data': {u'mac': u'0c:c4:7a:54:0e:a1', u'bonded': True}, u'id': u'e91cd320-7ecf-4381-afd4-0ca619d8ea59', u'bond': {u'id': u'b5cd3218-90d0-4901-aafa-798de4b1d4c9', u'name': u'bond0'}}], u'project_lite': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'description': None, u'tags': [], u'always_pxe': False, u'plan': {u'slug': u't1.small.x86', u'description': u'Our Type 0 configuration is a general use "cloud killer" server, with a Intel Atom 2.4Ghz processor and 8GB of RAM.', u'class': u't1.small.x86', u'available_in': [{u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, {u'href': u'/facilities/8ea03255-89f9-4e62-9d3f-8817db82ceed'}, {u'href': u'/facilities/2b70eb8f-fa18-47c0-aba7-222a842362fd'}, {u'href': u'/facilities/e1e9c52e-a0bc-4117-b996-0fc94843ea09'}], u'specs': {u'nics': [{u'count': 2, u'type': u'1Gbps'}], u'drives': [{u'count': 1, u'type': u'SSD', u'size': u'80GB'}], u'features': {u'txt': True, u'raid': False}, u'cpus': [{u'count': 1, u'type': u'Intel Atom C2550 @ 2.4Ghz'}], u'memory': {u'total': u'8GB'}}, u'legacy': False, u'pricing': {u'hour': 0.07}, u'deployment_types': [u'on_demand', u'spot_market'], u'line': u'baremetal', u'id': u'e69c0169-4726-46ea-98f1-939c9e8a3607', u'name': u't1.small.x86'}, u'bonding_mode': 5, u'operating_system': {u'preinstallable': True, u'name': u'Ubuntu 16.04 LTS', u'slug': u'ubuntu_16_04', u'licensed': False, u'version': u'16.04', u'pricing': {}, u'provisionable_on': [u'baremetal_2a4', u'baremetal_2a5', u'baremetal_5', u'baremetal_hua', u'c1.bloomberg.x86', u'c1.large.arm', u'baremetal_2a', u'c1.large.arm.xda', u'baremetal_2a2', u'c1.small.x86', u'baremetal_1', u'c1.xlarge.x86', u'baremetal_3', u'c2.large.arm', u'c2.medium.x86', u'd1f.optane.x86', u'd1p.optane.x86', u'g2.large.x86', u'm1.xlarge.x86', u'baremetal_2', u'm2.xlarge.x86', u'n2.xlarge.x86', u's1.large.x86', u'baremetal_s', u't1.small.x86', u'baremetal_0', u'x1.small.x86', u'baremetal_1e', u'x2.xlarge.x86'], u'id': u'1b9b78e3-de68-466e-ba00-f2123e89c112', u'distro': u'ubuntu'}, u'locked': False, u'switch_uuid': u'5834e961', u'created_at': u'2019-06-07T17:39:42Z', u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'iqn': u'iqn.2019-06.net.packet:device.f558a96f', u'image_url': None, u'volumes': [{u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86'}, {u'href': u'/storage/9437ec17-1666-440e-bf97-18af637d5245'}, {u'href': u'/storage/221fadf5-af27-404f-bcb4-4f3d7c711869'}, {u'href': u'/storage/d043d206-5774-4af3-8c98-ab321c1dc0a7'}, {u'href': u'/storage/3b3dae4e-4e4e-43a2-ad30-a18eb35197b8'}, {u'href': u'/storage/63590eba-7ce0-41b6-81d3-e1eef8d61ed9'}], u'root_password': u'{926,ukIVa'}, u'etag': u'"4ba991c9c01bce8bf419046a387c43d6"', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'200'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': None, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'validate_certs': True, u'seuser': None, u'method': u'GET', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes, bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 200, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20766-CDG', u'msg': u'OK (unknown bytes)', u'last_modified': u'Fri, 07 Jun 2019 18:31:41 GMT', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:47 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/devices/f558a96f-17bf-42a4-9600-9d60f75ccab4', u'transfer_encoding': u'chunked', u'age': u'0, 0', u'changed': False, u'x_instana_t': u'61912cff5072e9cd', u'cookies_string': u'', u'x_cache_hits': u'0', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_request_id': u'504209f8-acfa-4f71-ac45-caa15cbbae4c', u'redirected': False, u'x_instana_s': u'61912cff5072e9cd', '_ansible_ignore_errors': None}, {u'content_length': u'745', '_ansible_parsed': True, u'cookies': {}, u'via': u'1.1 varnish', u'vary': u'Origin', u'x_timer': u'S1559932290.360129,VS0,VE2111', u'x_cache_hits': u'0', '_ansible_item_label': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_content_type_options': u'nosniff', u'connection': u'close', 'failed': False, u'json': {u'project': {u'href': u'/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2'}, u'locked': False, u'description': None, u'facility': {u'href': u'/facilities/8e6470b3-b75e-47d1-bb93-45b225750975'}, u'href': u'/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'created_at': u'2019-06-07T18:31:30Z', u'customdata': {}, u'attachments': [], u'updated_at': u'2019-06-07T18:31:30Z', u'snapshots': [], u'access': {}, u'state': u'queued', u'billing_cycle': u'hourly', u'plan': {u'slug': u'storage_1', u'description': u'TBD', u'class': u'storage_1', u'available_in': [], u'specs': {}, u'legacy': True, u'pricing': {u'hour': 0.000104}, u'deployment_types': [], u'line': u'storage', u'id': u'87728148-3155-4992-a730-8d1e6aca8a32', u'name': u'Standard'}, u'snapshot_policies': [], u'size': 50, u'id': u'fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'name': u'volume-fd0bb8fc'}, u'etag': u'W/"a7139a46256982c4314fd3d3cedbcbbe"', u'location': u'https://api.packet.net/storage/fd0bb8fc-bb71-4b15-93f6-77a581322a86', u'invocation': {u'module_args': {u'directory_mode': None, u'force': False, u'remote_src': None, u'status_code': [u'201'], u'body_format': u'json', u'owner': None, u'follow': False, u'client_key': None, u'group': None, u'use_proxy': True, u'unsafe_writes': None, u'serole': None, u'content': None, u'setype': None, u'follow_redirects': u'safe', u'return_content': False, u'client_cert': None, u'body': {u'facility': u'ams1', u'billing_cycle': u'hourly', u'plan': u'storage_1', u'size': u'50'}, u'url_username': None, u'src': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'http_agent': u'ansible-httpget', u'regexp': None, u'url_password': None, u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'validate_certs': True, u'seuser': None, u'method': u'POST', u'creates': None, u'headers': {u'Content-Type': u'application/json', u'X-Auth-Token': u'vRRU93xtvhjVWWVuW2KerBPivc8kLVmh'}, u'delimiter': None, u'mode': None, u'timeout': 30, u'attributes': None, u'backup': None}}, u'accept_ranges': u'bytes', u'cache_control': u'max-age=0, private, must-revalidate', u'status': 201, '_ansible_item_result': True, u'x_served_by': u'cache-cdg20742-CDG', u'msg': u'OK (745 bytes)', u'content_type': u'application/json; charset=utf-8', u'date': u'Fri, 07 Jun 2019 18:31:32 GMT', u'x_frame_options': u'SAMEORIGIN', '_ansible_no_log': False, u'x_xss_protection': u'1; mode=block', u'url': u'https://api.packet.net/projects/bdbd5cf0-7453-434b-99f8-0c3e3f83dbe2/storage', u'x_instana_s': u'b82340971af33a80', u'changed': False, u'x_instana_t': u'b82340971af33a80', u'x_cache': u'MISS', 'item': u'f558a96f-17bf-42a4-9600-9d60f75ccab4', u'x_request_id': u'a2e3b9b8-6b96-4852-b0c8-38fbd3a11305', u'redirected': False, u'cookies_string': u'', '_ansible_ignore_errors': None}])

TASK [Set Test Status] ********************************************************************************************************************************************
ok: [localhost]

PLAY RECAP ********************************************************************************************************************************************************
localhost                  : ok=11   changed=6    unreachable=0    failed=0 
```
