### PR TITLE
(feat)experiment: add disk loss simulation experiment

### DIFF
--- a/chaoslib/disk_chaos/disk_chaos_kube.yml
+++ b/chaoslib/disk_chaos/disk_chaos_kube.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: disk-chaos
+  labels:
+    app: disk-chaos
+spec:
+  nodeSelector: 
+    kubernetes.io/hostname: NODE_UNDER_TEST
+  containers:
+  - name: disk-chaos
+    image: ubuntu:16.04
+    command: ["/bin/bash"]
+    args: ["-c", "sleep 100000"]
+    resources:
+      requests:
+        cpu: 10m
+        memory: 5M
+      limits:
+        cpu: 100m
+        memory: 20M
+    volumeMounts:
+      - name: udev
+        mountPath: /run/udev
+      - name: procmount
+        mountPath: /host/mounts
+      - name: sysfs
+        mountPath: /sys
+      - name: disk
+        mountPath: /dev/disk
+        # DISK_MOUNT_PATH is a placeholder 
+      - name: diskmount
+        mountPath: DISK_MOUNT_PATH
+        mountPropagation: Bidirectional  
+    securityContext:
+      privileged: true
+    #tty: true
+  volumes:
+    - name: udev
+      hostPath: 
+        path: /run/udev
+    - name: procmount
+      hostPath:
+        path: /proc/1/mounts 
+    - name: sysfs
+      hostPath:
+        path: /sys
+    - name: disk
+      hostPath: 
+        path: /dev/disk
+        type: Directory
+    - name: diskmount
+      hostPath:
+        path: DISK_MOUNT_PATH
+        type: Directory

--- a/chaoslib/disk_chaos/disk_loss_via_sysfs.yml
+++ b/chaoslib/disk_chaos/disk_loss_via_sysfs.yml
@@ -1,0 +1,197 @@
+- block:
+
+    - name: update nodeSelector for disk chaos pod
+      replace:
+        path: /chaoslib/disk_chaos/disk_chaos_kube.yml
+        regexp: NODE_UNDER_TEST
+        replace: "{{ n_name }}"
+
+    - name: update bi-directional mount paths for device 
+      replace:
+        path: /chaoslib/disk_chaos/disk_chaos_kube.yml
+        regexp: DISK_MOUNT_PATH
+        replace: "{{ d_mntpath }}"
+      when: 'd_mntpath is defined and d_mntpath != ""'
+      
+    - name: setup disk chaos infra
+      shell: >
+        kubectl create -f /chaoslib/disk_chaos/disk_chaos_kube.yml
+        -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+    
+    - name: Confirm that the disk chaos pod is running 
+      shell: >
+        kubectl get pod -l app=disk-chaos
+        --no-headers -o custom-columns=:status.phase
+        -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "result.stdout == 'Running'"
+      delay: 20
+      retries: 15
+
+    - name: Obtain the SCSI device name
+      set_fact:
+        disk: "{{ n_disk.split(\"/dev/\")[1] }}"
+
+    - name: Record the disk chaos pod name
+      shell: >
+        kubectl get pod -l app=disk-chaos
+        --no-headers -o custom-columns=:metadata.name
+        -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+
+    - set_fact:
+        disk_chaos_pod: "{{ result.stdout }}"
+    
+    - name: Verify availability of specified disk
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "lsblk {{ n_disk }}"
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "result.rc != 0"
+       
+    - name: Obtain identifer for specified disk 
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "lsblk -o UUID --noheadings {{ n_disk }} | tr -d '\n'"
+      args:
+        executable: /bin/bash
+      register: uuid
+
+    - block:
+        
+        - debug:
+            msg: "Disk UUID is {{ uuid.stdout }}"
+
+        - name: Check mount status of the specified disk
+          shell: >
+            timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+            -- bash -c "lsblk -o MOUNTPOINT --noheadings {{ n_disk }} | tr -d '\n'"
+          args:
+            executable: /bin/bash
+          register: mountpoint
+
+        - name: Get the mount options for the specified disk
+          shell: >
+            timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+            -- bash -c "grep {{ n_disk }} /host/mounts" | awk '{print $4}'
+          args:
+            executable: /bin/bash
+          register: mountoptions
+          when: 'mountpoint.stdout != ""'
+
+      when: 'uuid.stdout != ""'
+
+    - block: 
+
+        - debug:
+            msg: 
+              - "Disk is found to be un-utilized/un-formatted (no UUID found)"
+              - "Disk recovery validation will be skipped"
+
+      when: 'uuid.stdout == ""'
+
+    - name: Fail/Detach the specified disk  
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "echo 1 > /sys/block/{{ disk }}/device/delete"
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: 'result.rc != 0'
+      
+    - name: Verify disk has been removed 
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "lsblk | grep {{ n_disk }}"
+      args:
+        executable: /bin/bash
+      register: result_disk_check
+      failed_when: 'result_disk_check.rc != 1'  
+
+    - block:  
+        - name: Unmount the stale device mount  
+          shell: >
+            timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+            -- bash -c "umount {{ mountpoint.stdout }}"
+          args:
+            executable: /bin/bash
+          ignore_errors: true
+
+      when: 'mountpoint.stdout is defined and mountpoint.stdout != ""'
+
+    - name: Keep disk in detached state for {{ c_duration }}s
+      shell: sleep {{ c_duration }}
+
+    - name: List the available scsi host bus 
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "ls /sys/class/scsi_host/"
+      args:
+        executable: /bin/bash
+      register: result_host
+          
+    - name: Rescan the SCSI bus to rediscover/reattach disk
+      shell: >
+        timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+        -- bash -c "echo '- - -' > /sys/class/scsi_host/{{ item }}/scan"
+      args:
+        executable: /bin/bash
+      with_items: "{{ result_host.stdout_lines }}"
+
+    - block: 
+        - name: Verify disk device is re-attached (valid if disk formatted)
+          shell: >
+            timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+            -- bash -c "ls /dev/disk/by-uuid/{{ uuid.stdout }}"
+          args:
+            executable: /bin/bash
+          register: result_disk_check
+          failed_when: 'result_disk_check.rc != 0'
+
+      when: 'uuid.stdout != ""'
+ 
+    - block: 
+        - name: Remount the disk with mount original options 
+          shell: >
+            timeout 10 kubectl exec -it {{ disk_chaos_pod }} -n {{ a_ns }}
+            -- bash -c "mount -o {{ mountoptions.stdout }} /dev/disk/by-uuid/{{ uuid.stdout }} {{ mountpoint.stdout }}"
+          args:
+            executable: /bin/bash
+
+      when: 'mountpoint.stdout is defined and mountpoint.stdout != ""' 
+  
+  when: action == "disk_chaos_inject"
+
+- block: 
+    - name: Remove the disk chaos pod 
+      shell: >
+        kubectl delete -f /chaoslib/disk_chaos/disk_chaos_kube.yml
+        -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+  
+    - name: Verify disk chaos pod has been removed
+      shell: >
+        kubectl get pod -l app=disk-chaos
+        --no-headers -o custom-columns=:status.phase
+        -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' not in result.stdout"
+      delay: 20
+      retries: 15
+
+  when: action == "disk_chaos_remove"
+
+
+        

--- a/experiments/chaos/kubernetes/disk_loss/run_litmus_test.yml
+++ b/experiments/chaos/kubernetes/disk_loss/run_litmus_test.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: disk-loss-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: disk-loss
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: ksatchit/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: default 
+
+          - name: APP_LABEL
+            value: 'app=nginx'
+
+          - name: TOTAL_CHAOS_DURATION
+            value: "15"
+
+          - name: DISK_DEVICE_PATH
+            value: '/dev/sdb'
+
+          - name: DISK_MOUNT_PATH
+            value: '/mnt'
+
+          - name: NODE_NAME
+            value: 'gke-playground-default-pool-1b790f33-269d' 
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/kubernetes/disk_loss/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/chaos/kubernetes/disk_loss/test.yml
+++ b/experiments/chaos/kubernetes/disk_loss/test.yml
@@ -1,0 +1,80 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "disk-loss"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_util: "/chaoslib/disk_chaos/disk_loss_via_sysfs.yml"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+    n_disk: "{{ lookup('env','DISK_DEVICE_PATH') }}"
+    d_mntpath: "{{ lookup('env','DISK_MOUNT_PATH') | default('/mnt', true) }}"
+    n_name: "{{ lookup('env','NODE_NAME') }}" 
+
+  tasks:
+    - block:
+
+        ## GENERATE EXP RESULT NAME
+        - block:
+
+            - name: Construct chaos result name (experiment_name)
+              set_fact:
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+
+          when: lookup('env','CHAOSENGINE')    
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90
+
+        ## FAULT INJECTION 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            action: "disk_chaos_inject"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 2
+            retries: 90        
+
+        - set_fact:
+            flag: "pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            action: "disk_chaos_remove"
+
+        - include_tasks: /utils/fcm/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"
+


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Introduces a new experiment to simulate disk loss on baremetal cluster nodes 
- Accepts the following important job ENV (apart from Application Info & Chaos Duration) : 

  - DISK_DEVICE_PATH: The SCSI device path of the Disk Under Test (ex: `/dev/sdb`)
  - DISK_MOUNT_PATH: The fs mountpoint where the Disk Under Test is mounted. Please provide the **parent** dir of the actual mount path to enable successful mount propagation. 
  - NODE_NAME: The Node in which the DUT is attached. 

  Note: In future/enhanced versions of the experiment (such as the variant bundled into openebs chaos chart will derive the above info from a higher-level entity such as storage pool). 

### Workflow: 

- Pre-chaos app health check is performed
- A privileged *disk-chaos* pod (which mounts necessary system paths - such as `/run/udev`, `sysfs`, `/dev/disk`, `/proc/1/mounts` to perform disk-level ops)  is launched on the specified node.
- The availability of the specified disk is verified, followed by recording the disk's unique identifier
- The disk loss is simulated via `echo 1 > /sys/block/{{disk}}/device/delete` & subsequent rescan (after waiting for chaos interval) is performed via `echo "- - -" > /sys/class/scsi_host/host{#}/scan` 
- The disk reattachment is verified & post-chaos app health check is performed

### Considerations/Pre-Requisites

- Supported only on SCSI disks (i.e., the physical/virtual disk on the cluster node should be seen as a SCSI device)
- `udev` & dependent tools such as `lsblk` have been used to perform disk checks 
- Disk states (in terms on utilization) are typically one of these: 
  - (a) Unformatted Block Device (either used as is or un-utilized) 
  - (b) Formatted Device, part of  a pool/logical disk group (such as ZFS pool) 
  - (c) Formatted & Mounted: In use as a direct host mount
- Ensure that the MountFlags on the docker runtime on the host is set to "shared" : https://kubernetes.io/docs/concepts/storage/volumes/#configuration



### Tested

- On ubuntu-based Packet cluster. 
- On RHEL-based OpenShift cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Currently tested against disk devices. Partitions not tested yet
- `lsblk` can sometimes return stale UUIDs (such as those of removed partitions). This can affect recovery of mounted disks

