### PR TITLE
refactor[yaml]: Added timeout task in statefulset volume distribution litmusbook

### DIFF
--- a/experiments/functional/sts-volume-distribution/test.yml
+++ b/experiments/functional/sts-volume-distribution/test.yml
@@ -130,6 +130,9 @@
               register: result
               failed_when: "'scaled' not in result.stdout"
 
+            - name: sleep for 60 seconds and continue with play
+              wait_for: timeout=60
+
             - name: Obtain number of healthy PVC
               shell: >
                 kubectl get pvc -n {{ app_ns }} -l {{ app_label }}  -o custom-columns=:.status.phase | grep Bound | wc -l


### PR DESCRIPTION
* Added timeout in sts-volume-distribution.
* Wait for 60 seconds
* Following file is modified:
 experiments/functional/sts-volume-distribution/test.yml

Here are the logs of litmus pod:
```
[root@master-1554817485 sts-volume-distribution]# kubectl logs litmus-sts-replica-distribution-g8m4n-996tc -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-06-19T11:53:43.340408 (delta: 0.066902)         elapsed: 0.066902 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-06-19T11:53:43.366695 (delta: 0.026209)         elapsed: 0.093189 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-19T11:53:54.343937 (delta: 10.977191)         elapsed: 11.070431 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-19T11:53:54.459701 (delta: 0.115707)         elapsed: 11.186195 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-19T11:53:54.558234 (delta: 0.098433)         elapsed: 11.284728 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-19T11:53:54.645905 (delta: 0.087584)         elapsed: 11.372399 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-19T11:53:54.818880 (delta: 0.172902)         elapsed: 11.545374 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "90d9ad54a895f3d10a73f17fa97d90a4b47eeaa5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "239780ad5408fdda9046b3cd09041578", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1560945234.92-5227883790254/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-19T11:53:55.885869 (delta: 1.066906)         elapsed: 12.612363 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.288458", "end": "2019-06-19 11:53:57.689587", "rc": 0, "start": "2019-06-19 11:53:56.401129", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: replica-distribution \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: replica-distribution ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-19T11:53:57.766402 (delta: 1.880467)         elapsed: 14.492896 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.867247", "end": "2019-06-19 11:53:59.893847", "failed_when_result": false, "rc": 0, "start": "2019-06-19 11:53:58.026600", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/replica-distribution configured", "stdout_lines": ["litmusresult.litmus.io/replica-distribution configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-19T11:53:59.976990 (delta: 2.210498)         elapsed: 16.703484 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-19T11:54:00.040803 (delta: 0.06373)         elapsed: 16.767297 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-19T11:54:00.117998 (delta: 0.077124)         elapsed: 16.844492 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the storage class yaml] **********************************************
2019-06-19T11:54:00.200291 (delta: 0.08219)         elapsed: 16.926785 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk -o yaml > cstor-disk-standalone.yaml", "delta": "0:00:01.479168", "end": "2019-06-19 11:54:01.974101", "rc": 0, "start": "2019-06-19 11:54:00.494933", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Update the replica count storage class yaml] *****************************
2019-06-19T11:54:02.092137 (delta: 1.891749)         elapsed: 18.818631 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Update the storage class yaml] *******************************************
2019-06-19T11:54:02.756435 (delta: 0.664225)         elapsed: 19.482929 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create the storage class with single replica] ****************************
2019-06-19T11:54:03.100519 (delta: 0.344011)         elapsed: 19.827013 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cstor-disk-standalone.yaml", "delta": "0:00:01.545954", "end": "2019-06-19 11:54:04.924158", "rc": 0, "start": "2019-06-19 11:54:03.378204", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-disk-standalone created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-disk-standalone created"]}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:04.982888 (delta: 1.882281)         elapsed: 21.709382 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-06-19T11:54:05.153642 (delta: 0.170684)         elapsed: 21.880136 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk", "delta": "0:00:01.469269", "end": "2019-06-19 11:54:06.879368", "rc": 0, "start": "2019-06-19 11:54:05.410099", "stderr": "", "stderr_lines": [], "stdout": "NAME                 PROVISIONER                    AGE\nopenebs-cstor-disk   openebs.io/provisioner-iscsi   1d", "stdout_lines": ["NAME                 PROVISIONER                    AGE", "openebs-cstor-disk   openebs.io/provisioner-iscsi   1d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-06-19T11:54:06.953909 (delta: 1.800194)         elapsed: 23.680403 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-19T11:54:07.304698 (delta: 0.3507)         elapsed: 24.031192 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:07.676729 (delta: 0.371953)         elapsed: 24.403223 ******* 
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-06-19T11:54:07.815191 (delta: 0.13838)         elapsed: 24.541685 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-06-19T11:54:07.941514 (delta: 0.126231)         elapsed: 24.668008 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
2019-06-19T11:54:08.252585 (delta: 0.310982)         elapsed: 24.979079 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-sts"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-19T11:54:08.411384 (delta: 0.158702)         elapsed: 25.137878 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-06-19T11:54:08.714331 (delta: 0.302846)         elapsed: 25.440825 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:08.792496 (delta: 0.078098)         elapsed: 25.51899 ******** 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-06-19T11:54:08.914216 (delta: 0.121648)         elapsed: 25.64071 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.506673", "end": "2019-06-19 11:54:10.713066", "rc": 0, "start": "2019-06-19 11:54:09.206393", "stderr": "", "stderr_lines": [], "stdout": "app-cass-five\ndefault\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmaya-system\nmemleak\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\ntest-pvc", "stdout_lines": ["app-cass-five", "default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "maya-system", "memleak", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "test-pvc"]}

TASK [Create test specific namespace.] *****************************************
2019-06-19T11:54:10.783913 (delta: 1.869596)         elapsed: 27.510407 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-busybox-sushma", "delta": "0:00:01.530211", "end": "2019-06-19 11:54:12.566527", "rc": 0, "start": "2019-06-19 11:54:11.036316", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-busybox-sushma created", "stdout_lines": ["namespace/app-busybox-sushma created"]}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:12.639369 (delta: 1.855391)         elapsed: 29.365863 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-06-19T11:54:12.759685 (delta: 0.120237)         elapsed: 29.486179 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-busybox-sushma -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.491130", "end": "2019-06-19 11:54:14.489877", "rc": 0, "start": "2019-06-19 11:54:12.998747", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the storage class in application deployment file] ****************
2019-06-19T11:54:14.570812 (delta: 1.811058)         elapsed: 31.297306 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the replica anti affinity label value] ***************************
2019-06-19T11:54:14.918981 (delta: 0.348086)         elapsed: 31.645475 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:15.226031 (delta: 0.306969)         elapsed: 31.952525 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying busybox statefulset] *******************************************
2019-06-19T11:54:15.375650 (delta: 0.149546)         elapsed: 32.102144 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox_statefulset.yml -n app-busybox-sushma", "delta": "0:00:02.023290", "end": "2019-06-19 11:54:17.676067", "rc": 0, "start": "2019-06-19 11:54:15.652777", "stderr": "", "stderr_lines": [], "stdout": "service/busybox created\nstatefulset.apps/busybox created", "stdout_lines": ["service/busybox created", "statefulset.apps/busybox created"]}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:17.736156 (delta: 2.360421)         elapsed: 34.46265 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-19T11:54:17.804601 (delta: 0.068378)         elapsed: 34.531095 ******* 
included: /utils/scm/openebs/check_replica_count.yml for 127.0.0.1

TASK [Obtain the number of replicas.] ******************************************
2019-06-19T11:54:17.916892 (delta: 0.112202)         elapsed: 34.643386 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-busybox-sushma --no-headers -l \"app=busybox-sts\" -o custom-columns=:spec.replicas", "delta": "0:00:01.728629", "end": "2019-06-19 11:54:19.966997", "rc": 0, "start": "2019-06-19 11:54:18.238368", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
2019-06-19T11:54:20.054716 (delta: 2.137755)         elapsed: 36.78121 ******** 
FAILED - RETRYING: Obtain the ready replica count and compare with the replica count. (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get statefulset -n app-busybox-sushma -l \"app=busybox-sts\" --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.543518", "end": "2019-06-19 11:55:23.684293", "rc": 0, "start": "2019-06-19 11:55:22.140775", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Get the pv list] *********************************************************
2019-06-19T11:55:23.835216 (delta: 63.780439)         elapsed: 100.56171 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-sushma -l app=busybox-sts -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.514885", "end": "2019-06-19 11:55:25.607892", "rc": 0, "start": "2019-06-19 11:55:24.093007", "stderr": "", "stderr_lines": [], "stdout": "pvc-f780f6a3-9288-11e9-ab49-00505698550d\npvc-105e2f4d-9289-11e9-ab49-00505698550d", "stdout_lines": ["pvc-f780f6a3-9288-11e9-ab49-00505698550d", "pvc-105e2f4d-9289-11e9-ab49-00505698550d"]}

TASK [Obtain the pool claim name from storage class] ***************************
2019-06-19T11:55:25.689322 (delta: 1.854037)         elapsed: 102.415816 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk-standalone -o jsonpath='{.metadata.annotations}' | grep -A 1 -w \"name: StoragePoolClaim\" | grep value | awk '{print $2}' | cut -d '\"' -f 2 | head -1", "delta": "0:00:01.695835", "end": "2019-06-19 11:55:27.648090", "rc": 0, "start": "2019-06-19 11:55:25.952255", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool", "stdout_lines": ["cstor-block-disk-pool"]}

TASK [Get the total number of sp] **********************************************
2019-06-19T11:55:27.723785 (delta: 2.034364)         elapsed: 104.450279 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o custom-columns=:.metadata.name --no-headers | wc -l", "delta": "0:00:01.550022", "end": "2019-06-19 11:55:29.529512", "rc": 0, "start": "2019-06-19 11:55:27.979490", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the cstor storage pool list from cvr] *****************************
2019-06-19T11:55:29.613841 (delta: 1.889988)         elapsed: 106.340335 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -l openebs.io/replica-anti-affinity=busybox-sts -n openebs -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:01.424006", "end": "2019-06-19 11:55:31.342424", "rc": 0, "start": "2019-06-19 11:55:29.918418", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-h8cr cstor-block-disk-pool-ova2", "stdout_lines": ["cstor-block-disk-pool-h8cr cstor-block-disk-pool-ova2"]}

TASK [set_fact] ****************************************************************
2019-06-19T11:55:31.412137 (delta: 1.798222)         elapsed: 108.138631 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"csp_list": ["cstor-block-disk-pool-h8cr", "cstor-block-disk-pool-ova2"]}, "changed": false}

TASK [Verify the CVR's sceduled on different sp] *******************************
2019-06-19T11:55:31.545037 (delta: 0.132834)         elapsed: 108.271531 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-h8cr) => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/replica-anti-affinity=busybox-sts,cstorpool.openebs.io/name=cstor-block-disk-pool-h8cr --no-headers | wc -l", "delta": "0:00:01.540324", "end": "2019-06-19 11:55:33.371352", "failed_when_result": false, "item": "cstor-block-disk-pool-h8cr", "rc": 0, "start": "2019-06-19 11:55:31.831028", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ova2) => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/replica-anti-affinity=busybox-sts,cstorpool.openebs.io/name=cstor-block-disk-pool-ova2 --no-headers | wc -l", "delta": "0:00:01.717894", "end": "2019-06-19 11:55:35.342420", "failed_when_result": false, "item": "cstor-block-disk-pool-ova2", "rc": 0, "start": "2019-06-19 11:55:33.624526", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Obtain the application name] *********************************************
2019-06-19T11:55:35.443611 (delta: 3.898473)         elapsed: 112.170105 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get statefulset -n app-busybox-sushma -l app=busybox-sts -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.567502", "end": "2019-06-19 11:55:37.332868", "rc": 0, "start": "2019-06-19 11:55:35.765366", "stderr": "", "stderr_lines": [], "stdout": "busybox", "stdout_lines": ["busybox"]}

TASK [Scaleup the application replica] *****************************************
2019-06-19T11:55:37.417354 (delta: 1.973639)         elapsed: 114.143848 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale statefulsets busybox --replicas=3 -n app-busybox-sushma", "delta": "0:00:01.632134", "end": "2019-06-19 11:55:39.317923", "failed_when_result": false, "rc": 0, "start": "2019-06-19 11:55:37.685789", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/busybox scaled", "stdout_lines": ["statefulset.apps/busybox scaled"]}

TASK [sleep for 60 seconds and continue with play] *****************************
2019-06-19T11:55:39.415038 (delta: 1.997601)         elapsed: 116.141532 ****** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 60, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Obtain number of healthy PVC] ********************************************
2019-06-19T11:56:40.172028 (delta: 60.756889)         elapsed: 176.898522 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-sushma -l app=busybox-sts -o custom-columns=:.status.phase | grep Bound | wc -l", "delta": "0:00:01.660928", "end": "2019-06-19 11:56:42.119329", "rc": 0, "start": "2019-06-19 11:56:40.458401", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the pv list after scale up the application replica] ******************
2019-06-19T11:56:42.258877 (delta: 2.086718)         elapsed: 178.985371 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-sushma -l app=busybox-sts -o custom-columns=:.spec.volumeName --no-headers | grep -v none | wc -l", "delta": "0:00:01.753885", "end": "2019-06-19 11:56:44.277557", "rc": 0, "start": "2019-06-19 11:56:42.523672", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if all the application replicas are running.] **********************
2019-06-19T11:56:44.348327 (delta: 2.089379)         elapsed: 181.074821 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-busybox-sushma --no-headers -l app=busybox-sts -o custom-columns=:..readyReplicas", "delta": "0:00:01.343279", "end": "2019-06-19 11:56:45.936938", "rc": 0, "start": "2019-06-19 11:56:44.593659", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the pv list after scale up the application replica] ******************
2019-06-19T11:56:46.021311 (delta: 1.672913)         elapsed: 182.747805 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-sushma -l app=busybox-sts -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.482540", "end": "2019-06-19 11:56:47.782505", "rc": 0, "start": "2019-06-19 11:56:46.299965", "stderr": "", "stderr_lines": [], "stdout": "pvc-f780f6a3-9288-11e9-ab49-00505698550d\npvc-105e2f4d-9289-11e9-ab49-00505698550d\npvc-2827289d-9289-11e9-ab49-00505698550d", "stdout_lines": ["pvc-f780f6a3-9288-11e9-ab49-00505698550d", "pvc-105e2f4d-9289-11e9-ab49-00505698550d", "pvc-2827289d-9289-11e9-ab49-00505698550d"]}

TASK [Obtain newly created pv list] ********************************************
2019-06-19T11:56:47.845530 (delta: 1.82415)         elapsed: 184.572024 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"new_pv": ["pvc-2827289d-9289-11e9-ab49-00505698550d"]}, "changed": false}

TASK [Get the cstor storage pool list after scale up the application replica] ***
2019-06-19T11:56:47.947628 (delta: 0.102031)         elapsed: 184.674122 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -l openebs.io/replica-anti-affinity=busybox-sts -n openebs -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:01.381732", "end": "2019-06-19 11:56:49.660487", "rc": 0, "start": "2019-06-19 11:56:48.278755", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-h8cr cstor-block-disk-pool-apm7 cstor-block-disk-pool-ova2", "stdout_lines": ["cstor-block-disk-pool-h8cr cstor-block-disk-pool-apm7 cstor-block-disk-pool-ova2"]}

TASK [set_fact] ****************************************************************
2019-06-19T11:56:49.734923 (delta: 1.787228)         elapsed: 186.461417 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"new_csp_list": ["cstor-block-disk-pool-h8cr", "cstor-block-disk-pool-apm7", "cstor-block-disk-pool-ova2"]}, "changed": false}

TASK [Verify the CVR's sceduled on different cstor storage pool] ***************
2019-06-19T11:56:49.842191 (delta: 0.107178)         elapsed: 186.568685 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-h8cr) => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/replica-anti-affinity=busybox-sts,cstorpool.openebs.io/name=cstor-block-disk-pool-h8cr --no-headers | wc -l", "delta": "0:00:01.358070", "end": "2019-06-19 11:56:51.503341", "failed_when_result": false, "item": "cstor-block-disk-pool-h8cr", "rc": 0, "start": "2019-06-19 11:56:50.145271", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-apm7) => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/replica-anti-affinity=busybox-sts,cstorpool.openebs.io/name=cstor-block-disk-pool-apm7 --no-headers | wc -l", "delta": "0:00:01.568857", "end": "2019-06-19 11:56:53.351446", "failed_when_result": false, "item": "cstor-block-disk-pool-apm7", "rc": 0, "start": "2019-06-19 11:56:51.782589", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ova2) => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/replica-anti-affinity=busybox-sts,cstorpool.openebs.io/name=cstor-block-disk-pool-ova2 --no-headers | wc -l", "delta": "0:00:01.525232", "end": "2019-06-19 11:56:55.128282", "failed_when_result": false, "item": "cstor-block-disk-pool-ova2", "rc": 0, "start": "2019-06-19 11:56:53.603050", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Deprovisioning the Application] ******************************************
2019-06-19T11:56:55.217400 (delta: 5.375142)         elapsed: 191.943894 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-06-19T11:56:55.313174 (delta: 0.09569)         elapsed: 192.039668 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-19T11:56:55.422636 (delta: 0.109364)         elapsed: 192.14913 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-19T11:56:55.549572 (delta: 0.126843)         elapsed: 192.276066 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-19T11:56:55.626534 (delta: 0.076839)         elapsed: 192.353028 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-19T11:56:55.701769 (delta: 0.075114)         elapsed: 192.428263 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-19T11:56:55.764692 (delta: 0.062818)         elapsed: 192.491186 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "fd0605c6bff14796e031242127572310e68dc178", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "db8a69568de9d7d3e74f4ed730b643e0", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1560945415.84-129665022808257/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-19T11:56:58.894426 (delta: 3.129664)         elapsed: 195.62092 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.262374", "end": "2019-06-19 11:57:00.414492", "rc": 0, "start": "2019-06-19 11:56:59.152118", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: replica-distribution \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: replica-distribution ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-19T11:57:00.481696 (delta: 1.5872)         elapsed: 197.20819 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.712761", "end": "2019-06-19 11:57:02.472244", "failed_when_result": false, "rc": 0, "start": "2019-06-19 11:57:00.759483", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/replica-distribution configured", "stdout_lines": ["litmusresult.litmus.io/replica-distribution configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=36   unreachable=0    failed=0   

2019-06-19T11:57:02.522227 (delta: 2.040442)         elapsed: 199.248721 ****** 
=============================================================================== 
```