### PR TITLE
Refactored ansible playbooks to take analytics val as env

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -105,8 +105,8 @@
             path: "{{ openebs_operator }}"
             regexp: 'value: "false"'
             after: '- name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL'
-            replace: 'value: "{{ analytics_value }}"'  
-          when: lookup('env','ANALYTICS_VALUE') | length > 0             
+            replace: 'value: "{{ install_default_csp }}"'  
+          when: lookup('env','INSTALL_DEFAULT_CSP') | length > 0             
 
         - name: Applying openebs operator
           shell: "{{ kubeapply }} apply -f {{ openebs_operator }}"

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -105,7 +105,8 @@
             path: "{{ openebs_operator }}"
             regexp: 'value: "false"'
             after: '- name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL'
-            replace: 'value: "true"'          
+            replace: 'value: "{{ analytics_value }}"'  
+          when: lookup('env','ANALYTICS_VALUE') != ''       
 
         - name: Applying openebs operator
           shell: "{{ kubeapply }} apply -f {{ openebs_operator }}"

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -106,7 +106,7 @@
             regexp: 'value: "false"'
             after: '- name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL'
             replace: 'value: "{{ analytics_value }}"'  
-          when: lookup('env','ANALYTICS_VALUE') != ''       
+          when: lookup('env','ANALYTICS_VALUE') | length > 0             
 
         - name: Applying openebs operator
           shell: "{{ kubeapply }} apply -f {{ openebs_operator }}"

--- a/providers/openebs/installers/operator/master/ansible/vars.yaml
+++ b/providers/openebs/installers/operator/master/ansible/vars.yaml
@@ -12,4 +12,4 @@ installation_test_name: openebsinstaller
 cleanup_test_name: openebscleanup
 psp_spec: openebs_psp.yaml 
 sparse_file_count: "{{ lookup('env','SPARSE_FILE_COUNT') }}"
-analytics_value: "{{ lookup('env', 'ANALYTICS_VALUE') }}"
+analytics_value: "{{ lookup('env','ANALYTICS_VALUE') }}"

--- a/providers/openebs/installers/operator/master/ansible/vars.yaml
+++ b/providers/openebs/installers/operator/master/ansible/vars.yaml
@@ -12,3 +12,4 @@ installation_test_name: openebsinstaller
 cleanup_test_name: openebscleanup
 psp_spec: openebs_psp.yaml 
 sparse_file_count: "{{ lookup('env','SPARSE_FILE_COUNT') }}"
+analytics_value: "{{ lookup('env', 'ANALYTICS_VALUE') }}"

--- a/providers/openebs/installers/operator/master/ansible/vars.yaml
+++ b/providers/openebs/installers/operator/master/ansible/vars.yaml
@@ -12,4 +12,4 @@ installation_test_name: openebsinstaller
 cleanup_test_name: openebscleanup
 psp_spec: openebs_psp.yaml 
 sparse_file_count: "{{ lookup('env','SPARSE_FILE_COUNT') }}"
-analytics_value: "{{ lookup('env','ANALYTICS_VALUE') }}"
+install_default_csp: "{{ lookup('env','INSTALL_DEFAULT_CSP') }}"

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -61,7 +61,7 @@ spec:
           - name: SPARSE_FILE_COUNT
             value: "10" 
           - name: ANALYTICS_VALUE
-            value: "true"       
+            value: ""       
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -61,7 +61,7 @@ spec:
           - name: SPARSE_FILE_COUNT
             value: "10" 
           - name: ANALYTICS_VALUE
-            value: ""       
+            value:      
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -59,7 +59,9 @@ spec:
           - name: RUN_ID
             value:   
           - name: SPARSE_FILE_COUNT
-            value: "6"       
+            value: "10" 
+          - name: ANALYTICS_VALUE
+            value: "true"       
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -60,7 +60,7 @@ spec:
             value:   
           - name: SPARSE_FILE_COUNT
             value: "10" 
-          - name: ANALYTICS_VALUE
+          - name: INSTALL_DEFAULT_CSP
             value:      
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]


### PR DESCRIPTION
* Modified ansible playbooks to take analytics value as env.
* Following files modified:
  	modified:   ansible/openebs_setup.yaml
	modified:   ansible/vars.yaml
	modified:   litmusbook/openebs_setup.yaml

Here are the logs when  ANALYTICS_VALUE is not null
```
[root@master-1554817485 litmusbook]# kubectl logs litmus-openebs-setup-24dtf -n litmus -f
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: openebs_setup.yaml ***************************************************
1 plays in ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml

PLAY [localhost] ***************************************************************
2019-06-17T09:31:31.334177 (delta: 0.073032)         elapsed: 0.073032 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:4
2019-06-17T09:31:31.358861 (delta: 0.02462)         elapsed: 0.097716 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [Record test instance/run ID] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:14
2019-06-17T09:31:41.672033 (delta: 10.313125)         elapsed: 10.410888 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:17
2019-06-17T09:31:41.754236 (delta: 0.082153)         elapsed: 10.493091 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect Start of Installation] **********
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:22
2019-06-17T09:31:41.824268 (delta: 0.069948)         elapsed: 10.563123 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "5ecda94797aa6d989ef03225f169572090e95130", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f04da1cef5f4da047dade7df612c46e", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1560763901.89-27327053840560/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:33
2019-06-17T09:31:42.789225 (delta: 0.964897)         elapsed: 11.52808 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.209420", "end": "2019-06-17 09:31:44.451840", "rc": 0, "start": "2019-06-17 09:31:43.242420", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:36
2019-06-17T09:31:44.532765 (delta: 1.74347)         elapsed: 13.27162 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.818537", "end": "2019-06-17 09:31:46.591897", "failed_when_result": false, "rc": 0, "start": "2019-06-17 09:31:44.773360", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}

TASK [Creating pod security policy, cluster role and clusterrolebinding] *******
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:48
2019-06-17T09:31:46.660294 (delta: 2.127451)         elapsed: 15.399149 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"openebs_psp.yaml\"", "delta": "0:00:01.690507", "end": "2019-06-17 09:31:48.576533", "failed_when_result": false, "rc": 0, "start": "2019-06-17 09:31:46.886026", "stderr": "", "stderr_lines": [], "stdout": "podsecuritypolicy.extensions/privileged unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-psp unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged", "stdout_lines": ["podsecuritypolicy.extensions/privileged unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-psp unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged"]}

TASK [Downloading openebs-operator.yaml] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:55
2019-06-17T09:31:48.644283 (delta: 1.983929)         elapsed: 17.383138 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "c9477e7125c6157406a49b19d47fbf4e5b515fe6", "dest": "/providers/openebs/installers/operator/master/ansible/openebs-operator.yaml", "gid": 0, "group": "root", "md5sum": "76372d1a80f514015dde6294a73b02fb", "mode": "0644", "msg": "OK (26612 bytes)", "owner": "root", "size": 26612, "src": "/root/.ansible/tmp/ansible-tmp-1560763908.74-210848542336617/tmp8izVDR", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [Downloading openebs-storageclasses.yaml] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:65
2019-06-17T09:31:55.014405 (delta: 6.370057)         elapsed: 23.75326 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "a8aa0d7e36752b07b7061449384b341a34ad4c45", "dest": "/providers/openebs/installers/operator/master/ansible/storageclass.yaml", "gid": 0, "group": "root", "md5sum": "325c4aac8f18d22423932a4ad93137af", "mode": "0644", "msg": "OK (661 bytes)", "owner": "root", "size": 661, "src": "/root/.ansible/tmp/ansible-tmp-1560763915.1-275353656278884/tmpEhUmTB", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:75
2019-06-17T09:31:55.956897 (delta: 0.942405)         elapsed: 24.695752 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Change the value of sparse file count in operator YAML] ******************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:82
2019-06-17T09:31:56.510487 (delta: 0.553504)         elapsed: 25.249342 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the Node Disk manager Image] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:89
2019-06-17T09:31:56.810964 (delta: 0.300391)         elapsed: 25.549819 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the Node Disk operator Image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:96
2019-06-17T09:31:56.893870 (delta: 0.082842)         elapsed: 25.632725 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:103
2019-06-17T09:31:56.965583 (delta: 0.071631)         elapsed: 25.704438 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Applying openebs operator] ***********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:110
2019-06-17T09:31:57.303206 (delta: 0.337231)         elapsed: 26.042061 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f openebs-operator.yaml", "delta": "0:00:08.151919", "end": "2019-06-17 09:32:05.728012", "rc": 0, "start": "2019-06-17 09:31:57.576093", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs created\nserviceaccount/openebs-maya-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged\ndeployment.apps/maya-apiserver created\nservice/maya-apiserver-service created\ndeployment.apps/openebs-provisioner created\ndeployment.apps/openebs-snapshot-operator created\nconfigmap/openebs-ndm-config created\ndaemonset.extensions/openebs-ndm created\ndeployment.apps/openebs-ndm-operator created\nsecret/admission-server-certs created\nservice/admission-server-svc created\ndeployment.apps/openebs-admission-server created\nvalidatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged\ndeployment.apps/openebs-localpv-provisioner created", "stdout_lines": ["namespace/openebs created", "serviceaccount/openebs-maya-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "deployment.apps/maya-apiserver created", "service/maya-apiserver-service created", "deployment.apps/openebs-provisioner created", "deployment.apps/openebs-snapshot-operator created", "configmap/openebs-ndm-config created", "daemonset.extensions/openebs-ndm created", "deployment.apps/openebs-ndm-operator created", "secret/admission-server-certs created", "service/admission-server-svc created", "deployment.apps/openebs-admission-server created", "validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged", "deployment.apps/openebs-localpv-provisioner created"]}

TASK [Applying storageclasses] *************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:115
2019-06-17T09:32:05.822380 (delta: 8.519096)         elapsed: 34.561235 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f storageclass.yaml", "delta": "0:00:02.848168", "end": "2019-06-17 09:32:08.951141", "rc": 0, "start": "2019-06-17 09:32:06.102973", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-standard unchanged\nstorageclass.storage.k8s.io/openebs-standalone unchanged\nstorageclass.storage.k8s.io/openebs-mongodb unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-standard unchanged", "storageclass.storage.k8s.io/openebs-standalone unchanged", "storageclass.storage.k8s.io/openebs-mongodb unchanged"]}

TASK [Updating maya api server image] ******************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:120
2019-06-17T09:32:09.015019 (delta: 3.19257)         elapsed: 37.753874 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva controller image] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:126
2019-06-17T09:32:09.142575 (delta: 0.127487)         elapsed: 37.88143 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:132
2019-06-17T09:32:09.245674 (delta: 0.102982)         elapsed: 37.984529 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica count] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:138
2019-06-17T09:32:09.349959 (delta: 0.104205)         elapsed: 38.088814 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor target image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:144
2019-06-17T09:32:09.461348 (delta: 0.111302)         elapsed: 38.200203 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool image] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:150
2019-06-17T09:32:09.571809 (delta: 0.110392)         elapsed: 38.310664 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool management image] ****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:156
2019-06-17T09:32:09.670042 (delta: 0.098135)         elapsed: 38.408897 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume management image] **************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:162
2019-06-17T09:32:09.744715 (delta: 0.074592)         elapsed: 38.48357 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:168
2019-06-17T09:32:09.847412 (delta: 0.102628)         elapsed: 38.586267 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:174
2019-06-17T09:32:09.931157 (delta: 0.083676)         elapsed: 38.670012 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting all pods in openebs namespace] ********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:180
2019-06-17T09:32:10.018022 (delta: 0.086795)         elapsed: 38.756877 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po --all -n openebs", "delta": "0:01:52.077561", "end": "2019-06-17 09:34:02.387342", "rc": 0, "start": "2019-06-17 09:32:10.309781", "stderr": "", "stderr_lines": [], "stdout": "pod \"maya-apiserver-57886f9f9b-dpdph\" deleted\npod \"openebs-admission-server-585b45c995-gd579\" deleted\npod \"openebs-localpv-provisioner-7f6c44d5c7-k4sbf\" deleted\npod \"openebs-ndm-operator-78b848dbf4-2w8bd\" deleted\npod \"openebs-ndm-qfbmn\" deleted\npod \"openebs-ndm-rssw7\" deleted\npod \"openebs-ndm-v2wlh\" deleted\npod \"openebs-provisioner-5695f8d98f-q8qt8\" deleted\npod \"openebs-snapshot-operator-7ddb4c97d-7cnk6\" deleted", "stdout_lines": ["pod \"maya-apiserver-57886f9f9b-dpdph\" deleted", "pod \"openebs-admission-server-585b45c995-gd579\" deleted", "pod \"openebs-localpv-provisioner-7f6c44d5c7-k4sbf\" deleted", "pod \"openebs-ndm-operator-78b848dbf4-2w8bd\" deleted", "pod \"openebs-ndm-qfbmn\" deleted", "pod \"openebs-ndm-rssw7\" deleted", "pod \"openebs-ndm-v2wlh\" deleted", "pod \"openebs-provisioner-5695f8d98f-q8qt8\" deleted", "pod \"openebs-snapshot-operator-7ddb4c97d-7cnk6\" deleted"]}

TASK [Verify that rolling update of maya-apiserver is completed] ***************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:185
2019-06-17T09:34:02.464256 (delta: 112.446165)         elapsed: 151.203111 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver | wc -l", "delta": "0:00:01.391096", "end": "2019-06-17 09:34:04.126969", "rc": 0, "start": "2019-06-17 09:34:02.735873", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking Maya-API-Server container status] *******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:196
2019-06-17T09:34:04.230846 (delta: 1.766485)         elapsed: 152.969701 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver -o jsonpath='{.items[?(@.status.containerStatuses[*].name==\"maya-apiserver\")].status.containerStatuses[*].ready}'", "delta": "0:00:01.396232", "end": "2019-06-17 09:34:05.919021", "rc": 0, "start": "2019-06-17 09:34:04.522789", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Checking OpenEBS-provisioner is running] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:205
2019-06-17T09:34:06.022091 (delta: 1.791152)         elapsed: 154.760946 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-provisioner\")].status.phase}'", "delta": "0:00:01.620988", "end": "2019-06-17 09:34:07.924949", "rc": 0, "start": "2019-06-17 09:34:06.303961", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get maya-apiserver pod name] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:219
2019-06-17T09:34:08.007539 (delta: 1.985348)         elapsed: 156.746394 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs --no-headers --selector=name=maya-apiserver -o custom-columns=:metadata.name", "delta": "0:00:01.528699", "end": "2019-06-17 09:34:09.829290", "rc": 0, "start": "2019-06-17 09:34:08.300591", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-57886f9f9b-4qkzf", "stdout_lines": ["maya-apiserver-57886f9f9b-4qkzf"]}

TASK [Create fact for pod name] ************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:228
2019-06-17T09:34:09.917535 (delta: 1.909872)         elapsed: 158.65639 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "maya-apiserver-57886f9f9b-4qkzf"}, "changed": false}

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:232
2019-06-17T09:34:10.023086 (delta: 0.10545)         elapsed: 158.761941 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-snapshot-operator\")].status.phase}'", "delta": "0:00:01.602743", "end": "2019-06-17 09:34:11.957474", "rc": 0, "start": "2019-06-17 09:34:10.354731", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Confirm that maya-cli is available in the maya-apiserver pod] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:239
2019-06-17T09:34:12.067571 (delta: 2.044408)         elapsed: 160.806426 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec maya-apiserver-57886f9f9b-4qkzf -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:02.186940", "end": "2019-06-17 09:34:14.541970", "failed_when_result": false, "rc": 0, "start": "2019-06-17 09:34:12.355030", "stderr": "", "stderr_lines": [], "stdout": "Version: 1.1.0-unreleased\nGit commit: ba5f9937332d754cd5620ba4bbfaed3e36dbacca\nGO Version: go1.11.2\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://172.23.6.107:5656\nm-apiserver status:  running", "stdout_lines": ["Version: 1.1.0-unreleased", "Git commit: ba5f9937332d754cd5620ba4bbfaed3e36dbacca", "GO Version: go1.11.2", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://172.23.6.107:5656", "m-apiserver status:  running"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:247
2019-06-17T09:34:14.645590 (delta: 2.577887)         elapsed: 163.384445 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node --no-headers | grep -v \"master\" | wc -l", "delta": "0:00:01.492260", "end": "2019-06-17 09:34:16.415082", "rc": 0, "start": "2019-06-17 09:34:14.922822", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:253
2019-06-17T09:34:16.483338 (delta: 1.837622)         elapsed: 165.222193 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --selector=name=openebs-ndm | grep Running | wc -l", "delta": "0:00:01.607437", "end": "2019-06-17 09:34:18.354821", "rc": 0, "start": "2019-06-17 09:34:16.747384", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:279
2019-06-17T09:34:18.464917 (delta: 1.981508)         elapsed: 167.203772 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:285
2019-06-17T09:34:18.565431 (delta: 0.100441)         elapsed: 167.304286 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm CAS Templates are deployed] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:310
2019-06-17T09:34:18.639798 (delta: 0.074266)         elapsed: 167.378653 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get castemplate -n openebs", "delta": "0:00:01.520631", "end": "2019-06-17 09:34:20.432970", "rc": 0, "start": "2019-06-17 09:34:18.912339", "stderr": "", "stderr_lines": [], "stdout": "NAME                                  CREATED AT\ncas-volume-stats-default-0.9.0        9d\ncas-volume-stats-default-1.0.0        6d\ncas-volume-stats-default-1.1.0        9d\ncstor-pool-create-default-0.9.0       9d\ncstor-pool-create-default-1.0.0       6d\ncstor-pool-create-default-1.1.0       9d\ncstor-snapshot-create-default-0.9.0   9d\ncstor-snapshot-create-default-1.0.0   6d\ncstor-snapshot-create-default-1.1.0   9d\ncstor-snapshot-delete-default-0.9.0   9d\ncstor-snapshot-delete-default-1.0.0   6d\ncstor-snapshot-delete-default-1.1.0   9d\ncstor-volume-create-default-0.9.0     9d\ncstor-volume-create-default-1.0.0     6d\ncstor-volume-create-default-1.1.0     9d\ncstor-volume-delete-default-0.9.0     9d\ncstor-volume-delete-default-1.0.0     6d\ncstor-volume-delete-default-1.1.0     9d\ncstor-volume-list-default-0.9.0       9d\ncstor-volume-list-default-1.0.0       6d\ncstor-volume-list-default-1.1.0       9d\ncstor-volume-read-default-0.9.0       9d\ncstor-volume-read-default-1.0.0       6d\ncstor-volume-read-default-1.1.0       9d\njiva-snapshot-create-default-0.9.0    9d\njiva-snapshot-create-default-1.0.0    6d\njiva-snapshot-create-default-1.1.0    9d\njiva-volume-create-default-0.9.0      9d\njiva-volume-create-default-1.0.0      6d\njiva-volume-create-default-1.1.0      9d\njiva-volume-delete-default-0.6.0      9d\njiva-volume-delete-default-0.9.0      9d\njiva-volume-delete-default-1.0.0      6d\njiva-volume-delete-default-1.1.0      9d\njiva-volume-list-default-0.6.0        9d\njiva-volume-list-default-0.9.0        9d\njiva-volume-list-default-1.0.0        6d\njiva-volume-list-default-1.1.0        9d\njiva-volume-read-default-0.6.0        9d\njiva-volume-read-default-0.9.0        9d\njiva-volume-read-default-1.0.0        6d\njiva-volume-read-default-1.1.0        9d\nstorage-pool-list-default-0.9.0       9d\nstorage-pool-list-default-1.0.0       6d\nstorage-pool-list-default-1.1.0       9d\nstorage-pool-read-default-0.9.0       9d\nstorage-pool-read-default-1.0.0       6d\nstorage-pool-read-default-1.1.0       9d", "stdout_lines": ["NAME                                  CREATED AT", "cas-volume-stats-default-0.9.0        9d", "cas-volume-stats-default-1.0.0        6d", "cas-volume-stats-default-1.1.0        9d", "cstor-pool-create-default-0.9.0       9d", "cstor-pool-create-default-1.0.0       6d", "cstor-pool-create-default-1.1.0       9d", "cstor-snapshot-create-default-0.9.0   9d", "cstor-snapshot-create-default-1.0.0   6d", "cstor-snapshot-create-default-1.1.0   9d", "cstor-snapshot-delete-default-0.9.0   9d", "cstor-snapshot-delete-default-1.0.0   6d", "cstor-snapshot-delete-default-1.1.0   9d", "cstor-volume-create-default-0.9.0     9d", "cstor-volume-create-default-1.0.0     6d", "cstor-volume-create-default-1.1.0     9d", "cstor-volume-delete-default-0.9.0     9d", "cstor-volume-delete-default-1.0.0     6d", "cstor-volume-delete-default-1.1.0     9d", "cstor-volume-list-default-0.9.0       9d", "cstor-volume-list-default-1.0.0       6d", "cstor-volume-list-default-1.1.0       9d", "cstor-volume-read-default-0.9.0       9d", "cstor-volume-read-default-1.0.0       6d", "cstor-volume-read-default-1.1.0       9d", "jiva-snapshot-create-default-0.9.0    9d", "jiva-snapshot-create-default-1.0.0    6d", "jiva-snapshot-create-default-1.1.0    9d", "jiva-volume-create-default-0.9.0      9d", "jiva-volume-create-default-1.0.0      6d", "jiva-volume-create-default-1.1.0      9d", "jiva-volume-delete-default-0.6.0      9d", "jiva-volume-delete-default-0.9.0      9d", "jiva-volume-delete-default-1.0.0      6d", "jiva-volume-delete-default-1.1.0      9d", "jiva-volume-list-default-0.6.0        9d", "jiva-volume-list-default-0.9.0        9d", "jiva-volume-list-default-1.0.0        6d", "jiva-volume-list-default-1.1.0        9d", "jiva-volume-read-default-0.6.0        9d", "jiva-volume-read-default-0.9.0        9d", "jiva-volume-read-default-1.0.0        6d", "jiva-volume-read-default-1.1.0        9d", "storage-pool-list-default-0.9.0       9d", "storage-pool-list-default-1.0.0       6d", "storage-pool-list-default-1.1.0       9d", "storage-pool-read-default-0.9.0       9d", "storage-pool-read-default-1.0.0       6d", "storage-pool-read-default-1.1.0       9d"]}

TASK [set_fact] ****************************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:319
2019-06-17T09:34:20.547042 (delta: 1.907178)         elapsed: 169.285897 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect End of Installation] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:327
2019-06-17T09:34:20.675380 (delta: 0.128236)         elapsed: 169.414235 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "42e0ea578ffa4a1a9cda422fa345344dcc5667c9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c579bb9e9e52957afe03dfa862f9b3e2", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1560764060.74-178417180435895/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:338
2019-06-17T09:34:23.878689 (delta: 3.203242)         elapsed: 172.617544 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.274258", "end": "2019-06-17 09:34:25.397944", "rc": 0, "start": "2019-06-17 09:34:24.123686", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:341
2019-06-17T09:34:25.474136 (delta: 1.595376)         elapsed: 174.212991 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.163480", "end": "2019-06-17 09:34:27.903067", "failed_when_result": false, "rc": 0, "start": "2019-06-17 09:34:25.739587", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=23   unreachable=0    failed=0   

```
```
[root@master-1554817485 litmusbook]# kubectl get bd -n openebs
NAME                                           AGE
blockdevice-592f162914abf0c392bea480845d8422   3m
blockdevice-6911d32fb9e9d958966e09b373fd679c   3m
blockdevice-6d77e19f09d49a1b9395779f150e8de5   3m
sparse-01a34b4bcc85881ab3a985a5ff37ed79        3m
sparse-094507bb8c5d1d3299f191ae8ff12e5a        3m
sparse-2160dd2d8563a7c882fbde7b2c4db0ee        3m
sparse-297500cba5def4cd6fb394bf1480bc8a        3m
sparse-4a43425e9b9232dd93c3a6ee8d64d811        3m
sparse-6de5ca4002054f7aee8ce5c3b5c3c7c9        3m
sparse-77a895e87070261d6ec4b2839cc7c47e        3m
sparse-7a998823d247f4e935d5d3f0b7bb1315        3m
sparse-8bd5ff5d334570b00e4525b3941eb3d6        3m
sparse-8c08761881790d3b3a2e1428c13f8741        3m
sparse-90599ef3f286fb9aa04b71b0a669f1db        3m
sparse-9073379a92949af0d658ca43df5b8eeb        3m
sparse-9fdd7f50a2a01f93ed091d210e98f98b        3m
sparse-a419a9ae6e5e0df6965f4d9d99f98e13        3m
sparse-aeb96a986ffe3c34906749a10389e910        3m
sparse-c9e56ec334118f6984132695b7d8b74d        3m
sparse-dac5bbd59cf92a43b4c7757c781b240c        3m
sparse-f01a04cdccd3d75e7ed2ef99950b2fa4        3m
```
Here are the logs when ANALYTICS_VALUE is null
```
[root@master-1554817485 litmusbook]# kubectl logs litmus-openebs-setup-222wk -n litmus -f
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: openebs_setup.yaml ***************************************************
1 plays in ./providers/openebs/installers/operator/master/ansible/openebs_setup.yaml

PLAY [localhost] ***************************************************************
2019-06-17T11:28:58.795634 (delta: 0.087646)         elapsed: 0.087646 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:4
2019-06-17T11:28:58.815432 (delta: 0.019689)         elapsed: 0.107444 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [Record test instance/run ID] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:14
2019-06-17T11:29:09.491906 (delta: 10.676436)         elapsed: 10.783918 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:17
2019-06-17T11:29:09.592397 (delta: 0.100436)         elapsed: 10.884409 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect Start of Installation] **********
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:22
2019-06-17T11:29:09.682114 (delta: 0.089638)         elapsed: 10.974126 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "5ecda94797aa6d989ef03225f169572090e95130", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f04da1cef5f4da047dade7df612c46e", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1560770949.76-44203886383726/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:33
2019-06-17T11:29:10.791497 (delta: 1.10931)         elapsed: 12.083509 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.204303", "end": "2019-06-17 11:29:12.454085", "rc": 0, "start": "2019-06-17 11:29:11.249782", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:36
2019-06-17T11:29:12.531090 (delta: 1.739524)         elapsed: 13.823102 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.129811", "end": "2019-06-17 11:29:14.897757", "failed_when_result": false, "rc": 0, "start": "2019-06-17 11:29:12.767946", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}

TASK [Creating pod security policy, cluster role and clusterrolebinding] *******
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:48
2019-06-17T11:29:14.988058 (delta: 2.456881)         elapsed: 16.28007 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"openebs_psp.yaml\"", "delta": "0:00:01.521174", "end": "2019-06-17 11:29:16.768296", "failed_when_result": false, "rc": 0, "start": "2019-06-17 11:29:15.247122", "stderr": "", "stderr_lines": [], "stdout": "podsecuritypolicy.extensions/privileged unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-psp unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged", "stdout_lines": ["podsecuritypolicy.extensions/privileged unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-psp unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged"]}

TASK [Downloading openebs-operator.yaml] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:55
2019-06-17T11:29:16.843666 (delta: 1.855535)         elapsed: 18.135678 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "c9477e7125c6157406a49b19d47fbf4e5b515fe6", "dest": "/providers/openebs/installers/operator/master/ansible/openebs-operator.yaml", "gid": 0, "group": "root", "md5sum": "76372d1a80f514015dde6294a73b02fb", "mode": "0644", "msg": "OK (26612 bytes)", "owner": "root", "size": 26612, "src": "/root/.ansible/tmp/ansible-tmp-1560770956.95-240837445381306/tmpOKzCAR", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [Downloading openebs-storageclasses.yaml] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:65
2019-06-17T11:29:23.256236 (delta: 6.41249)         elapsed: 24.548248 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "a8aa0d7e36752b07b7061449384b341a34ad4c45", "dest": "/providers/openebs/installers/operator/master/ansible/storageclass.yaml", "gid": 0, "group": "root", "md5sum": "325c4aac8f18d22423932a4ad93137af", "mode": "0644", "msg": "OK (661 bytes)", "owner": "root", "size": 661, "src": "/root/.ansible/tmp/ansible-tmp-1560770963.34-777933302683/tmpNMYK97", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:75
2019-06-17T11:29:24.273011 (delta: 1.016692)         elapsed: 25.565023 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Change the value of sparse file count in operator YAML] ******************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:82
2019-06-17T11:29:24.862222 (delta: 0.589106)         elapsed: 26.154234 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the Node Disk manager Image] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:89
2019-06-17T11:29:25.236024 (delta: 0.373739)         elapsed: 26.528036 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the Node Disk operator Image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:96
2019-06-17T11:29:25.321401 (delta: 0.085309)         elapsed: 26.613413 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:103
2019-06-17T11:29:25.416558 (delta: 0.095088)         elapsed: 26.70857 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Applying openebs operator] ***********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:111
2019-06-17T11:29:25.509629 (delta: 0.092973)         elapsed: 26.801641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f openebs-operator.yaml", "delta": "0:00:05.755428", "end": "2019-06-17 11:29:31.515043", "rc": 0, "start": "2019-06-17 11:29:25.759615", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs created\nserviceaccount/openebs-maya-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged\ndeployment.apps/maya-apiserver created\nservice/maya-apiserver-service created\ndeployment.apps/openebs-provisioner created\ndeployment.apps/openebs-snapshot-operator created\nconfigmap/openebs-ndm-config created\ndaemonset.extensions/openebs-ndm created\ndeployment.apps/openebs-ndm-operator created\nsecret/admission-server-certs created\nservice/admission-server-svc created\ndeployment.apps/openebs-admission-server created\nvalidatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged\ndeployment.apps/openebs-localpv-provisioner created", "stdout_lines": ["namespace/openebs created", "serviceaccount/openebs-maya-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator unchanged", "deployment.apps/maya-apiserver created", "service/maya-apiserver-service created", "deployment.apps/openebs-provisioner created", "deployment.apps/openebs-snapshot-operator created", "configmap/openebs-ndm-config created", "daemonset.extensions/openebs-ndm created", "deployment.apps/openebs-ndm-operator created", "secret/admission-server-certs created", "service/admission-server-svc created", "deployment.apps/openebs-admission-server created", "validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg unchanged", "deployment.apps/openebs-localpv-provisioner created"]}

TASK [Applying storageclasses] *************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:116
2019-06-17T11:29:31.601383 (delta: 6.091687)         elapsed: 32.893395 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f storageclass.yaml", "delta": "0:00:02.125652", "end": "2019-06-17 11:29:34.003477", "rc": 0, "start": "2019-06-17 11:29:31.877825", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-standard unchanged\nstorageclass.storage.k8s.io/openebs-standalone unchanged\nstorageclass.storage.k8s.io/openebs-mongodb unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-standard unchanged", "storageclass.storage.k8s.io/openebs-standalone unchanged", "storageclass.storage.k8s.io/openebs-mongodb unchanged"]}

TASK [Updating maya api server image] ******************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:121
2019-06-17T11:29:34.084741 (delta: 2.483276)         elapsed: 35.376753 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva controller image] **********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:127
2019-06-17T11:29:34.196599 (delta: 0.111789)         elapsed: 35.488611 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:133
2019-06-17T11:29:34.295091 (delta: 0.098425)         elapsed: 35.587103 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica count] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:139
2019-06-17T11:29:34.399853 (delta: 0.104686)         elapsed: 35.691865 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor target image] *************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:145
2019-06-17T11:29:34.543513 (delta: 0.143589)         elapsed: 35.835525 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool image] ***************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:151
2019-06-17T11:29:34.658384 (delta: 0.114778)         elapsed: 35.950396 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool management image] ****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:157
2019-06-17T11:29:34.737663 (delta: 0.079187)         elapsed: 36.029675 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume management image] **************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:163
2019-06-17T11:29:34.834200 (delta: 0.096472)         elapsed: 36.126212 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:169
2019-06-17T11:29:34.918504 (delta: 0.084237)         elapsed: 36.210516 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:175
2019-06-17T11:29:35.007065 (delta: 0.088474)         elapsed: 36.299077 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting all pods in openebs namespace] ********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:181
2019-06-17T11:29:35.106756 (delta: 0.099625)         elapsed: 36.398768 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po --all -n openebs", "delta": "0:00:39.347441", "end": "2019-06-17 11:30:14.780252", "rc": 0, "start": "2019-06-17 11:29:35.432811", "stderr": "", "stderr_lines": [], "stdout": "pod \"maya-apiserver-6dfc747f96-wrzk7\" deleted\npod \"openebs-admission-server-585b45c995-rkhlk\" deleted\npod \"openebs-localpv-provisioner-54fb4cd4dd-wj6cx\" deleted\npod \"openebs-ndm-bxjcq\" deleted\npod \"openebs-ndm-mmq5w\" deleted\npod \"openebs-ndm-operator-78b848dbf4-h8p2s\" deleted\npod \"openebs-ndm-stssq\" deleted\npod \"openebs-provisioner-5695f8d98f-h7z2k\" deleted\npod \"openebs-snapshot-operator-7ddb4c97d-dp42b\" deleted", "stdout_lines": ["pod \"maya-apiserver-6dfc747f96-wrzk7\" deleted", "pod \"openebs-admission-server-585b45c995-rkhlk\" deleted", "pod \"openebs-localpv-provisioner-54fb4cd4dd-wj6cx\" deleted", "pod \"openebs-ndm-bxjcq\" deleted", "pod \"openebs-ndm-mmq5w\" deleted", "pod \"openebs-ndm-operator-78b848dbf4-h8p2s\" deleted", "pod \"openebs-ndm-stssq\" deleted", "pod \"openebs-provisioner-5695f8d98f-h7z2k\" deleted", "pod \"openebs-snapshot-operator-7ddb4c97d-dp42b\" deleted"]}

TASK [Verify that rolling update of maya-apiserver is completed] ***************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:186
2019-06-17T11:30:14.852584 (delta: 39.745748)         elapsed: 76.144596 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver | wc -l", "delta": "0:00:01.451436", "end": "2019-06-17 11:30:16.528578", "rc": 0, "start": "2019-06-17 11:30:15.077142", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking Maya-API-Server container status] *******************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:197
2019-06-17T11:30:16.622789 (delta: 1.770117)         elapsed: 77.914801 ******* 
FAILED - RETRYING: Checking Maya-API-Server container status (120 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (119 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (118 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver -o jsonpath='{.items[?(@.status.containerStatuses[*].name==\"maya-apiserver\")].status.containerStatuses[*].ready}'", "delta": "0:00:01.440865", "end": "2019-06-17 11:30:38.409354", "rc": 0, "start": "2019-06-17 11:30:36.968489", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Checking OpenEBS-provisioner is running] *********************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:206
2019-06-17T11:30:38.490149 (delta: 21.867277)         elapsed: 99.782161 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-provisioner\")].status.phase}'", "delta": "0:00:01.638275", "end": "2019-06-17 11:30:40.368055", "rc": 0, "start": "2019-06-17 11:30:38.729780", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get maya-apiserver pod name] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:220
2019-06-17T11:30:40.453365 (delta: 1.96315)         elapsed: 101.745377 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs --no-headers --selector=name=maya-apiserver -o custom-columns=:metadata.name", "delta": "0:00:01.542248", "end": "2019-06-17 11:30:42.273809", "rc": 0, "start": "2019-06-17 11:30:40.731561", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-6dfc747f96-vpn86", "stdout_lines": ["maya-apiserver-6dfc747f96-vpn86"]}

TASK [Create fact for pod name] ************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:229
2019-06-17T11:30:42.341841 (delta: 1.888411)         elapsed: 103.633853 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "maya-apiserver-6dfc747f96-vpn86"}, "changed": false}

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:233
2019-06-17T11:30:42.452914 (delta: 0.111009)         elapsed: 103.744926 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-snapshot-operator\")].status.phase}'", "delta": "0:00:01.495363", "end": "2019-06-17 11:30:44.203224", "rc": 0, "start": "2019-06-17 11:30:42.707861", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Confirm that maya-cli is available in the maya-apiserver pod] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:240
2019-06-17T11:30:44.283680 (delta: 1.830695)         elapsed: 105.575692 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec maya-apiserver-6dfc747f96-vpn86 -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:01.691961", "end": "2019-06-17 11:30:46.269594", "failed_when_result": false, "rc": 0, "start": "2019-06-17 11:30:44.577633", "stderr": "", "stderr_lines": [], "stdout": "Version: 1.1.0-unreleased\nGit commit: cef80e3495c88a8664948f70e1fae5870bc07c28\nGO Version: go1.11.2\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://172.23.5.79:5656\nm-apiserver status:  running", "stdout_lines": ["Version: 1.1.0-unreleased", "Git commit: cef80e3495c88a8664948f70e1fae5870bc07c28", "GO Version: go1.11.2", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://172.23.5.79:5656", "m-apiserver status:  running"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:248
2019-06-17T11:30:46.369467 (delta: 2.085722)         elapsed: 107.661479 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node --no-headers | grep -v \"master\" | wc -l", "delta": "0:00:01.572106", "end": "2019-06-17 11:30:48.219508", "rc": 0, "start": "2019-06-17 11:30:46.647402", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:254
2019-06-17T11:30:48.307134 (delta: 1.937595)         elapsed: 109.599146 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --selector=name=openebs-ndm | grep Running | wc -l", "delta": "0:00:01.583967", "end": "2019-06-17 11:30:50.202997", "rc": 0, "start": "2019-06-17 11:30:48.619030", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:280
2019-06-17T11:30:50.289402 (delta: 1.982195)         elapsed: 111.581414 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:286
2019-06-17T11:30:50.384326 (delta: 0.094855)         elapsed: 111.676338 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm CAS Templates are deployed] **************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:311
2019-06-17T11:30:50.469476 (delta: 0.085081)         elapsed: 111.761488 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get castemplate -n openebs", "delta": "0:00:01.699097", "end": "2019-06-17 11:30:52.444244", "rc": 0, "start": "2019-06-17 11:30:50.745147", "stderr": "", "stderr_lines": [], "stdout": "NAME                                  CREATED AT\ncas-volume-stats-default-0.9.0        10d\ncas-volume-stats-default-1.0.0        7d\ncas-volume-stats-default-1.1.0        9d\ncstor-pool-create-default-0.9.0       10d\ncstor-pool-create-default-1.0.0       7d\ncstor-pool-create-default-1.1.0       9d\ncstor-snapshot-create-default-0.9.0   10d\ncstor-snapshot-create-default-1.0.0   7d\ncstor-snapshot-create-default-1.1.0   9d\ncstor-snapshot-delete-default-0.9.0   10d\ncstor-snapshot-delete-default-1.0.0   7d\ncstor-snapshot-delete-default-1.1.0   9d\ncstor-volume-create-default-0.9.0     10d\ncstor-volume-create-default-1.0.0     7d\ncstor-volume-create-default-1.1.0     9d\ncstor-volume-delete-default-0.9.0     10d\ncstor-volume-delete-default-1.0.0     7d\ncstor-volume-delete-default-1.1.0     9d\ncstor-volume-list-default-0.9.0       10d\ncstor-volume-list-default-1.0.0       7d\ncstor-volume-list-default-1.1.0       9d\ncstor-volume-read-default-0.9.0       10d\ncstor-volume-read-default-1.0.0       7d\ncstor-volume-read-default-1.1.0       9d\njiva-snapshot-create-default-0.9.0    10d\njiva-snapshot-create-default-1.0.0    7d\njiva-snapshot-create-default-1.1.0    9d\njiva-volume-create-default-0.9.0      10d\njiva-volume-create-default-1.0.0      7d\njiva-volume-create-default-1.1.0      9d\njiva-volume-delete-default-0.6.0      10d\njiva-volume-delete-default-0.9.0      10d\njiva-volume-delete-default-1.0.0      7d\njiva-volume-delete-default-1.1.0      9d\njiva-volume-list-default-0.6.0        10d\njiva-volume-list-default-0.9.0        10d\njiva-volume-list-default-1.0.0        7d\njiva-volume-list-default-1.1.0        9d\njiva-volume-read-default-0.6.0        10d\njiva-volume-read-default-0.9.0        10d\njiva-volume-read-default-1.0.0        7d\njiva-volume-read-default-1.1.0        9d\nstorage-pool-list-default-0.9.0       10d\nstorage-pool-list-default-1.0.0       7d\nstorage-pool-list-default-1.1.0       9d\nstorage-pool-read-default-0.9.0       10d\nstorage-pool-read-default-1.0.0       7d\nstorage-pool-read-default-1.1.0       9d", "stdout_lines": ["NAME                                  CREATED AT", "cas-volume-stats-default-0.9.0        10d", "cas-volume-stats-default-1.0.0        7d", "cas-volume-stats-default-1.1.0        9d", "cstor-pool-create-default-0.9.0       10d", "cstor-pool-create-default-1.0.0       7d", "cstor-pool-create-default-1.1.0       9d", "cstor-snapshot-create-default-0.9.0   10d", "cstor-snapshot-create-default-1.0.0   7d", "cstor-snapshot-create-default-1.1.0   9d", "cstor-snapshot-delete-default-0.9.0   10d", "cstor-snapshot-delete-default-1.0.0   7d", "cstor-snapshot-delete-default-1.1.0   9d", "cstor-volume-create-default-0.9.0     10d", "cstor-volume-create-default-1.0.0     7d", "cstor-volume-create-default-1.1.0     9d", "cstor-volume-delete-default-0.9.0     10d", "cstor-volume-delete-default-1.0.0     7d", "cstor-volume-delete-default-1.1.0     9d", "cstor-volume-list-default-0.9.0       10d", "cstor-volume-list-default-1.0.0       7d", "cstor-volume-list-default-1.1.0       9d", "cstor-volume-read-default-0.9.0       10d", "cstor-volume-read-default-1.0.0       7d", "cstor-volume-read-default-1.1.0       9d", "jiva-snapshot-create-default-0.9.0    10d", "jiva-snapshot-create-default-1.0.0    7d", "jiva-snapshot-create-default-1.1.0    9d", "jiva-volume-create-default-0.9.0      10d", "jiva-volume-create-default-1.0.0      7d", "jiva-volume-create-default-1.1.0      9d", "jiva-volume-delete-default-0.6.0      10d", "jiva-volume-delete-default-0.9.0      10d", "jiva-volume-delete-default-1.0.0      7d", "jiva-volume-delete-default-1.1.0      9d", "jiva-volume-list-default-0.6.0        10d", "jiva-volume-list-default-0.9.0        10d", "jiva-volume-list-default-1.0.0        7d", "jiva-volume-list-default-1.1.0        9d", "jiva-volume-read-default-0.6.0        10d", "jiva-volume-read-default-0.9.0        10d", "jiva-volume-read-default-1.0.0        7d", "jiva-volume-read-default-1.1.0        9d", "storage-pool-list-default-0.9.0       10d", "storage-pool-list-default-1.0.0       7d", "storage-pool-list-default-1.1.0       9d", "storage-pool-read-default-0.9.0       10d", "storage-pool-read-default-1.0.0       7d", "storage-pool-read-default-1.1.0       9d"]}

TASK [set_fact] ****************************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:320
2019-06-17T11:30:52.527592 (delta: 2.058033)         elapsed: 113.819604 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect End of Installation] ************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:328
2019-06-17T11:30:52.657912 (delta: 0.130254)         elapsed: 113.949924 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "42e0ea578ffa4a1a9cda422fa345344dcc5667c9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c579bb9e9e52957afe03dfa862f9b3e2", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1560771052.75-251538868383756/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:339
2019-06-17T11:30:55.799627 (delta: 3.14162)         elapsed: 117.091639 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.247829", "end": "2019-06-17 11:30:57.291676", "rc": 0, "start": "2019-06-17 11:30:56.043847", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /providers/openebs/installers/operator/master/ansible/openebs_setup.yaml:342
2019-06-17T11:30:57.376082 (delta: 1.57638)         elapsed: 118.668094 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.799952", "end": "2019-06-17 11:30:59.392636", "failed_when_result": false, "rc": 0, "start": "2019-06-17 11:30:57.592684", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=22   unreachable=0    failed=0   

2019-06-17T11:30:59.449744 (delta: 2.073577)         elapsed: 120.741756 ****** 
=============================================================================== 

```
```
[root@master-1554817485 litmusbook]# kubectl get pods -n openebs
NAME                                           READY     STATUS    RESTARTS   AGE
maya-apiserver-6dfc747f96-vpn86                1/1       Running   0          1m
openebs-admission-server-585b45c995-djhdc      1/1       Running   0          1m
openebs-localpv-provisioner-54fb4cd4dd-j8zbm   1/1       Running   0          1m
openebs-ndm-8pjwh                              1/1       Running   0          1m
openebs-ndm-9cgl6                              1/1       Running   0          1m
openebs-ndm-operator-78b848dbf4-kfknx          1/1       Running   0          1m
openebs-ndm-wfc7k                              1/1       Running   0          1m
openebs-provisioner-5695f8d98f-n6lts           1/1       Running   0          1m
openebs-snapshot-operator-7ddb4c97d-gqhdn      2/2       Running   0          1m
[root@master-1554817485 litmusbook]# kubectl get bd -n openebs
NAME                                           AGE
blockdevice-592f162914abf0c392bea480845d8422   1m
blockdevice-6911d32fb9e9d958966e09b373fd679c   1m
blockdevice-6d77e19f09d49a1b9395779f150e8de5   1m
sparse-01a34b4bcc85881ab3a985a5ff37ed79        1m
sparse-094507bb8c5d1d3299f191ae8ff12e5a        1m
sparse-2160dd2d8563a7c882fbde7b2c4db0ee        1m
sparse-297500cba5def4cd6fb394bf1480bc8a        1m
sparse-4a43425e9b9232dd93c3a6ee8d64d811        1m
sparse-6de5ca4002054f7aee8ce5c3b5c3c7c9        1m
sparse-77a895e87070261d6ec4b2839cc7c47e        1m
sparse-7a998823d247f4e935d5d3f0b7bb1315        1m
sparse-8bd5ff5d334570b00e4525b3941eb3d6        1m
sparse-8c08761881790d3b3a2e1428c13f8741        1m
sparse-90599ef3f286fb9aa04b71b0a669f1db        1m
sparse-9073379a92949af0d658ca43df5b8eeb        1m
sparse-9fdd7f50a2a01f93ed091d210e98f98b        1m
sparse-a419a9ae6e5e0df6965f4d9d99f98e13        1m
sparse-aeb96a986ffe3c34906749a10389e910        1m
sparse-c9e56ec334118f6984132695b7d8b74d        1m
sparse-dac5bbd59cf92a43b4c7757c781b240c        1m
sparse-f01a04cdccd3d75e7ed2ef99950b2fa4        1m
[root@master-1554817485 litmusbook]# kubectl get bd -n openebs -o yaml | grep claimState
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
    claimState: Unclaimed
```