### PR TITLE
Refactored the litmus books to take sparse file count as env

### DIFF
--- a/apps/jenkins/deployers/run_litmus_test.yml
+++ b/apps/jenkins/deployers/run_litmus_test.yml
@@ -33,7 +33,7 @@ spec:
 
             # Application label
           - name: APP_LABEL
-            value: 'app=jenkins'
+            value: 'app=jenkins-app'
 
             # Affinity Label for Application
           - name: AFFINITY_LABEL

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -84,7 +84,7 @@
             path: "{{ openebs_operator }}"
             regexp: 'value: "1"'
             after: '- name: SPARSE_FILE_COUNT'
-            replace: 'value: sparse_file_count'          
+            replace: 'value: "{{ sparse_file_count }}"'          
      
         - name: Change the Node Disk manager Image
           replace:

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -77,8 +77,15 @@
             path: "{{ openebs_operator }}"
             regexp: 'value: "true"'
             after: '- name: OPENEBS_IO_ENABLE_ANALYTICS'
-            replace: 'value: "false"'          
+            replace: 'value: "false"'     
 
+        - name: Change the value of sparse file count in operator YAML
+          replace:
+            path: "{{ openebs_operator }}"
+            regexp: 'value: "1"'
+            after: '- name: SPARSE_FILE_COUNT'
+            replace: 'value: sparse_file_count'          
+     
         - name: Change the Node Disk manager Image
           replace:
             path: "{{ openebs_operator }}"

--- a/providers/openebs/installers/operator/master/ansible/vars.yaml
+++ b/providers/openebs/installers/operator/master/ansible/vars.yaml
@@ -11,3 +11,4 @@ sparse_pool_label: 'app=cstor-pool'
 installation_test_name: openebsinstaller
 cleanup_test_name: openebscleanup
 psp_spec: openebs_psp.yaml 
+sparse_file_count: "{{ lookup('env','SPARSE_FILE_COUNT') }}"

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -57,7 +57,9 @@ spec:
           - name: OPENEBS_INFRA_CHAOS
             value: 
           - name: RUN_ID
-            value:          
+            value:   
+          - name: SPARSE_FILE_COUNT
+            value: "6"       
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:


### PR DESCRIPTION
* Sparse file count is taken as env.
* Following files are modified :
             * ansible/openebs_setup.yaml
             * ansible/vars.yaml
             * litmusbook/openebs_setup.yaml

The playbooks are tested in openshift cluster. After deleting all the contents of openebs namespace, openebs namespace is also deleted. Later,  openebs_setup.yaml is applied. It pulls the docker image and creates openebs namespace with all its resources.  Here are the logs 
```
[root@master-1554817485 litmusbook]# kubectl logs litmus-openebs-setup-cgf47 -n litmus -f
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: openebs_setup.yaml ***************************************************
1 plays in ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml

PLAY [localhost] ***************************************************************
2019-06-17T08:42:36.464535 (delta: 0.090479)         elapsed: 0.090479 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:4
2019-06-17T08:42:36.485502 (delta: 0.020906)         elapsed: 0.111446 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [Record test instance/run ID] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:14
2019-06-17T08:42:47.986992 (delta: 11.501439)         elapsed: 11.612936 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:17
2019-06-17T08:42:48.094014 (delta: 0.106956)         elapsed: 11.719958 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect Start of Installation] **********
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:22
2019-06-17T08:42:48.195438 (delta: 0.10133)         elapsed: 11.821382 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "5ecda94797aa6d989ef03225f169572090e95130", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f04da1cef5f4da047dade7df612c46e", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1560760968.29-70923986644470/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:33
2019-06-17T08:42:49.203558 (delta: 1.008048)         elapsed: 12.829502 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.404049", "end": "2019-06-17 08:42:51.047877", "rc": 0, "start": "2019-06-17 08:42:49.643828", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:36
2019-06-17T08:42:51.126871 (delta: 1.923232)         elapsed: 14.752815 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.271002", "end": "2019-06-17 08:42:53.678933", "failed_when_result": false, "rc": 0, "start": "2019-06-17 08:42:51.407931", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}

TASK [Creating pod security policy, cluster role and clusterrolebinding] *******
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:48
2019-06-17T08:42:53.761228 (delta: 2.634279)         elapsed: 17.387172 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"openebs_psp.yaml\"", "delta": "0:00:01.758352", "end": "2019-06-17 08:42:55.757315", "failed_when_result": false, "rc": 0, "start": "2019-06-17 08:42:53.998963", "stderr": "", "stderr_lines": [], "stdout": "podsecuritypolicy.extensions/privileged unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-psp unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged", "stdout_lines": ["podsecuritypolicy.extensions/privileged unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-psp unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged"]}

TASK [Downloading openebs-operator.yaml] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:55
2019-06-17T08:42:55.848149 (delta: 2.086856)         elapsed: 19.474093 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "c9477e7125c6157406a49b19d47fbf4e5b515fe6", "dest": "/providers/openebs/installers/operator/master/ansible/openebs-operator.yaml", "gid": 0, "group": "root", "md5sum": "76372d1a80f514015dde6294a73b02fb", "mode": "0644", "msg": "OK (26612 bytes)", "owner": "root", "size": 26612, "src": "/root/.ansible/tmp/ansible-tmp-1560760975.94-186547815270699/tmpUN6kaR", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [Downloading openebs-storageclasses.yaml] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:65
2019-06-17T08:43:02.357527 (delta: 6.509302)         elapsed: 25.983471 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "a8aa0d7e36752b07b7061449384b341a34ad4c45", "dest": "/providers/openebs/installers/operator/master/ansible/storageclass.yaml", "gid": 0, "group": "root", "md5sum": "325c4aac8f18d22423932a4ad93137af", "mode": "0644", "msg": "OK (661 bytes)", "owner": "root", "size": 661, "src": "/root/.ansible/tmp/ansible-tmp-1560760982.44-73908831265698/tmpNEMmuW", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:75
2019-06-17T08:43:03.354941 (delta: 0.997343)         elapsed: 26.980885 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Change the value of sparse file count in operator YAML] ******************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:82
2019-06-17T08:43:03.921954 (delta: 0.566924)         elapsed: 27.547898 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the Node Disk manager Image] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:89
2019-06-17T08:43:04.241826 (delta: 0.319803)         elapsed: 27.86777 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the Node Disk operator Image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:96
2019-06-17T08:43:04.360755 (delta: 0.118846)         elapsed: 27.986699 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:103
2019-06-17T08:43:04.470499 (delta: 0.109666)         elapsed: 28.096443 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Applying openebs operator] ***********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:110
2019-06-17T08:43:04.813562 (delta: 0.342988)         elapsed: 28.439506 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f openebs-operator.yaml", "delta": "0:00:06.861546", "end": "2019-06-17 08:43:11.931066", "rc": 0, "start": "2019-06-17 08:43:05.069520", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs created\nserviceaccount/openebs-maya-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged\ndeployment.apps/maya-apiserver created\nservice/maya-apiserver-service created\ndeployment.apps/openebs-provisioner created\ndeployment.apps/openebs-snapshot-operator created\nconfigmap/openebs-ndm-config created\ndaemonset.extensions/openebs-ndm created\ndeployment.apps/openebs-ndm-operator created\nsecret/admission-server-certs created\nservice/admission-server-svc created\ndeployment.apps/openebs-admission-server created\nvalidatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged\ndeployment.apps/openebs-localpv-provisioner created", "stdout_lines": ["namespace/openebs created", "serviceaccount/openebs-maya-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "deployment.apps/maya-apiserver created", "service/maya-apiserver-service created", "deployment.apps/openebs-provisioner created", "deployment.apps/openebs-snapshot-operator created", "configmap/openebs-ndm-config created", "daemonset.extensions/openebs-ndm created", "deployment.apps/openebs-ndm-operator created", "secret/admission-server-certs created", "service/admission-server-svc created", "deployment.apps/openebs-admission-server created", "validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged", "deployment.apps/openebs-localpv-provisioner created"]}

TASK [Applying storageclasses] *************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:115
2019-06-17T08:43:12.035830 (delta: 7.222174)         elapsed: 35.661774 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f storageclass.yaml", "delta": "0:00:03.727428", "end": "2019-06-17 08:43:16.146933", "rc": 0, "start": "2019-06-17 08:43:12.419505", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-standard unchanged\nstorageclass.storage.k8s.io/openebs-standalone unchanged\nstorageclass.storage.k8s.io/openebs-mongodb unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-standard unchanged", "storageclass.storage.k8s.io/openebs-standalone unchanged", "storageclass.storage.k8s.io/openebs-mongodb unchanged"]}

TASK [Updating maya api server image] ******************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:120
2019-06-17T08:43:16.241881 (delta: 4.205981)         elapsed: 39.867825 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva controller image] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:126
2019-06-17T08:43:16.342204 (delta: 0.100235)         elapsed: 39.968148 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:132
2019-06-17T08:43:16.450509 (delta: 0.108207)         elapsed: 40.076453 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica count] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:138
2019-06-17T08:43:16.574857 (delta: 0.124262)         elapsed: 40.200801 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor target image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:144
2019-06-17T08:43:16.683292 (delta: 0.108364)         elapsed: 40.309236 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool image] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:150
2019-06-17T08:43:16.772158 (delta: 0.088795)         elapsed: 40.398102 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool management image] ****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:156
2019-06-17T08:43:16.844021 (delta: 0.071799)         elapsed: 40.469965 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume management image] **************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:162
2019-06-17T08:43:16.918557 (delta: 0.074473)         elapsed: 40.544501 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:168
2019-06-17T08:43:17.015008 (delta: 0.096361)         elapsed: 40.640952 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:174
2019-06-17T08:43:17.114310 (delta: 0.099211)         elapsed: 40.740254 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting all pods in openebs namespace] ********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:180
2019-06-17T08:43:17.210891 (delta: 0.096509)         elapsed: 40.836835 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po --all -n openebs", "delta": "0:00:43.181222", "end": "2019-06-17 08:44:01.384529", "rc": 0, "start": "2019-06-17 08:43:18.203307", "stderr": "", "stderr_lines": [], "stdout": "pod \"maya-apiserver-57886f9f9b-k65hx\" deleted\npod \"openebs-admission-server-585b45c995-7kztq\" deleted\npod \"openebs-localpv-provisioner-7f6c44d5c7-j67nq\" deleted\npod \"openebs-ndm-4pt8j\" deleted\npod \"openebs-ndm-hcq4c\" deleted\npod \"openebs-ndm-operator-78b848dbf4-btct8\" deleted\npod \"openebs-ndm-vt7h4\" deleted\npod \"openebs-provisioner-5695f8d98f-8lzv9\" deleted\npod \"openebs-snapshot-operator-7ddb4c97d-tp9jp\" deleted", "stdout_lines": ["pod \"maya-apiserver-57886f9f9b-k65hx\" deleted", "pod \"openebs-admission-server-585b45c995-7kztq\" deleted", "pod \"openebs-localpv-provisioner-7f6c44d5c7-j67nq\" deleted", "pod \"openebs-ndm-4pt8j\" deleted", "pod \"openebs-ndm-hcq4c\" deleted", "pod \"openebs-ndm-operator-78b848dbf4-btct8\" deleted", "pod \"openebs-ndm-vt7h4\" deleted", "pod \"openebs-provisioner-5695f8d98f-8lzv9\" deleted", "pod \"openebs-snapshot-operator-7ddb4c97d-tp9jp\" deleted"]}

TASK [Verify that rolling update of maya-apiserver is completed] ***************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:185
2019-06-17T08:44:01.464346 (delta: 44.253362)         elapsed: 85.09029 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver | wc -l", "delta": "0:00:01.661874", "end": "2019-06-17 08:44:03.392125", "rc": 0, "start": "2019-06-17 08:44:01.730251", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking Maya-API-Server container status] *******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:196
2019-06-17T08:44:03.491146 (delta: 2.026714)         elapsed: 87.11709 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver -o jsonpath='{.items[?(@.status.containerStatuses[*].name==\"maya-apiserver\")].status.containerStatuses[*].ready}'", "delta": "0:00:01.595790", "end": "2019-06-17 08:44:05.319934", "rc": 0, "start": "2019-06-17 08:44:03.724144", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Checking OpenEBS-provisioner is running] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:205
2019-06-17T08:44:05.406097 (delta: 1.914886)         elapsed: 89.032041 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-provisioner\")].status.phase}'", "delta": "0:00:01.675055", "end": "2019-06-17 08:44:07.353339", "rc": 0, "start": "2019-06-17 08:44:05.678284", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get maya-apiserver pod name] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:219
2019-06-17T08:44:07.439721 (delta: 2.033541)         elapsed: 91.065665 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs --no-headers --selector=name=maya-apiserver -o custom-columns=:metadata.name", "delta": "0:00:01.552706", "end": "2019-06-17 08:44:09.256007", "rc": 0, "start": "2019-06-17 08:44:07.703301", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-57886f9f9b-5zd2h", "stdout_lines": ["maya-apiserver-57886f9f9b-5zd2h"]}

TASK [Create fact for pod name] ************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:228
2019-06-17T08:44:09.342684 (delta: 1.902901)         elapsed: 92.968628 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "maya-apiserver-57886f9f9b-5zd2h"}, "changed": false}

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:232
2019-06-17T08:44:09.454928 (delta: 0.112168)         elapsed: 93.080872 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-snapshot-operator\")].status.phase}'", "delta": "0:00:01.581696", "end": "2019-06-17 08:44:11.289343", "rc": 0, "start": "2019-06-17 08:44:09.707647", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Confirm that maya-cli is available in the maya-apiserver pod] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:239
2019-06-17T08:44:11.370075 (delta: 1.915079)         elapsed: 94.996019 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec maya-apiserver-57886f9f9b-5zd2h -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:01.787562", "end": "2019-06-17 08:44:13.440885", "failed_when_result": false, "rc": 0, "start": "2019-06-17 08:44:11.653323", "stderr": "", "stderr_lines": [], "stdout": "Version: 1.1.0-unreleased\nGit commit: ba5f9937332d754cd5620ba4bbfaed3e36dbacca\nGO Version: go1.11.2\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://172.23.6.101:5656\nm-apiserver status:  running", "stdout_lines": ["Version: 1.1.0-unreleased", "Git commit: ba5f9937332d754cd5620ba4bbfaed3e36dbacca", "GO Version: go1.11.2", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://172.23.6.101:5656", "m-apiserver status:  running"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:247
2019-06-17T08:44:13.531554 (delta: 2.161412)         elapsed: 97.157498 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node --no-headers | grep -v \"master\" | wc -l", "delta": "0:00:01.490652", "end": "2019-06-17 08:44:15.261975", "rc": 0, "start": "2019-06-17 08:44:13.771323", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:253
2019-06-17T08:44:15.356315 (delta: 1.824651)         elapsed: 98.982259 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --selector=name=openebs-ndm | grep Running | wc -l", "delta": "0:00:01.751037", "end": "2019-06-17 08:44:17.413431", "rc": 0, "start": "2019-06-17 08:44:15.662394", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:279
2019-06-17T08:44:17.503029 (delta: 2.146628)         elapsed: 101.128973 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:285
2019-06-17T08:44:17.592794 (delta: 0.089701)         elapsed: 101.218738 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm CAS Templates are deployed] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:310
2019-06-17T08:44:17.686128 (delta: 0.093268)         elapsed: 101.312072 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get castemplate -n openebs", "delta": "0:00:01.673714", "end": "2019-06-17 08:44:19.619649", "rc": 0, "start": "2019-06-17 08:44:17.945935", "stderr": "", "stderr_lines": [], "stdout": "NAME                                  CREATED AT\ncas-volume-stats-default-0.9.0        9d\ncas-volume-stats-default-1.0.0        6d\ncas-volume-stats-default-1.1.0        9d\ncstor-pool-create-default-0.9.0       9d\ncstor-pool-create-default-1.0.0       6d\ncstor-pool-create-default-1.1.0       9d\ncstor-snapshot-create-default-0.9.0   9d\ncstor-snapshot-create-default-1.0.0   6d\ncstor-snapshot-create-default-1.1.0   9d\ncstor-snapshot-delete-default-0.9.0   9d\ncstor-snapshot-delete-default-1.0.0   6d\ncstor-snapshot-delete-default-1.1.0   9d\ncstor-volume-create-default-0.9.0     9d\ncstor-volume-create-default-1.0.0     6d\ncstor-volume-create-default-1.1.0     9d\ncstor-volume-delete-default-0.9.0     9d\ncstor-volume-delete-default-1.0.0     6d\ncstor-volume-delete-default-1.1.0     9d\ncstor-volume-list-default-0.9.0       9d\ncstor-volume-list-default-1.0.0       6d\ncstor-volume-list-default-1.1.0       9d\ncstor-volume-read-default-0.9.0       9d\ncstor-volume-read-default-1.0.0       6d\ncstor-volume-read-default-1.1.0       9d\njiva-snapshot-create-default-0.9.0    9d\njiva-snapshot-create-default-1.0.0    6d\njiva-snapshot-create-default-1.1.0    9d\njiva-volume-create-default-0.9.0      9d\njiva-volume-create-default-1.0.0      6d\njiva-volume-create-default-1.1.0      9d\njiva-volume-delete-default-0.6.0      9d\njiva-volume-delete-default-0.9.0      9d\njiva-volume-delete-default-1.0.0      6d\njiva-volume-delete-default-1.1.0      9d\njiva-volume-list-default-0.6.0        9d\njiva-volume-list-default-0.9.0        9d\njiva-volume-list-default-1.0.0        6d\njiva-volume-list-default-1.1.0        9d\njiva-volume-read-default-0.6.0        9d\njiva-volume-read-default-0.9.0        9d\njiva-volume-read-default-1.0.0        6d\njiva-volume-read-default-1.1.0        9d\nstorage-pool-list-default-0.9.0       9d\nstorage-pool-list-default-1.0.0       6d\nstorage-pool-list-default-1.1.0       9d\nstorage-pool-read-default-0.9.0       9d\nstorage-pool-read-default-1.0.0       6d\nstorage-pool-read-default-1.1.0       9d", "stdout_lines": ["NAME                                  CREATED AT", "cas-volume-stats-default-0.9.0        9d", "cas-volume-stats-default-1.0.0        6d", "cas-volume-stats-default-1.1.0        9d", "cstor-pool-create-default-0.9.0       9d", "cstor-pool-create-default-1.0.0       6d", "cstor-pool-create-default-1.1.0       9d", "cstor-snapshot-create-default-0.9.0   9d", "cstor-snapshot-create-default-1.0.0   6d", "cstor-snapshot-create-default-1.1.0   9d", "cstor-snapshot-delete-default-0.9.0   9d", "cstor-snapshot-delete-default-1.0.0   6d", "cstor-snapshot-delete-default-1.1.0   9d", "cstor-volume-create-default-0.9.0     9d", "cstor-volume-create-default-1.0.0     6d", "cstor-volume-create-default-1.1.0     9d", "cstor-volume-delete-default-0.9.0     9d", "cstor-volume-delete-default-1.0.0     6d", "cstor-volume-delete-default-1.1.0     9d", "cstor-volume-list-default-0.9.0       9d", "cstor-volume-list-default-1.0.0       6d", "cstor-volume-list-default-1.1.0       9d", "cstor-volume-read-default-0.9.0       9d", "cstor-volume-read-default-1.0.0       6d", "cstor-volume-read-default-1.1.0       9d", "jiva-snapshot-create-default-0.9.0    9d", "jiva-snapshot-create-default-1.0.0    6d", "jiva-snapshot-create-default-1.1.0    9d", "jiva-volume-create-default-0.9.0      9d", "jiva-volume-create-default-1.0.0      6d", "jiva-volume-create-default-1.1.0      9d", "jiva-volume-delete-default-0.6.0      9d", "jiva-volume-delete-default-0.9.0      9d", "jiva-volume-delete-default-1.0.0      6d", "jiva-volume-delete-default-1.1.0      9d", "jiva-volume-list-default-0.6.0        9d", "jiva-volume-list-default-0.9.0        9d", "jiva-volume-list-default-1.0.0        6d", "jiva-volume-list-default-1.1.0        9d", "jiva-volume-read-default-0.6.0        9d", "jiva-volume-read-default-0.9.0        9d", "jiva-volume-read-default-1.0.0        6d", "jiva-volume-read-default-1.1.0        9d", "storage-pool-list-default-0.9.0       9d", "storage-pool-list-default-1.0.0       6d", "storage-pool-list-default-1.1.0       9d", "storage-pool-read-default-0.9.0       9d", "storage-pool-read-default-1.0.0       6d", "storage-pool-read-default-1.1.0       9d"]}

TASK [set_fact] ****************************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:319
2019-06-17T08:44:19.714303 (delta: 2.028107)         elapsed: 103.340247 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect End of Installation] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:327
2019-06-17T08:44:19.821575 (delta: 0.107183)         elapsed: 103.447519 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "42e0ea578ffa4a1a9cda422fa345344dcc5667c9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c579bb9e9e52957afe03dfa862f9b3e2", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1560761059.9-73897216273377/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:338
2019-06-17T08:44:23.204993 (delta: 3.383277)         elapsed: 106.830937 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.426506", "end": "2019-06-17 08:44:24.903898", "rc": 0, "start": "2019-06-17 08:44:23.477392", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:341
2019-06-17T08:44:24.983504 (delta: 1.778427)         elapsed: 108.609448 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.855432", "end": "2019-06-17 08:44:27.130973", "failed_when_result": false, "rc": 0, "start": "2019-06-17 08:44:25.275541", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=23   unreachable=0    failed=0   

2019-06-17T08:44:27.193211 (delta: 2.20964)         elapsed: 110.819155 ******* 
=============================================================================== 
```
Now openebs namespace can be found.
```
[root@master-1554817485 litmusbook]# kubectl get ns
NAME                                STATUS    AGE
default                             Active    67d
kube-public                         Active    67d
kube-service-catalog                Active    67d
kube-system                         Active    67d
litmus                              Active    13m
management-infra                    Active    67d
maya-system                         Active    6d
memleak                             Active    7d
openebs                             Active    2m
openshift                           Active    67d
openshift-ansible-service-broker    Active    67d
openshift-infra                     Active    67d
openshift-logging                   Active    67d
openshift-node                      Active    67d
openshift-sdn                       Active    67d
openshift-template-service-broker   Active    67d
openshift-web-console               Active    67d
test-pvc                            Active    3d
```
```
[root@master-1554817485 litmusbook]# kubectl get bd -n openebs
NAME                                           AGE
blockdevice-592f162914abf0c392bea480845d8422   3m
blockdevice-6911d32fb9e9d958966e09b373fd679c   3m
blockdevice-6d77e19f09d49a1b9395779f150e8de5   3m
sparse-01a34b4bcc85881ab3a985a5ff37ed79        3m
sparse-094507bb8c5d1d3299f191ae8ff12e5a        3m
sparse-2160dd2d8563a7c882fbde7b2c4db0ee        3m
sparse-297500cba5def4cd6fb394bf1480bc8a        3m
sparse-4a43425e9b9232dd93c3a6ee8d64d811        3m
sparse-6de5ca4002054f7aee8ce5c3b5c3c7c9        3m
sparse-77a895e87070261d6ec4b2839cc7c47e        3m
sparse-7a998823d247f4e935d5d3f0b7bb1315        3m
sparse-8bd5ff5d334570b00e4525b3941eb3d6        3m
sparse-8c08761881790d3b3a2e1428c13f8741        3m
sparse-90599ef3f286fb9aa04b71b0a669f1db        3m
sparse-9073379a92949af0d658ca43df5b8eeb        3m
sparse-9fdd7f50a2a01f93ed091d210e98f98b        3m
sparse-a419a9ae6e5e0df6965f4d9d99f98e13        3m
sparse-aeb96a986ffe3c34906749a10389e910        3m
sparse-c9e56ec334118f6984132695b7d8b74d        3m
sparse-dac5bbd59cf92a43b4c7757c781b240c        3m
sparse-f01a04cdccd3d75e7ed2ef99950b2fa4        3m
```