### PR TITLE
feat[litmusbook]: Created a litmusbook to check the status deleted pv stale lists in pool pods

### DIFF
--- a/experiments/functional/deprovision-multiple-volumes/pvc.yml
+++ b/experiments/functional/deprovision-multiple-volumes/pvc.yml
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+  labels:
+    lkey: lvalue
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"

--- a/experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml
+++ b/experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml
@@ -1,0 +1,61 @@
+---
+   - name: Get the pvc label values from env
+     set_fact:
+         pvc_lkey: "{{ pvc_label.split('=')[0] }}"
+         pvc_lvalue: "{{ pvc_label.split('=')[1] }}"
+
+   - name: Replace the pvc label placeholder in spec
+     replace:
+        path: "{{ pvc_deployment }}"
+        regexp: "lkey: lvalue"
+        replace: "{{ pvc_lkey }}: {{ pvc_lvalue }}{{i}}"
+ 
+   - name: Change the claim name in deployment.
+     replace:
+       dest: "{{ pvc_deployment }}"
+       regexp: "testclaim"
+       replace: "{{pvc_name}}-{{i}}"
+
+   - name: Deploy the test pvc
+     shell: kubectl apply -f {{ pvc_deployment }} -n {{ namespace }}
+     args:
+       executable: /bin/bash
+     register: pvc
+
+   - name: check if the PVC is created
+     shell: kubectl get pvc "{{ pvc_name }}-{{i}}" -n {{ namespace }} -o jsonpath='{.status.phase}'
+     args: 
+       executable: /bin/bash
+     register: pvc_status
+     until: "'Bound' in pvc_status.stdout"
+     delay: 10
+     retries: 20
+
+   - name: Check if the target pod is running
+     shell: >
+       kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume-claim="{{ pvc_name }}-{{i}}" 
+       -o custom-columns=:status.phase --no-headers
+     args:
+       executable: /bin/bash
+     register: target
+     until: "'Running' in target.stdout"
+     delay: 10
+     retries: 20
+   
+   ### Revert the changes ########
+   
+   - name: Revert the claim name in deployment.
+     replace:
+       dest: "{{ pvc_deployment }}"
+       regexp: "{{pvc_name}}-{{i}}"
+       replace: "testclaim"
+
+   - name: Revert the label in spec file.
+     replace:
+        dest: "{{ pvc_deployment }}"
+        regexp: "{{ pvc_lkey }}: {{ pvc_lvalue }}{{i}}"
+        replace: "lkey: lvalue"
+
+   ## For continuos iteration of "i" value ## 
+   - set_fact:
+       i: '{{ i | int + 1 }}'

--- a/experiments/functional/deprovision-multiple-volumes/run_litmus_test.yml
+++ b/experiments/functional/deprovision-multiple-volumes/run_litmus_test.yml
@@ -45,5 +45,8 @@ spec:
           - name: PVC_COUNT
             value: "5"
 
+          - name: POOL_POD_LABEL
+            value: cstor-block-disk-pool
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/deprovision-multiple-volumes/test.yml -i /etc/ansible/hosts -v; exit 0"] 

--- a/experiments/functional/deprovision-multiple-volumes/run_litmus_test.yml
+++ b/experiments/functional/deprovision-multiple-volumes/run_litmus_test.yml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-pvc-deprovision-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: pvc-deprovision
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci 
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            # Supported values: local-storage, openebs-cstor-disk
+            value: openebs-cstor-disk
+
+            # Application label
+          - name: PVC_LABEL
+            value: name=test-pvc
+
+          - name: PVC_NAME
+            value: demo-pvc-claim
+
+            # deployment namespace
+          - name: DEPLOY_NAMESPACE
+            value: test-pvc
+
+          - name: OPERATOR_NS
+            value: openebs
+
+            # Number of application instances to be created.
+          - name: PVC_COUNT
+            value: "5"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/deprovision-multiple-volumes/test.yml -i /etc/ansible/hosts -v; exit 0"] 

--- a/experiments/functional/deprovision-multiple-volumes/test.yml
+++ b/experiments/functional/deprovision-multiple-volumes/test.yml
@@ -36,7 +36,7 @@
             regexp: "testclass"
             replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 
-        ## Setting up iteration value to generate continuos values ##
+        ## Setting up iteration value to generate continuous values ##
         - set_fact:
             i: 0
 
@@ -46,7 +46,7 @@
 
         - name: Obtain the cstor pool pod list
           shell: >
-            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool 
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_pod_label }}
             -o custom-columns=:.metadata.name --no-headers
           args:
             executable: /bin/bash
@@ -61,7 +61,7 @@
 
         - name: Delete the all PVC and pool pods
           shell: >
-             kubectl delete pods -n {{ operator_ns }} {{ pool_pods.stdout_lines[0] }} && kubectl delete pvc -n {{ namespace }} --all
+             kubectl delete pods -n openebs {{ pool_pods.stdout_lines[0] }} && kubectl delete pvc -n {{ namespace }} --all
           args:
             executable: /bin/bash
           register: pod_pvc_delete
@@ -77,34 +77,47 @@
 
         - name: Check if the pool pods are in Running state
           shell: >
-             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool 
+             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_pod_label }} 
              -o custom-columns=:.status.phase --no-headers
           args:
             executable: /bin/bash
           register: pool_pod_status
           until: "((pool_pod_status.stdout_lines|unique)|length) == 1 and 'Running' in pool_pod_status.stdout"
           delay: 5
-          retries: 6          
+          retries: 6   
         
         - name: Get the newly created pool pod list
           shell: >
-             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool
+             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_pod_label }}
              -o custom-columns=:.metadata.name --no-headers
           args: 
             executable: /bin/bash
           register: new_pool_pod
 
+        - name: Check if the CVRs are deleted
+          shell: >
+             kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ item }}
+          args:
+            executable: /bin/bash
+          register: cvr_status
+          until: "'No resources found.' in cvr_status.stderr"
+          delay: 5
+          retries: 12
+          with_items:
+            - "{{ pv_name.stdout_lines }}"
+
         - name: sleep for 30 seconds and continue with play
           wait_for: timeout=30
 
-        - name: Check if the PV stales not there in pool pods
+        - name: Check is the volumes are not present in cstor pool pods
           shell: >
-             kubectl exec -it "{{ new_pool_pod.stdout_lines[0] }}" -n {{ operator_ns }} -c cstor-pool -- zfs list | grep {{ item }}
+             kubectl exec -it {{ item[0] }} -n {{ operator_ns }} -c cstor-pool -- zfs list | grep {{ item[1] }}
           args:
             executable: /bin/bash
           register: zfs_list
           failed_when: zfs_list.stdout != ""
           with_items:
+            - "{{ new_pool_pod.stdout_lines }}"
             - "{{ pv_name.stdout_lines }}"
 
         - set_fact:

--- a/experiments/functional/deprovision-multiple-volumes/test.yml
+++ b/experiments/functional/deprovision-multiple-volumes/test.yml
@@ -1,0 +1,121 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'            
+         
+        ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS
+        - name: Check whether the provider storageclass is provided.
+          shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Create namespace for deployment.
+          shell: kubectl create ns {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: app_ns
+          failed_when: "'created' not in app_ns.stdout"
+
+        - name: Replace the storageclass placeholder with provider
+          replace:
+            path: "{{ pvc_deployment }}"
+            regexp: "testclass"
+            replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+        ## Setting up iteration value to generate continuos values ##
+        - set_fact:
+            i: 0
+
+        ## Required application and PVC creation tasks ##
+        - include_tasks: "{{ pvc_creation_tasks }}"
+          with_sequence: start=0 count={{ pvc_count }}
+
+        - name: Obtain the cstor pool pod list
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool 
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: pool_pods
+
+        - name: Obtain the PV name
+          shell: >
+             kubectl get pvc -n {{ namespace }} -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv_name
+
+        - name: Delete the all PVC and pool pods
+          shell: >
+             kubectl delete pods -n {{ operator_ns }} {{ pool_pods.stdout_lines[0] }} && kubectl delete pvc -n {{ namespace }} --all
+          args:
+            executable: /bin/bash
+          register: pod_pvc_delete
+
+        - name: Check if the PVCs are deleted
+          shell: kubectl get pvc -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: pvc_status
+          until: "'No resources found.' in pvc_status.stderr"
+          delay: 5
+          retries: 30
+
+        - name: Check if the pool pods are in Running state
+          shell: >
+             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool 
+             -o custom-columns=:.status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: pool_pod_status
+          until: "((pool_pod_status.stdout_lines|unique)|length) == 1 and 'Running' in pool_pod_status.stdout"
+          delay: 5
+          retries: 6          
+        
+        - name: Get the newly created pool pod list
+          shell: >
+             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim=cstor-block-disk-pool
+             -o custom-columns=:.metadata.name --no-headers
+          args: 
+            executable: /bin/bash
+          register: new_pool_pod
+
+        - name: sleep for 30 seconds and continue with play
+          wait_for: timeout=30
+
+        - name: Check if the PV stales not there in pool pods
+          shell: >
+             kubectl exec -it "{{ new_pool_pod.stdout_lines[0] }}" -n {{ operator_ns }} -c cstor-pool -- zfs list | grep {{ item }}
+          args:
+            executable: /bin/bash
+          register: zfs_list
+          failed_when: zfs_list.stdout != ""
+          with_items:
+            - "{{ pv_name.stdout_lines }}"
+
+        - set_fact:
+           flag: "Pass"
+
+      rescue:
+         - set_fact:
+             flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'            

--- a/experiments/functional/deprovision-multiple-volumes/test_vars.yml
+++ b/experiments/functional/deprovision-multiple-volumes/test_vars.yml
@@ -14,3 +14,5 @@ pvc_name: "{{ lookup('env','PVC_NAME') }}"
 pvc_label: "{{ lookup('env','PVC_LABEL') }}"
 
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+pool_pod_label: "{{ lookup('env','POOL_POD_LABEL') }}"

--- a/experiments/functional/deprovision-multiple-volumes/test_vars.yml
+++ b/experiments/functional/deprovision-multiple-volumes/test_vars.yml
@@ -1,0 +1,16 @@
+---
+pvc_deployment: pvc.yml
+
+test_name: deprovision-all-pvc
+
+namespace: "{{ lookup('env','DEPLOY_NAMESPACE') }}" 
+
+pvc_creation_tasks: pvc_provision.yaml
+
+pvc_count: "{{ lookup('env','PVC_COUNT') }}"
+
+pvc_name: "{{ lookup('env','PVC_NAME') }}"
+
+pvc_label: "{{ lookup('env','PVC_LABEL') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a litmusbook to check whether the stale pv details not present in cstor pool pods
- Deployed Multiple PVs in the same namespace
- Delete the pool pod and all the pvcs together
- Wait until pool pods are up and running
- Exed into the cstor-pool pod container and check if the pv is not present in the pool pods.

```
[root@master-1554817485 sathya]# kubectl logs -f litmus-pvc-deprovision-7dfgs-d4f7z -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-06-14T06:45:12.128116 (delta: 0.088646)         elapsed: 0.088646 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-14T06:45:12.143091 (delta: 0.014917)         elapsed: 0.103621 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-14T06:45:22.554836 (delta: 10.411718)         elapsed: 10.515366 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-14T06:45:22.641555 (delta: 0.086663)         elapsed: 10.602085 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-14T06:45:22.720864 (delta: 0.079226)         elapsed: 10.681394 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-14T06:45:22.805964 (delta: 0.085012)         elapsed: 10.766494 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-14T06:45:22.952418 (delta: 0.146381)         elapsed: 10.912948 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "fc0d4bce83b2dec81f1e1167b24f149d42a66d36", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f12f5e1b6fca1853afb7405c3040f9bb", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1560494723.03-254612129437857/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-14T06:45:23.866076 (delta: 0.913591)         elapsed: 11.826606 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.316220", "end": "2019-06-14 06:45:25.638137", "rc": 0, "start": "2019-06-14 06:45:24.321917", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deprovision-all-pvc \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deprovision-all-pvc ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-14T06:45:25.749065 (delta: 1.882926)         elapsed: 13.709595 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.135601", "end": "2019-06-14 06:45:28.132819", "failed_when_result": false, "rc": 0, "start": "2019-06-14 06:45:25.997218", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deprovision-all-pvc configured", "stdout_lines": ["litmusresult.litmus.io/deprovision-all-pvc configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-14T06:45:28.210209 (delta: 2.461064)         elapsed: 16.170739 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-14T06:45:28.273221 (delta: 0.062942)         elapsed: 16.233751 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-14T06:45:28.334473 (delta: 0.061181)         elapsed: 16.295003 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is provided.] ********************
2019-06-14T06:45:28.404731 (delta: 0.070192)         elapsed: 16.365261 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk", "delta": "0:00:01.472410", "end": "2019-06-14 06:45:30.129683", "rc": 0, "start": "2019-06-14 06:45:28.657273", "stderr": "", "stderr_lines": [], "stdout": "NAME                 PROVISIONER                    AGE\nopenebs-cstor-disk   openebs.io/provisioner-iscsi   6d", "stdout_lines": ["NAME                 PROVISIONER                    AGE", "openebs-cstor-disk   openebs.io/provisioner-iscsi   6d"]}

TASK [Create namespace for deployment.] ****************************************
2019-06-14T06:45:30.202968 (delta: 1.798136)         elapsed: 18.163498 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns test-pvc", "delta": "0:00:01.492648", "end": "2019-06-14 06:45:31.908367", "failed_when_result": false, "rc": 0, "start": "2019-06-14 06:45:30.415719", "stderr": "", "stderr_lines": [], "stdout": "namespace/test-pvc created", "stdout_lines": ["namespace/test-pvc created"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-14T06:45:32.021218 (delta: 1.81818)         elapsed: 19.981748 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:45:32.627980 (delta: 0.606696)         elapsed: 20.58851 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"i": 0}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-14T06:45:32.713177 (delta: 0.085112)         elapsed: 20.673707 ******* 
included: /experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml for 127.0.0.1 => (item=0)
included: /experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml for 127.0.0.1 => (item=1)
included: /experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml for 127.0.0.1 => (item=2)
included: /experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml for 127.0.0.1 => (item=3)
included: /experiments/functional/deprovision-multiple-volumes/pvc_provision.yaml for 127.0.0.1 => (item=4)

TASK [Get the pvc label values from env] ***************************************
2019-06-14T06:45:33.014205 (delta: 0.300961)         elapsed: 20.974735 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pvc_lkey": "name", "pvc_lvalue": "test-pvc"}, "changed": false}

TASK [Replace the pvc label placeholder in spec] *******************************
2019-06-14T06:45:33.159596 (delta: 0.14532)         elapsed: 21.120126 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the claim name in deployment.] ************************************
2019-06-14T06:45:33.467872 (delta: 0.308187)         elapsed: 21.428402 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy the test pvc] *****************************************************
2019-06-14T06:45:33.761332 (delta: 0.29339)         elapsed: 21.721862 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n test-pvc", "delta": "0:00:01.609055", "end": "2019-06-14 06:45:35.608764", "rc": 0, "start": "2019-06-14 06:45:33.999709", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-pvc-claim-0 created", "stdout_lines": ["persistentvolumeclaim/demo-pvc-claim-0 created"]}

TASK [check if the PVC is created] *********************************************
2019-06-14T06:45:35.683811 (delta: 1.922385)         elapsed: 23.644341 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc \"demo-pvc-claim-0\" -n test-pvc -o jsonpath='{.status.phase}'", "delta": "0:00:01.734828", "end": "2019-06-14 06:45:37.653881", "rc": 0, "start": "2019-06-14 06:45:35.919053", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Check if the target pod is running] **************************************
2019-06-14T06:45:37.744434 (delta: 2.060529)         elapsed: 25.704964 ******* 
FAILED - RETRYING: Check if the target pod is running (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume-claim=\"demo-pvc-claim-0\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.384087", "end": "2019-06-14 06:45:50.957872", "rc": 0, "start": "2019-06-14 06:45:49.573785", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Revert the claim name in deployment.] ************************************
2019-06-14T06:45:51.026880 (delta: 13.282374)         elapsed: 38.98741 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Revert the label in spec file.] ******************************************
2019-06-14T06:45:51.354023 (delta: 0.327077)         elapsed: 39.314553 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:45:51.626016 (delta: 0.271921)         elapsed: 39.586546 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"i": "1"}, "changed": false}

TASK [Get the pvc label values from env] ***************************************
2019-06-14T06:45:51.723833 (delta: 0.097749)         elapsed: 39.684363 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pvc_lkey": "name", "pvc_lvalue": "test-pvc"}, "changed": false}

TASK [Replace the pvc label placeholder in spec] *******************************
2019-06-14T06:45:51.829255 (delta: 0.105347)         elapsed: 39.789785 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the claim name in deployment.] ************************************
2019-06-14T06:45:52.129434 (delta: 0.300116)         elapsed: 40.089964 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy the test pvc] *****************************************************
2019-06-14T06:45:52.516540 (delta: 0.38704)         elapsed: 40.47707 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n test-pvc", "delta": "0:00:02.687472", "end": "2019-06-14 06:45:55.501380", "rc": 0, "start": "2019-06-14 06:45:52.813908", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-pvc-claim-1 created", "stdout_lines": ["persistentvolumeclaim/demo-pvc-claim-1 created"]}

TASK [check if the PVC is created] *********************************************
2019-06-14T06:45:55.583516 (delta: 3.066885)         elapsed: 43.544046 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc \"demo-pvc-claim-1\" -n test-pvc -o jsonpath='{.status.phase}'", "delta": "0:00:01.278658", "end": "2019-06-14 06:45:57.155120", "rc": 0, "start": "2019-06-14 06:45:55.876462", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Check if the target pod is running] **************************************
2019-06-14T06:45:57.239294 (delta: 1.655708)         elapsed: 45.199824 ******* 
FAILED - RETRYING: Check if the target pod is running (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume-claim=\"demo-pvc-claim-1\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.288013", "end": "2019-06-14 06:46:10.346310", "rc": 0, "start": "2019-06-14 06:46:09.058297", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Revert the claim name in deployment.] ************************************
2019-06-14T06:46:10.430561 (delta: 13.191198)         elapsed: 58.391091 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Revert the label in spec file.] ******************************************
2019-06-14T06:46:10.742175 (delta: 0.311528)         elapsed: 58.702705 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:46:11.038774 (delta: 0.29653)         elapsed: 58.999304 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"i": "2"}, "changed": false}

TASK [Get the pvc label values from env] ***************************************
2019-06-14T06:46:11.153508 (delta: 0.114655)         elapsed: 59.114038 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pvc_lkey": "name", "pvc_lvalue": "test-pvc"}, "changed": false}

TASK [Replace the pvc label placeholder in spec] *******************************
2019-06-14T06:46:11.286535 (delta: 0.132934)         elapsed: 59.247065 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the claim name in deployment.] ************************************
2019-06-14T06:46:11.631883 (delta: 0.345193)         elapsed: 59.592413 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy the test pvc] *****************************************************
2019-06-14T06:46:11.910934 (delta: 0.278984)         elapsed: 59.871464 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n test-pvc", "delta": "0:00:01.461037", "end": "2019-06-14 06:46:13.649602", "rc": 0, "start": "2019-06-14 06:46:12.188565", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-pvc-claim-2 created", "stdout_lines": ["persistentvolumeclaim/demo-pvc-claim-2 created"]}

TASK [check if the PVC is created] *********************************************
2019-06-14T06:46:13.713664 (delta: 1.802667)         elapsed: 61.674194 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc \"demo-pvc-claim-2\" -n test-pvc -o jsonpath='{.status.phase}'", "delta": "0:00:01.269460", "end": "2019-06-14 06:46:15.280974", "rc": 0, "start": "2019-06-14 06:46:14.011514", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Check if the target pod is running] **************************************
2019-06-14T06:46:15.365733 (delta: 1.651998)         elapsed: 63.326263 ******* 
FAILED - RETRYING: Check if the target pod is running (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume-claim=\"demo-pvc-claim-2\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.180603", "end": "2019-06-14 06:46:28.375472", "rc": 0, "start": "2019-06-14 06:46:27.194869", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Revert the claim name in deployment.] ************************************
2019-06-14T06:46:28.452836 (delta: 13.087034)         elapsed: 76.413366 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Revert the label in spec file.] ******************************************
2019-06-14T06:46:28.748524 (delta: 0.295619)         elapsed: 76.709054 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:46:29.209712 (delta: 0.461064)         elapsed: 77.170242 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"i": "3"}, "changed": false}

TASK [Get the pvc label values from env] ***************************************
2019-06-14T06:46:29.341936 (delta: 0.132137)         elapsed: 77.302466 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pvc_lkey": "name", "pvc_lvalue": "test-pvc"}, "changed": false}

TASK [Replace the pvc label placeholder in spec] *******************************
2019-06-14T06:46:29.480949 (delta: 0.138911)         elapsed: 77.441479 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the claim name in deployment.] ************************************
2019-06-14T06:46:29.794505 (delta: 0.313486)         elapsed: 77.755035 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy the test pvc] *****************************************************
2019-06-14T06:46:30.130909 (delta: 0.336337)         elapsed: 78.091439 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n test-pvc", "delta": "0:00:01.429716", "end": "2019-06-14 06:46:31.814526", "rc": 0, "start": "2019-06-14 06:46:30.384810", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-pvc-claim-3 created", "stdout_lines": ["persistentvolumeclaim/demo-pvc-claim-3 created"]}

TASK [check if the PVC is created] *********************************************
2019-06-14T06:46:31.876561 (delta: 1.745583)         elapsed: 79.837091 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc \"demo-pvc-claim-3\" -n test-pvc -o jsonpath='{.status.phase}'", "delta": "0:00:01.555202", "end": "2019-06-14 06:46:33.663060", "rc": 0, "start": "2019-06-14 06:46:32.107858", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Check if the target pod is running] **************************************
2019-06-14T06:46:33.740281 (delta: 1.863639)         elapsed: 81.700811 ******* 
FAILED - RETRYING: Check if the target pod is running (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume-claim=\"demo-pvc-claim-3\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.232894", "end": "2019-06-14 06:46:47.014977", "rc": 0, "start": "2019-06-14 06:46:45.782083", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Revert the claim name in deployment.] ************************************
2019-06-14T06:46:47.084940 (delta: 13.344588)         elapsed: 95.04547 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Revert the label in spec file.] ******************************************
2019-06-14T06:46:47.390486 (delta: 0.305479)         elapsed: 95.351016 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:46:47.658127 (delta: 0.267568)         elapsed: 95.618657 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"i": "4"}, "changed": false}

TASK [Get the pvc label values from env] ***************************************
2019-06-14T06:46:47.759963 (delta: 0.101771)         elapsed: 95.720493 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pvc_lkey": "name", "pvc_lvalue": "test-pvc"}, "changed": false}

TASK [Replace the pvc label placeholder in spec] *******************************
2019-06-14T06:46:47.855765 (delta: 0.095735)         elapsed: 95.816295 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the claim name in deployment.] ************************************
2019-06-14T06:46:48.145978 (delta: 0.29015)         elapsed: 96.106508 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy the test pvc] *****************************************************
2019-06-14T06:46:48.497000 (delta: 0.350955)         elapsed: 96.45753 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n test-pvc", "delta": "0:00:01.665375", "end": "2019-06-14 06:46:50.499735", "rc": 0, "start": "2019-06-14 06:46:48.834360", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-pvc-claim-4 created", "stdout_lines": ["persistentvolumeclaim/demo-pvc-claim-4 created"]}

TASK [check if the PVC is created] *********************************************
2019-06-14T06:46:50.565509 (delta: 2.068417)         elapsed: 98.526039 ******* 
FAILED - RETRYING: check if the PVC is created (20 retries left).
FAILED - RETRYING: check if the PVC is created (19 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pvc \"demo-pvc-claim-4\" -n test-pvc -o jsonpath='{.status.phase}'", "delta": "0:00:01.393273", "end": "2019-06-14 06:47:15.925284", "rc": 0, "start": "2019-06-14 06:47:14.532011", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Check if the target pod is running] **************************************
2019-06-14T06:47:16.004159 (delta: 25.438591)         elapsed: 123.964689 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume-claim=\"demo-pvc-claim-4\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.297042", "end": "2019-06-14 06:47:17.604325", "rc": 0, "start": "2019-06-14 06:47:16.307283", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Revert the claim name in deployment.] ************************************
2019-06-14T06:47:17.674188 (delta: 1.669939)         elapsed: 125.634718 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Revert the label in spec file.] ******************************************
2019-06-14T06:47:17.965818 (delta: 0.291566)         elapsed: 125.926348 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [set_fact] ****************************************************************
2019-06-14T06:47:18.298951 (delta: 0.33307)         elapsed: 126.259481 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"i": "5"}, "changed": false}

TASK [Obtain the cstor pool pod list] ******************************************
2019-06-14T06:47:18.407459 (delta: 0.108439)         elapsed: 126.367989 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.583963", "end": "2019-06-14 06:47:20.239205", "rc": 0, "start": "2019-06-14 06:47:18.655242", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-b8hg-5f788b7cf8-5f8ln\ncstor-block-disk-pool-ir2z-788c8cbb75-rl7gw\ncstor-block-disk-pool-ry6b-6dddd56f7b-hktzj", "stdout_lines": ["cstor-block-disk-pool-b8hg-5f788b7cf8-5f8ln", "cstor-block-disk-pool-ir2z-788c8cbb75-rl7gw", "cstor-block-disk-pool-ry6b-6dddd56f7b-hktzj"]}

TASK [Obtain the PV name] ******************************************************
2019-06-14T06:47:20.312711 (delta: 1.90518)         elapsed: 128.273241 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n test-pvc -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.478731", "end": "2019-06-14 06:47:22.050863", "rc": 0, "start": "2019-06-14 06:47:20.572132", "stderr": "", "stderr_lines": [], "stdout": "pvc-0364f6eb-8e70-11e9-ab49-00505698550d\npvc-0ea6684b-8e70-11e9-ab49-00505698550d\npvc-1a1196d2-8e70-11e9-ab49-00505698550d\npvc-24e57a14-8e70-11e9-ab49-00505698550d\npvc-3005da41-8e70-11e9-ab49-00505698550d", "stdout_lines": ["pvc-0364f6eb-8e70-11e9-ab49-00505698550d", "pvc-0ea6684b-8e70-11e9-ab49-00505698550d", "pvc-1a1196d2-8e70-11e9-ab49-00505698550d", "pvc-24e57a14-8e70-11e9-ab49-00505698550d", "pvc-3005da41-8e70-11e9-ab49-00505698550d"]}

TASK [Delete the all PVC and pool pods] ****************************************
2019-06-14T06:47:22.140598 (delta: 1.827824)         elapsed: 130.101128 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs cstor-block-disk-pool-b8hg-5f788b7cf8-5f8ln && kubectl delete pvc -n test-pvc --all", "delta": "0:00:43.279234", "end": "2019-06-14 06:48:05.669214", "rc": 0, "start": "2019-06-14 06:47:22.389980", "stderr": "", "stderr_lines": [], "stdout": "pod \"cstor-block-disk-pool-b8hg-5f788b7cf8-5f8ln\" deleted\npersistentvolumeclaim \"demo-pvc-claim-0\" deleted\npersistentvolumeclaim \"demo-pvc-claim-1\" deleted\npersistentvolumeclaim \"demo-pvc-claim-2\" deleted\npersistentvolumeclaim \"demo-pvc-claim-3\" deleted\npersistentvolumeclaim \"demo-pvc-claim-4\" deleted", "stdout_lines": ["pod \"cstor-block-disk-pool-b8hg-5f788b7cf8-5f8ln\" deleted", "persistentvolumeclaim \"demo-pvc-claim-0\" deleted", "persistentvolumeclaim \"demo-pvc-claim-1\" deleted", "persistentvolumeclaim \"demo-pvc-claim-2\" deleted", "persistentvolumeclaim \"demo-pvc-claim-3\" deleted", "persistentvolumeclaim \"demo-pvc-claim-4\" deleted"]}

TASK [Check if the PVCs are deleted] *******************************************
2019-06-14T06:48:05.764668 (delta: 43.623982)         elapsed: 173.725198 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n test-pvc", "delta": "0:00:01.886303", "end": "2019-06-14 06:48:07.909026", "rc": 0, "start": "2019-06-14 06:48:06.022723", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Check if the pool pods are in Running state] *****************************
2019-06-14T06:48:07.997298 (delta: 2.232557)         elapsed: 175.957828 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.901196", "end": "2019-06-14 06:48:10.168799", "rc": 0, "start": "2019-06-14 06:48:08.267603", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Get the newly created pool pod list] *************************************
2019-06-14T06:48:10.249139 (delta: 2.251764)         elapsed: 178.209669 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.607460", "end": "2019-06-14 06:48:12.151722", "rc": 0, "start": "2019-06-14 06:48:10.544262", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-b8hg-5f788b7cf8-7hpt4\ncstor-block-disk-pool-ir2z-788c8cbb75-rl7gw\ncstor-block-disk-pool-ry6b-6dddd56f7b-hktzj", "stdout_lines": ["cstor-block-disk-pool-b8hg-5f788b7cf8-7hpt4", "cstor-block-disk-pool-ir2z-788c8cbb75-rl7gw", "cstor-block-disk-pool-ry6b-6dddd56f7b-hktzj"]}

TASK [Check if the CVRs are deleted] *******************************************
2019-06-14T06:48:12.248233 (delta: 1.999008)         elapsed: 180.208763 ****** 
FAILED - RETRYING: Check if the CVRs are deleted (12 retries left).
FAILED - RETRYING: Check if the CVRs are deleted (11 retries left).
FAILED - RETRYING: Check if the CVRs are deleted (10 retries left).
FAILED - RETRYING: Check if the CVRs are deleted (9 retries left).
changed: [127.0.0.1] => (item=pvc-0364f6eb-8e70-11e9-ab49-00505698550d) => {"attempts": 5, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-0364f6eb-8e70-11e9-ab49-00505698550d", "delta": "0:00:01.828534", "end": "2019-06-14 06:48:40.533791", "item": "pvc-0364f6eb-8e70-11e9-ab49-00505698550d", "rc": 0, "start": "2019-06-14 06:48:38.705257", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
FAILED - RETRYING: Check if the CVRs are deleted (12 retries left).
FAILED - RETRYING: Check if the CVRs are deleted (11 retries left).
FAILED - RETRYING: Check if the CVRs are deleted (10 retries left).
changed: [127.0.0.1] => (item=pvc-0ea6684b-8e70-11e9-ab49-00505698550d) => {"attempts": 4, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-0ea6684b-8e70-11e9-ab49-00505698550d", "delta": "0:00:01.254496", "end": "2019-06-14 06:49:01.956349", "item": "pvc-0ea6684b-8e70-11e9-ab49-00505698550d", "rc": 0, "start": "2019-06-14 06:49:00.701853", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-1a1196d2-8e70-11e9-ab49-00505698550d) => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-1a1196d2-8e70-11e9-ab49-00505698550d", "delta": "0:00:01.337478", "end": "2019-06-14 06:49:03.545560", "item": "pvc-1a1196d2-8e70-11e9-ab49-00505698550d", "rc": 0, "start": "2019-06-14 06:49:02.208082", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-24e57a14-8e70-11e9-ab49-00505698550d) => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-24e57a14-8e70-11e9-ab49-00505698550d", "delta": "0:00:01.480983", "end": "2019-06-14 06:49:05.278688", "item": "pvc-24e57a14-8e70-11e9-ab49-00505698550d", "rc": 0, "start": "2019-06-14 06:49:03.797705", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-3005da41-8e70-11e9-ab49-00505698550d) => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-3005da41-8e70-11e9-ab49-00505698550d", "delta": "0:00:01.434121", "end": "2019-06-14 06:49:06.937992", "item": "pvc-3005da41-8e70-11e9-ab49-00505698550d", "rc": 0, "start": "2019-06-14 06:49:05.503871", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [sleep for 30 seconds and continue with play] *****************************
2019-06-14T06:49:07.028481 (delta: 54.780183)         elapsed: 234.989011 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 30, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Check is the volumes are not present in cstor pool pods] *****************
2019-06-14T06:49:37.666862 (delta: 30.638314)         elapsed: 265.627392 ***** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-b8hg-5f788b7cf8-7hpt4) => {"changed": true, "cmd": "kubectl exec -it c -n openebs -c cstor-pool -- zfs list | grep s", "delta": "0:00:01.456988", "end": "2019-06-14 06:49:39.456124", "failed_when_result": false, "item": "cstor-block-disk-pool-b8hg-5f788b7cf8-7hpt4", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:37.999136", "stderr": "Error from server (NotFound): pods \"c\" not found", "stderr_lines": ["Error from server (NotFound): pods \"c\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ir2z-788c8cbb75-rl7gw) => {"changed": true, "cmd": "kubectl exec -it c -n openebs -c cstor-pool -- zfs list | grep s", "delta": "0:00:01.549416", "end": "2019-06-14 06:49:41.243503", "failed_when_result": false, "item": "cstor-block-disk-pool-ir2z-788c8cbb75-rl7gw", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:39.694087", "stderr": "Error from server (NotFound): pods \"c\" not found", "stderr_lines": ["Error from server (NotFound): pods \"c\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ry6b-6dddd56f7b-hktzj) => {"changed": true, "cmd": "kubectl exec -it c -n openebs -c cstor-pool -- zfs list | grep s", "delta": "0:00:01.374543", "end": "2019-06-14 06:49:42.909045", "failed_when_result": false, "item": "cstor-block-disk-pool-ry6b-6dddd56f7b-hktzj", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:41.534502", "stderr": "Error from server (NotFound): pods \"c\" not found", "stderr_lines": ["Error from server (NotFound): pods \"c\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-0364f6eb-8e70-11e9-ab49-00505698550d) => {"changed": true, "cmd": "kubectl exec -it p -n openebs -c cstor-pool -- zfs list | grep v", "delta": "0:00:01.332165", "end": "2019-06-14 06:49:44.504058", "failed_when_result": false, "item": "pvc-0364f6eb-8e70-11e9-ab49-00505698550d", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:43.171893", "stderr": "Error from server (NotFound): pods \"p\" not found", "stderr_lines": ["Error from server (NotFound): pods \"p\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-0ea6684b-8e70-11e9-ab49-00505698550d) => {"changed": true, "cmd": "kubectl exec -it p -n openebs -c cstor-pool -- zfs list | grep v", "delta": "0:00:01.445767", "end": "2019-06-14 06:49:46.172009", "failed_when_result": false, "item": "pvc-0ea6684b-8e70-11e9-ab49-00505698550d", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:44.726242", "stderr": "Error from server (NotFound): pods \"p\" not found", "stderr_lines": ["Error from server (NotFound): pods \"p\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-1a1196d2-8e70-11e9-ab49-00505698550d) => {"changed": true, "cmd": "kubectl exec -it p -n openebs -c cstor-pool -- zfs list | grep v", "delta": "0:00:01.415692", "end": "2019-06-14 06:49:47.868185", "failed_when_result": false, "item": "pvc-1a1196d2-8e70-11e9-ab49-00505698550d", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:46.452493", "stderr": "Error from server (NotFound): pods \"p\" not found", "stderr_lines": ["Error from server (NotFound): pods \"p\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-24e57a14-8e70-11e9-ab49-00505698550d) => {"changed": true, "cmd": "kubectl exec -it p -n openebs -c cstor-pool -- zfs list | grep v", "delta": "0:00:01.447530", "end": "2019-06-14 06:49:49.554980", "failed_when_result": false, "item": "pvc-24e57a14-8e70-11e9-ab49-00505698550d", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:48.107450", "stderr": "Error from server (NotFound): pods \"p\" not found", "stderr_lines": ["Error from server (NotFound): pods \"p\" not found"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=pvc-3005da41-8e70-11e9-ab49-00505698550d) => {"changed": true, "cmd": "kubectl exec -it p -n openebs -c cstor-pool -- zfs list | grep v", "delta": "0:00:01.305352", "end": "2019-06-14 06:49:51.096846", "failed_when_result": false, "item": "pvc-3005da41-8e70-11e9-ab49-00505698550d", "msg": "non-zero return code", "rc": 1, "start": "2019-06-14 06:49:49.791494", "stderr": "Error from server (NotFound): pods \"p\" not found", "stderr_lines": ["Error from server (NotFound): pods \"p\" not found"], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2019-06-14T06:49:51.209605 (delta: 13.542661)         elapsed: 279.170135 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-14T06:49:51.334227 (delta: 0.124461)         elapsed: 279.294757 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-14T06:49:51.499811 (delta: 0.165481)         elapsed: 279.460341 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-14T06:49:51.578864 (delta: 0.078964)         elapsed: 279.539394 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-14T06:49:51.647638 (delta: 0.068706)         elapsed: 279.608168 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-14T06:49:51.727682 (delta: 0.079983)         elapsed: 279.688212 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e1abe8bd2a2f830cfc7db7aaef12f016989fb74c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6874a2c194a4474c9072b13aa38aed75", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1560494991.8-210510895591677/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-14T06:49:54.582143 (delta: 2.854395)         elapsed: 282.542673 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.216504", "end": "2019-06-14 06:49:56.083339", "rc": 0, "start": "2019-06-14 06:49:54.866835", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deprovision-all-pvc \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deprovision-all-pvc ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-14T06:49:56.179661 (delta: 1.597452)         elapsed: 284.140191 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.637120", "end": "2019-06-14 06:49:58.100546", "failed_when_result": false, "rc": 0, "start": "2019-06-14 06:49:56.463426", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deprovision-all-pvc configured", "stdout_lines": ["litmusresult.litmus.io/deprovision-all-pvc configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=74   changed=52   unreachable=0    failed=0   

2019-06-14T06:49:58.146868 (delta: 1.967123)         elapsed: 286.107398 ****** 
=============================================================================== 
```