### PR TITLE
Include localPV-device test in busybox-provision litmusbook

### DIFF
--- a/apps/busybox/deployers/run_litmus_test.yml
+++ b/apps/busybox/deployers/run_litmus_test.yml
@@ -63,5 +63,8 @@ spec:
           - name: ACTION
             value: provision
 
+          - name: LOCAL_PV_TEST
+            value: 'false'
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/busybox/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/busybox/deployers/test.yml
+++ b/apps/busybox/deployers/test.yml
@@ -75,6 +75,23 @@
                     check_app_pod: 'yes'
                     delay: 10
                     retries: 20
+                  when: "'true' not in perform_test"
+
+                - block:
+                    - name: Provisioning application
+                      shell: kubectl apply -f {{ application_deployment }} -n {{ app_ns }}
+
+                    - name: Getting the status of PVC
+                      shell: |
+                        sleep 10
+                        kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.status.phase}'
+                      register: pvc_status
+                      until: "'Pending' in pvc_status.stdout"
+                      delay: 2
+                      retries: 100  
+
+                  when: "'true' is in perform_test"
+
               when: "'deprovision' not in action"
 
             - name: Deprovisioning the Application

--- a/apps/busybox/deployers/test_vars.yml
+++ b/apps/busybox/deployers/test_vars.yml
@@ -10,4 +10,5 @@ application_name: "busybox"
 action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+perform_test: "{{ lookup('env','LOCAL_PV_TEST') }}"
 operator_ns: openebs


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

**What this PR does / why we need it**:
- Include volume over-provisioning test with localPV-device in busybox-provision litmusbook. 

**Following is the log of ansible-test-container**:
```

PLAY [localhost] ***************************************************************
2019-06-20T12:00:27.276223 (delta: 0.035387)         elapsed: 0.035387 ********
===============================================================================

TASK [Gathering Facts] *********************************************************
2019-06-20T12:00:27.285773 (delta: 0.009521)         elapsed: 0.044937 ********
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:31.984725 (delta: 4.698928)         elapsed: 4.743889 ********
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-06-20T12:00:32.030448 (delta: 0.045687)         elapsed: 4.789612 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-06-20T12:00:32.070775 (delta: 0.040284)         elapsed: 4.829939 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:32.108917 (delta: 0.038105)         elapsed: 4.868081 ********
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-20T12:00:32.166161 (delta: 0.057203)         elapsed: 4.925325 ********
changed: [127.0.0.1] => {"changed": true, "checksum": "0044cbb1339994e1991aea4ade51c1bd65b554be", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "ab8c2611b6fe090efcd48f433f0598d3", "mode": "0644", "owner": "root", "size": 437, "src": "/root/.ansible/tmp/ansible-tmp-1561032032.21-193149165901261/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-20T12:00:32.625624 (delta: 0.459428)         elapsed: 5.384788 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.526039", "end": "2019-06-20 12:00:33.380352", "rc": 0, "start": "2019-06-20 12:00:32.854313", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-provision-app-busybox-device \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-provision-app-busybox-device ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-20T12:00:33.415729 (delta: 0.790036)         elapsed: 6.174893 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.087389", "end": "2019-06-20 12:00:34.623658", "failed_when_result": false, "rc": 0, "start": "2019-06-20 12:00:33.536269", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-provision-app-busybox-device configured", "stdout_lines": ["litmusresult.litmus.io/busybox-provision-app-busybox-device configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-20T12:00:34.668149 (delta: 1.252382)         elapsed: 7.427313 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-20T12:00:34.704603 (delta: 0.036412)         elapsed: 7.463767 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-20T12:00:34.747893 (delta: 0.043246)         elapsed: 7.507057 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:34.780202 (delta: 0.032266)         elapsed: 7.539366 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-06-20T12:00:34.821774 (delta: 0.041532)         elapsed: 7.580938 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the volume capcity placeholder with provider] ********************
2019-06-20T12:00:34.864013 (delta: 0.042189)         elapsed: 7.623177 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:34.903771 (delta: 0.039717)         elapsed: 7.662935 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
2019-06-20T12:00:34.944528 (delta: 0.040719)         elapsed: 7.703692 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:34.984829 (delta: 0.040261)         elapsed: 7.743993 ********
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-06-20T12:00:35.058112 (delta: 0.073208)         elapsed: 7.817276 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-device", "delta": "0:00:00.627965", "end": "2019-06-20 12:00:35.826283", "rc": 0, "start": "2019-06-20 12:00:35.198318", "stderr": "", "stderr_lines": [], "stdout": "NAME             PROVISIONER        AGE\nopenebs-device   openebs.io/local   3d4h", "stdout_lines": ["NAME             PROVISIONER        AGE", "openebs-device   openebs.io/local   3d4h"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-06-20T12:00:35.863250 (delta: 0.805098)         elapsed: 8.622414 ********
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-06-20T12:00:36.151403 (delta: 0.288105)         elapsed: 8.910567 ********
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:36.313072 (delta: 0.161627)         elapsed: 9.072236 ********
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-06-20T12:00:36.377414 (delta: 0.064302)         elapsed: 9.136578 ********
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-06-20T12:00:36.442716 (delta: 0.065231)         elapsed: 9.20188 *********
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Get the application label values from env] *******************************
2019-06-20T12:00:36.606739 (delta: 0.163955)         elapsed: 9.365903 ********
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-06-20T12:00:36.672026 (delta: 0.065244)         elapsed: 9.43119 *********
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-06-20T12:00:36.859181 (delta: 0.187084)         elapsed: 9.618345 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:36.903217 (delta: 0.043969)         elapsed: 9.662381 ********
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-06-20T12:00:36.968094 (delta: 0.064841)         elapsed: 9.727258 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.622102", "end": "2019-06-20 12:00:37.718290", "rc": 0, "start": "2019-06-20 12:00:37.096188", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\napp-hostpath\napp-localpv-test\napp-ssd\napp-ssd-local\ndefault\nkube-public\nkube-system\nlitmus\nopenebs", "stdout_lines": ["app-busybox-ns", "app-hostpath", "app-localpv-test", "app-ssd", "app-ssd-local", "default", "kube-public", "kube-system", "litmus", "openebs"]}

TASK [Create test specific namespace.] *****************************************
2019-06-20T12:00:37.753324 (delta: 0.785191)         elapsed: 10.512488 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-busybox-device", "delta": "0:00:00.617629", "end": "2019-06-20 12:00:38.503782", "rc": 0, "start": "2019-06-20 12:00:37.886153", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-busybox-device created", "stdout_lines": ["namespace/app-busybox-device created"]}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:38.537782 (delta: 0.784392)         elapsed: 11.296946 *******
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-06-20T12:00:38.601007 (delta: 0.063134)         elapsed: 11.360171 *******
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-busybox-device -o custom-columns=:status.phase --no-headers", "delta": "0:00:00.611810", "end": "2019-06-20 12:00:39.351574", "rc": 0, "start": "2019-06-20 12:00:38.739764", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the affinity label annotation in deployment yml] *****************
2019-06-20T12:00:39.389812 (delta: 0.788729)         elapsed: 12.148976 *******
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replace the volume capcity placeholder with provider] ********************
2019-06-20T12:00:39.554848 (delta: 0.164997)         elapsed: 12.314012 *******
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:39.724829 (delta: 0.169942)         elapsed: 12.483993 *******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Provisioning application] ************************************************
2019-06-20T12:00:39.772442 (delta: 0.047546)         elapsed: 12.531606 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox_deployment.yml -n app-busybox-device", "delta": "0:00:00.789785", "end": "2019-06-20 12:00:40.694458", "rc": 0, "start": "2019-06-20 12:00:39.904673", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/app-busybox created\npersistentvolumeclaim/openebs-busybox created", "stdout_lines": ["deployment.apps/app-busybox created", "persistentvolumeclaim/openebs-busybox created"]}

TASK [Getting the status of PVC] ***********************************************
2019-06-20T12:00:40.742583 (delta: 0.970102)         elapsed: 13.501747 *******
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-device -o jsonpath='{.status.phase}'", "delta": "0:00:00.659465", "end": "2019-06-20 12:00:41.536603", "rc": 0, "start": "2019-06-20 12:00:40.877138", "stderr": "", "stderr_lines": [], "stdout": "Pending", "stdout_lines": ["Pending"]}

TASK [Deprovisioning the Application] ******************************************
2019-06-20T12:00:41.575519 (delta: 0.832894)         elapsed: 14.334683 *******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-06-20T12:00:41.618660 (delta: 0.0431)         elapsed: 14.377824 *********
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-06-20T12:00:41.664706 (delta: 0.04598)         elapsed: 14.42387 *********
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-06-20T12:00:41.717623 (delta: 0.05288)         elapsed: 14.476787 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-06-20T12:00:41.753697 (delta: 0.036008)         elapsed: 14.512861 *******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-06-20T12:00:41.786120 (delta: 0.032382)         elapsed: 14.545284 *******
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-06-20T12:00:41.817993 (delta: 0.031791)         elapsed: 14.577157 *******
changed: [127.0.0.1] => {"changed": true, "checksum": "380165703ef4b514751927944cc46a7415868f69", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0037507ec220f6af4f537dffb0fadfbb", "mode": "0644", "owner": "root", "size": 435, "src": "/root/.ansible/tmp/ansible-tmp-1561032041.86-58480772325788/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-06-20T12:00:43.156318 (delta: 1.338284)         elapsed: 15.915482 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.527332", "end": "2019-06-20 12:00:43.805225", "rc": 0, "start": "2019-06-20 12:00:43.277893", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-provision-app-busybox-device \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-provision-app-busybox-device ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-06-20T12:00:43.839391 (delta: 0.683032)         elapsed: 16.598555 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.720255", "end": "2019-06-20 12:00:44.678143", "failed_when_result": false, "rc": 0, "start": "2019-06-20 12:00:43.957888", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-provision-app-busybox-device configured", "stdout_lines": ["litmusresult.litmus.io/busybox-provision-app-busybox-device configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=29   changed=17   unreachable=0    failed=0
```
