### PR TITLE
Refactored litmus books to take pool type as environmental variable

### DIFF
--- a/experiments/chaos/app_node_failure_diff_aws/run_litmus_test.yml
+++ b/experiments/chaos/app_node_failure_diff_aws/run_litmus_test.yml
@@ -68,5 +68,5 @@ spec:
             value: "subnet_id"
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/chaos/app_node_failure_ups_diff_name/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/app_node_failure_diff_aws/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -28,6 +28,8 @@ spec:
           - name: POOL_NAME
             value: cstor-block-disk-pool
 
+           # Provide the value for POOL_TYPE 
+           # Supported values: striped, mirrored, raidz ,raidz2
           - name: POOL_TYPE
             value: striped
 
@@ -41,5 +43,5 @@ spec:
             value: "20Gi"
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test1.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -28,6 +28,9 @@ spec:
           - name: POOL_NAME
             value: cstor-block-disk-pool
 
+          - name: POOL_TYPE
+            value: striped
+
           - name: OPERATOR_NS
             value: openebs
 

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -43,5 +43,5 @@ spec:
             value: "20Gi"
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test1.yml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -6,7 +6,7 @@ spec:
   name: pool-name
   type: disk
   poolSpec:
-    poolType: striped
+    poolType: pool-type
   blockDevices:
     blockDeviceList:
 

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -147,7 +147,7 @@
              #           rm ./tmp_block_device_claim.yml
              #         with_together: 
              #           - "{{ nodes.stdout_lines }}"
-             #           - "{{ blockDevice.results }}"     
+             #           - "{{ blockDevice.results }}"
 
              #         - name: display spc.yml
              #           debug: var=item
@@ -159,7 +159,7 @@
             path: ./spc.yml
             regexp: "pool-name"
             replace: "{{ pool_name }}"
-        
+                                             
         - name: Create cstor disk pool
           shell: kubectl apply -f spc.yml
           args:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -57,6 +57,12 @@
             regexp: "pool-name"
             replace: "{{ pool_name }}"
 
+        - name: Replacing the pool type in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "pool-type"
+            replace: "{{ pool_type }}"
+
         - name: Create cstor disk pool
           shell: kubectl apply -f spc.yml
           args:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -131,13 +131,18 @@
           when: pool_type == "raidz2"  
 
         - set_fact:
-             device_count: "{{ blockDevice|length}}"   
+             device_count: "{{ blockDevice|length}}"  
 
         - name: Replacing the pool name in SPC spec
           replace:
             path: ./spc.yml
             regexp: "pool-name"
             replace: "{{ pool_name }}"
+
+        - name: Display spc.yml for verification 
+          debug: var=item
+          with_file:
+           - "spc.yml"
 
         - name: Create cstor disk pool
           shell: kubectl apply -f spc.yml

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -128,38 +128,14 @@
                line: '    - {{ item }}'
              with_items: "{{ bd_names }}" 
           
-          when: pool_type == "raidz2"
-
-        - set_fact:
-             device_count: "{{ blockDevice|length}}"
-
-             #        - name: Fetching and Replacing device capacity from ENV
-             #         replace:
-             #           path: ./block_device_claim.yml
-             #           regexp: "device-capacity"
-             #           replace: "{{ device_capacity }}"
-
-             #       - name: Creating Block-Device-Claim
-             #         shell: |
-             #           cat ./block_device_claim.yml > tmp_block_device_claim.yml
-             #           sed -i -e 's/device-name/{{item.1.stdout}}/g' -e 's/host-name/{{item.0}}/g' ./tmp_block_device_claim.yml
-             #           kubectl apply -f tmp_block_device_claim.yml
-             #           rm ./tmp_block_device_claim.yml
-             #         with_together: 
-             #           - "{{ nodes.stdout_lines }}"
-             #           - "{{ blockDevice.results }}"
-
-             #         - name: display spc.yml
-             #           debug: var=item
-             #           with_file:
-             #            - "spc.yml"
+          when: pool_type == "raidz2"     
 
         - name: Replacing the pool name in SPC spec
           replace:
             path: ./spc.yml
             regexp: "pool-name"
             replace: "{{ pool_name }}"
-                                             
+
         - name: Create cstor disk pool
           shell: kubectl apply -f spc.yml
           args:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -128,7 +128,10 @@
                line: '    - {{ item }}'
              with_items: "{{ bd_names }}" 
           
-          when: pool_type == "raidz2"     
+          when: pool_type == "raidz2"  
+
+        - set_fact:
+             device_count: "{{ blockDevice|length}}"   
 
         - name: Replacing the pool name in SPC spec
           replace:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -20,10 +20,115 @@
           shell: kubectl get nodes -l {{ node_label }} -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
           register: nodes
 
-        - name: Getting the Unclaimed block-device from each node
-          shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
-          register: blockDevice
-          with_items: "{{ nodes.stdout_lines }}"
+        - name: Replacing the pool type in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "pool-type"
+            replace: "{{ pool_type }}"
+        
+        - block:
+
+           - name: Getting the Unclaimed block-device from each node when pool type is STRIPE
+             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
+             register: blockDevice
+             with_items: "{{ nodes.stdout_lines }}"
+
+           - name: Initialize an empty list to store block device names
+             set_fact:
+               bd_names: []
+
+           - name: Store name of all block devices in the list 
+             set_fact:
+               bd_names: "{{ bd_names + item.stdout_lines }}"
+             with_items:
+              - "{{ blockDevice.results }}"
+               
+           - name: Adding discovered block device into SPC spec
+             lineinfile:
+               path: "./spc.yml"
+               insertafter: 'blockDeviceList:'
+               line: '    - {{ item }}'
+             with_items: "{{ bd_names }}"
+ 
+          when: pool_type == "striped" 
+
+        - block:
+
+           - name: Getting the Unclaimed block-devices from each node when pool type is MIRROR 
+             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 2
+             register: blockDevice
+             with_items: "{{ nodes.stdout_lines }}" 
+           
+           - name: Initialize an empty list to store block device names
+             set_fact:
+               bd_names: []
+
+           - name: Store name of all block devices in the list 
+             set_fact:
+               bd_names: "{{ bd_names + item.stdout_lines }}"
+             with_items:
+              - "{{ blockDevice.results }}"
+           
+           - name: Adding discovered block devices into SPC spec
+             lineinfile:
+               path: "./spc.yml"
+               insertafter: 'blockDeviceList:'
+               line: '    - {{ item }}'
+             with_items: "{{ bd_names }}"
+
+          when: pool_type == "mirrored"
+
+        - block:
+
+           - name: Getting the Unclaimed block-devices from each node when pool type is RAIDZ1
+             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 3
+             register: blockDevice
+             with_items: "{{ nodes.stdout_lines }}"
+
+           - name: Initialize an empty list to store block device names
+             set_fact:
+               bd_names: []
+
+           - name: Store name of all block devices in the list
+             set_fact:
+               bd_names: "{{ bd_names + item.stdout_lines }}"
+             with_items:
+              - "{{ blockDevice.results }}"
+
+           - name: Adding discovered block device into SPC spec
+             lineinfile:
+               path: "./spc.yml"
+               insertafter: 'blockDeviceList:'
+               line: '    - {{ item }}'
+             with_items: "{{ bd_names }}"
+
+          when: pool_type == "raidz"
+
+        - block:
+
+           - name: Getting the Unclaimed block-device from each node when pool type is RAIDZ2
+             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 6
+             register: blockDevice
+             with_items: "{{ nodes.stdout_lines }}"
+
+           - name: Initialize an empty list to store block device names
+             set_fact:
+               bd_names: []
+
+           - name: Store name of all block devices in the list
+             set_fact:
+               bd_names: "{{ bd_names + item.stdout_lines }}"
+             with_items:
+              - "{{ blockDevice.results }}"
+             
+           - name: Adding discovered block device into SPC spec
+             lineinfile:
+               path: "./spc.yml"
+               insertafter: 'blockDeviceList:'
+               line: '    - {{ item }}'
+             with_items: "{{ bd_names }}" 
+          
+          when: pool_type == "raidz2"
 
         - set_fact:
              device_count: "{{ blockDevice|length}}"
@@ -42,27 +147,19 @@
              #           rm ./tmp_block_device_claim.yml
              #         with_together: 
              #           - "{{ nodes.stdout_lines }}"
-             #           - "{{ blockDevice.results }}" 
+             #           - "{{ blockDevice.results }}"     
 
-        - name: Adding discovered block device into SPC spec
-          lineinfile:
-            path: "./spc.yml"
-            insertafter: 'blockDeviceList:'
-            line: '    - {{ item.stdout }}'
-          with_items: "{{ blockDevice.results }}"
+             #         - name: display spc.yml
+             #           debug: var=item
+             #           with_file:
+             #            - "spc.yml"
 
         - name: Replacing the pool name in SPC spec
           replace:
             path: ./spc.yml
             regexp: "pool-name"
             replace: "{{ pool_name }}"
-
-        - name: Replacing the pool type in SPC spec
-          replace:
-            path: ./spc.yml
-            regexp: "pool-type"
-            replace: "{{ pool_type }}"
-
+        
         - name: Create cstor disk pool
           shell: kubectl apply -f spc.yml
           args:

--- a/providers/cstor/cstor-block-device-pool/test_vars.yml
+++ b/providers/cstor/cstor-block-device-pool/test_vars.yml
@@ -3,5 +3,6 @@ device_capacity: "{{ lookup('env', 'DEVICE_CAPACITY') }}"
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 test_name: cstor-block-device-pool-provision
 pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
 


### PR DESCRIPTION
* Pool type is taken as environmental variable. It can take the value striped, mirrored, raidz, raidz2.
* The pool type value is replaced in spc.yml and when this yaml is applied, a spc is created which uses  
   unclaimed bds to create csps.
* The following files are modified :
       providers/cstor/cstor-block-device-pool/run_litmus_test.yml
       providers/cstor/cstor-block-device-pool/spc.yml
       providers/cstor/cstor-block-device-pool/test.yml
       providers/cstor/cstor-block-device-pool/test_vars.yml

Here are the logs for reference :
1. Striped pool
```
[root@gitlab-master cstor-block-device-pool]# kubectl logs cstor-block-device-pool-provision-vbk8g-2rkwz -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-03T09:03:46.207886 (delta: 0.060846)         elapsed: 0.060846 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-03T09:03:46.223625 (delta: 0.015683)         elapsed: 0.076585 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-07-03T09:03:56.633561 (delta: 10.409905)         elapsed: 10.486521 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-07-03T09:03:56.772367 (delta: 0.138731)         elapsed: 10.625327 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-03T09:03:56.851247 (delta: 0.078772)         elapsed: 10.704207 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-03T09:03:56.996954 (delta: 0.145647)         elapsed: 10.849914 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:03:57.177333 (delta: 0.180267)         elapsed: 11.030293 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1562144637.23-93939772232835/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:03:58.129736 (delta: 0.952344)         elapsed: 11.982696 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.078451", "end": "2019-07-03 09:03:59.718770", "rc": 0, "start": "2019-07-03 09:03:58.640319", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:03:59.808336 (delta: 1.678517)         elapsed: 13.661296 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.763082", "end": "2019-07-03 09:04:01.930954", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:04:00.167872", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:04:02.038457 (delta: 2.230053)         elapsed: 15.891417 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:04:02.148922 (delta: 0.110387)         elapsed: 16.001882 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:04:02.260657 (delta: 0.111645)         elapsed: 16.113617 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-07-03T09:04:02.386899 (delta: 0.12615)         elapsed: 16.239859 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.268337", "end": "2019-07-03 09:04:04.013230", "rc": 0, "start": "2019-07-03 09:04:02.744893", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node1.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node4.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node1.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node4.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2019-07-03T09:04:04.162018 (delta: 1.775028)         elapsed: 18.014978 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-07-03T09:04:04.760182 (delta: 0.598056)         elapsed: 18.613142 ******* 
changed: [127.0.0.1] => (item=gitlab-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.266785", "end": "2019-07-03 09:04:06.415501", "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:05.148716", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "stdout_lines": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1"]}
changed: [127.0.0.1] => (item=gitlab-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.353549", "end": "2019-07-03 09:04:08.157740", "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:06.804191", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-203c066c394c8df9d60ca7fc20854391", "stdout_lines": ["blockdevice-203c066c394c8df9d60ca7fc20854391"]}
changed: [127.0.0.1] => (item=gitlab-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.192545", "end": "2019-07-03 09:04:09.618407", "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:08.425862", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "stdout_lines": ["blockdevice-3b9a32c82609c11ccf655f1cac907f2e"]}
changed: [127.0.0.1] => (item=gitlab-node4.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.311011", "end": "2019-07-03 09:04:11.244047", "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:09.933036", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-002992bf333da45cf5f84febb2926d1c", "stdout_lines": ["blockdevice-002992bf333da45cf5f84febb2926d1c"]}
changed: [127.0.0.1] => (item=gitlab-node5.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.140832", "end": "2019-07-03 09:04:12.629163", "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:11.488331", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "stdout_lines": ["blockdevice-0919f46b5498b6b100c2b7bdcd48ff10"]}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:04:12.748997 (delta: 7.988746)         elapsed: 26.601957 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:04:12.958885 (delta: 0.209773)         elapsed: 26.811845 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-09cee9f04928bad03341276d2f0a7ca1', '_ansible_item_result': True, u'delta': u'0:00:01.266785', 'stdout_lines': [u'blockdevice-09cee9f04928bad03341276d2f0a7ca1'], '_ansible_item_label': u'gitlab-node1.mayalabs.io', u'end': u'2019-07-03 09:04:06.415501', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'gitlab-node1.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:04:05.148716', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.266785", "end": "2019-07-03 09:04:06.415501", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:05.148716", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "stdout_lines": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-203c066c394c8df9d60ca7fc20854391', '_ansible_item_result': True, u'delta': u'0:00:01.353549', 'stdout_lines': [u'blockdevice-203c066c394c8df9d60ca7fc20854391'], '_ansible_item_label': u'gitlab-node2.mayalabs.io', u'end': u'2019-07-03 09:04:08.157740', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'gitlab-node2.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:04:06.804191', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1", "blockdevice-203c066c394c8df9d60ca7fc20854391"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.353549", "end": "2019-07-03 09:04:08.157740", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:06.804191", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-203c066c394c8df9d60ca7fc20854391", "stdout_lines": ["blockdevice-203c066c394c8df9d60ca7fc20854391"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-3b9a32c82609c11ccf655f1cac907f2e', '_ansible_item_result': True, u'delta': u'0:00:01.192545', 'stdout_lines': [u'blockdevice-3b9a32c82609c11ccf655f1cac907f2e'], '_ansible_item_label': u'gitlab-node3.mayalabs.io', u'end': u'2019-07-03 09:04:09.618407', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'gitlab-node3.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:04:08.425862', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1", "blockdevice-203c066c394c8df9d60ca7fc20854391", "blockdevice-3b9a32c82609c11ccf655f1cac907f2e"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.192545", "end": "2019-07-03 09:04:09.618407", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:08.425862", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "stdout_lines": ["blockdevice-3b9a32c82609c11ccf655f1cac907f2e"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-002992bf333da45cf5f84febb2926d1c', '_ansible_item_result': True, u'delta': u'0:00:01.311011', 'stdout_lines': [u'blockdevice-002992bf333da45cf5f84febb2926d1c'], '_ansible_item_label': u'gitlab-node4.mayalabs.io', u'end': u'2019-07-03 09:04:11.244047', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'gitlab-node4.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:04:09.933036', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1", "blockdevice-203c066c394c8df9d60ca7fc20854391", "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "blockdevice-002992bf333da45cf5f84febb2926d1c"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.311011", "end": "2019-07-03 09:04:11.244047", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:09.933036", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-002992bf333da45cf5f84febb2926d1c", "stdout_lines": ["blockdevice-002992bf333da45cf5f84febb2926d1c"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0919f46b5498b6b100c2b7bdcd48ff10', '_ansible_item_result': True, u'delta': u'0:00:01.140832', 'stdout_lines': [u'blockdevice-0919f46b5498b6b100c2b7bdcd48ff10'], '_ansible_item_label': u'gitlab-node5.mayalabs.io', u'end': u'2019-07-03 09:04:12.629163', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'gitlab-node5.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:04:11.488331', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-09cee9f04928bad03341276d2f0a7ca1", "blockdevice-203c066c394c8df9d60ca7fc20854391", "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "blockdevice-002992bf333da45cf5f84febb2926d1c", "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.140832", "end": "2019-07-03 09:04:12.629163", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:04:11.488331", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "stdout_lines": ["blockdevice-0919f46b5498b6b100c2b7bdcd48ff10"]}}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:04:13.168680 (delta: 0.20973)         elapsed: 27.02164 ********* 
changed: [127.0.0.1] => (item=blockdevice-09cee9f04928bad03341276d2f0a7ca1) => {"backup": "", "changed": true, "item": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-203c066c394c8df9d60ca7fc20854391) => {"backup": "", "changed": true, "item": "blockdevice-203c066c394c8df9d60ca7fc20854391", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3b9a32c82609c11ccf655f1cac907f2e) => {"backup": "", "changed": true, "item": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-002992bf333da45cf5f84febb2926d1c) => {"backup": "", "changed": true, "item": "blockdevice-002992bf333da45cf5f84febb2926d1c", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-0919f46b5498b6b100c2b7bdcd48ff10) => {"backup": "", "changed": true, "item": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "msg": "line added"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-07-03T09:04:14.888807 (delta: 1.720041)         elapsed: 28.741767 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:04:15.137293 (delta: 0.248398)         elapsed: 28.990253 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:04:15.265679 (delta: 0.128326)         elapsed: 29.118639 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-07-03T09:04:15.548967 (delta: 0.2832)         elapsed: 29.401927 ********* 
skipping: [127.0.0.1] => (item=blockdevice-09cee9f04928bad03341276d2f0a7ca1)  => {"changed": false, "item": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-203c066c394c8df9d60ca7fc20854391)  => {"changed": false, "item": "blockdevice-203c066c394c8df9d60ca7fc20854391", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3b9a32c82609c11ccf655f1cac907f2e)  => {"changed": false, "item": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-002992bf333da45cf5f84febb2926d1c)  => {"changed": false, "item": "blockdevice-002992bf333da45cf5f84febb2926d1c", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0919f46b5498b6b100c2b7bdcd48ff10)  => {"changed": false, "item": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-07-03T09:04:15.695168 (delta: 0.146144)         elapsed: 29.548128 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:04:15.920647 (delta: 0.225394)         elapsed: 29.773607 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:04:16.056018 (delta: 0.135231)         elapsed: 29.908978 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:04:16.196473 (delta: 0.140399)         elapsed: 30.049433 ******* 
skipping: [127.0.0.1] => (item=blockdevice-09cee9f04928bad03341276d2f0a7ca1)  => {"changed": false, "item": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-203c066c394c8df9d60ca7fc20854391)  => {"changed": false, "item": "blockdevice-203c066c394c8df9d60ca7fc20854391", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3b9a32c82609c11ccf655f1cac907f2e)  => {"changed": false, "item": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-002992bf333da45cf5f84febb2926d1c)  => {"changed": false, "item": "blockdevice-002992bf333da45cf5f84febb2926d1c", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0919f46b5498b6b100c2b7bdcd48ff10)  => {"changed": false, "item": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-07-03T09:04:16.340571 (delta: 0.14404)         elapsed: 30.193531 ******** 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:04:16.568519 (delta: 0.22788)         elapsed: 30.421479 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:04:16.739943 (delta: 0.171305)         elapsed: 30.592903 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:04:17.009192 (delta: 0.269113)         elapsed: 30.862152 ******* 
skipping: [127.0.0.1] => (item=blockdevice-09cee9f04928bad03341276d2f0a7ca1)  => {"changed": false, "item": "blockdevice-09cee9f04928bad03341276d2f0a7ca1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-203c066c394c8df9d60ca7fc20854391)  => {"changed": false, "item": "blockdevice-203c066c394c8df9d60ca7fc20854391", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3b9a32c82609c11ccf655f1cac907f2e)  => {"changed": false, "item": "blockdevice-3b9a32c82609c11ccf655f1cac907f2e", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-002992bf333da45cf5f84febb2926d1c)  => {"changed": false, "item": "blockdevice-002992bf333da45cf5f84febb2926d1c", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0919f46b5498b6b100c2b7bdcd48ff10)  => {"changed": false, "item": "blockdevice-0919f46b5498b6b100c2b7bdcd48ff10", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-07-03T09:04:17.212690 (delta: 0.203394)         elapsed: 31.06565 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-07-03T09:04:17.315264 (delta: 0.102512)         elapsed: 31.168224 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-07-03T09:04:17.715941 (delta: 0.400621)         elapsed: 31.568901 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-pool-striped
spec:
  name: cstor-pool-striped
  type: disk
  poolSpec:
    poolType: striped
  blockDevices:
    blockDeviceList:
    - blockdevice-0919f46b5498b6b100c2b7bdcd48ff10
    - blockdevice-002992bf333da45cf5f84febb2926d1c
    - blockdevice-3b9a32c82609c11ccf655f1cac907f2e
    - blockdevice-203c066c394c8df9d60ca7fc20854391
    - blockdevice-09cee9f04928bad03341276d2f0a7ca1

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-disk
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-pool-striped
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-pool-striped\nspec:\n  name: cstor-pool-striped\n  type: disk\n  poolSpec:\n    poolType: striped\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-0919f46b5498b6b100c2b7bdcd48ff10\n    - blockdevice-002992bf333da45cf5f84febb2926d1c\n    - blockdevice-3b9a32c82609c11ccf655f1cac907f2e\n    - blockdevice-203c066c394c8df9d60ca7fc20854391\n    - blockdevice-09cee9f04928bad03341276d2f0a7ca1\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-disk\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-pool-striped\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-07-03T09:04:17.947035 (delta: 0.230967)         elapsed: 31.799995 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:02.510898", "end": "2019-07-03 09:04:20.827939", "rc": 0, "start": "2019-07-03 09:04:18.317041", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-pool-striped created\nstorageclass.storage.k8s.io/openebs-cstor-disk configured", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-pool-striped created", "storageclass.storage.k8s.io/openebs-cstor-disk configured"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-07-03T09:04:20.972472 (delta: 3.025337)         elapsed: 34.825432 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-striped --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.280456", "end": "2019-07-03 09:04:34.454377", "rc": 0, "start": "2019-07-03 09:04:33.173921", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-07-03T09:04:34.606848 (delta: 13.634268)         elapsed: 48.459808 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-striped --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.356722", "end": "2019-07-03 09:04:36.374810", "rc": 0, "start": "2019-07-03 09:04:35.018088", "stderr": "", "stderr_lines": [], "stdout": "cstor-pool-striped-7j3c-ff654cf5-kxcnt\ncstor-pool-striped-jfc5-68dc8664bb-7x6pg\ncstor-pool-striped-k9gq-5dc8566655-rdp2m\ncstor-pool-striped-lrn1-76f9679cb6-rrqj5\ncstor-pool-striped-q6ot-96756d5dd-8s6lr", "stdout_lines": ["cstor-pool-striped-7j3c-ff654cf5-kxcnt", "cstor-pool-striped-jfc5-68dc8664bb-7x6pg", "cstor-pool-striped-k9gq-5dc8566655-rdp2m", "cstor-pool-striped-lrn1-76f9679cb6-rrqj5", "cstor-pool-striped-q6ot-96756d5dd-8s6lr"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-07-03T09:04:36.453126 (delta: 1.846171)         elapsed: 50.306086 ******* 
changed: [127.0.0.1] => (item=cstor-pool-striped-7j3c-ff654cf5-kxcnt) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-striped-7j3c-ff654cf5-kxcnt -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.337409", "end": "2019-07-03 09:04:38.100400", "item": "cstor-pool-striped-7j3c-ff654cf5-kxcnt", "rc": 0, "start": "2019-07-03 09:04:36.762991", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-striped-jfc5-68dc8664bb-7x6pg) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-striped-jfc5-68dc8664bb-7x6pg -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.085230", "end": "2019-07-03 09:04:39.527160", "item": "cstor-pool-striped-jfc5-68dc8664bb-7x6pg", "rc": 0, "start": "2019-07-03 09:04:38.441930", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-striped-k9gq-5dc8566655-rdp2m) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-striped-k9gq-5dc8566655-rdp2m -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.219133", "end": "2019-07-03 09:04:41.137920", "item": "cstor-pool-striped-k9gq-5dc8566655-rdp2m", "rc": 0, "start": "2019-07-03 09:04:39.918787", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-striped-lrn1-76f9679cb6-rrqj5) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-striped-lrn1-76f9679cb6-rrqj5 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.084582", "end": "2019-07-03 09:04:42.501151", "item": "cstor-pool-striped-lrn1-76f9679cb6-rrqj5", "rc": 0, "start": "2019-07-03 09:04:41.416569", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-striped-q6ot-96756d5dd-8s6lr) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-striped-q6ot-96756d5dd-8s6lr -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.385885", "end": "2019-07-03 09:04:44.153608", "item": "cstor-pool-striped-q6ot-96756d5dd-8s6lr", "rc": 0, "start": "2019-07-03 09:04:42.767723", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-07-03T09:04:44.302862 (delta: 7.849668)         elapsed: 58.155822 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-03T09:04:44.530421 (delta: 0.227465)         elapsed: 58.383381 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:04:44.654798 (delta: 0.124197)         elapsed: 58.507758 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:04:44.735736 (delta: 0.080885)         elapsed: 58.588696 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:04:44.844113 (delta: 0.108271)         elapsed: 58.697073 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:04:44.968188 (delta: 0.123988)         elapsed: 58.821148 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1562144685.11-242175020277149/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:04:47.686553 (delta: 2.718266)         elapsed: 61.539513 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.991325", "end": "2019-07-03 09:04:48.953123", "rc": 0, "start": "2019-07-03 09:04:47.961798", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:04:49.023830 (delta: 1.337204)         elapsed: 62.87679 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.333021", "end": "2019-07-03 09:04:50.587417", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:04:49.254396", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=15   unreachable=0    failed=0   

2019-07-03T09:04:50.635136 (delta: 1.611247)         elapsed: 64.488096 ******* 
===============================================================================
```
```
[root@gitlab-master cstor-block-device-pool]# kubectl get spc
NAME                 AGE
cstor-pool-striped   1m
[root@gitlab-master cstor-block-device-pool]# kubectl get csp
NAME                      AGE
cstor-pool-striped-7j3c   1m
cstor-pool-striped-jfc5   1m
cstor-pool-striped-k9gq   1m
cstor-pool-striped-lrn1   1m
cstor-pool-striped-q6ot   1m
```
2. Mirrored pool
```
[root@gitlab-master cstor-block-device-pool]# kubectl logs cstor-block-device-pool-provision-snl7r-h5zqz -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-03T09:07:29.881303 (delta: 0.065211)         elapsed: 0.065211 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-03T09:07:29.898778 (delta: 0.017418)         elapsed: 0.082686 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-07-03T09:07:38.652858 (delta: 8.754039)         elapsed: 8.836766 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-07-03T09:07:38.785600 (delta: 0.132699)         elapsed: 8.969508 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-03T09:07:38.862535 (delta: 0.076839)         elapsed: 9.046443 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-03T09:07:38.934938 (delta: 0.07235)         elapsed: 9.118846 ********* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:07:39.115668 (delta: 0.180647)         elapsed: 9.299576 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1562144859.2-42946752328397/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:07:40.054258 (delta: 0.938512)         elapsed: 10.238166 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.142657", "end": "2019-07-03 09:07:41.699385", "rc": 0, "start": "2019-07-03 09:07:40.556728", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:07:41.783711 (delta: 1.729356)         elapsed: 11.967619 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.526109", "end": "2019-07-03 09:07:43.558857", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:07:42.032748", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:07:43.634356 (delta: 1.850509)         elapsed: 13.818264 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:07:43.700331 (delta: 0.065919)         elapsed: 13.884239 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:07:43.761767 (delta: 0.061379)         elapsed: 13.945675 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-07-03T09:07:43.823947 (delta: 0.062128)         elapsed: 14.007855 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.044419", "end": "2019-07-03 09:07:45.057902", "rc": 0, "start": "2019-07-03 09:07:44.013483", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node1.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node4.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node1.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node4.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2019-07-03T09:07:45.171744 (delta: 1.347741)         elapsed: 15.355652 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-07-03T09:07:45.770613 (delta: 0.598789)         elapsed: 15.954521 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:07:45.895863 (delta: 0.125151)         elapsed: 16.079771 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:07:45.965539 (delta: 0.069619)         elapsed: 16.149447 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:07:46.146734 (delta: 0.181141)         elapsed: 16.330642 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-07-03T09:07:46.276607 (delta: 0.129757)         elapsed: 16.460515 ******* 
changed: [127.0.0.1] => (item=gitlab-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.090846", "end": "2019-07-03 09:07:47.664761", "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:46.573915", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8", "stdout_lines": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8"]}
changed: [127.0.0.1] => (item=gitlab-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.344620", "end": "2019-07-03 09:07:49.377598", "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:48.032978", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5", "stdout_lines": ["blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5"]}
changed: [127.0.0.1] => (item=gitlab-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.253403", "end": "2019-07-03 09:07:50.969138", "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:49.715735", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873", "stdout_lines": ["blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873"]}
changed: [127.0.0.1] => (item=gitlab-node4.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.123375", "end": "2019-07-03 09:07:52.425491", "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:51.302116", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "stdout_lines": ["blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688"]}
changed: [127.0.0.1] => (item=gitlab-node5.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.169445", "end": "2019-07-03 09:07:53.802630", "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:52.633185", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105", "stdout_lines": ["blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105"]}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:07:53.948189 (delta: 7.671501)         elapsed: 24.132097 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:07:54.159710 (delta: 0.211422)         elapsed: 24.343618 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8', '_ansible_item_result': True, u'delta': u'0:00:01.090846', 'stdout_lines': [u'blockdevice-0b18c8a56722bf907286610fbc77bc42', u'blockdevice-19e671b7c0078253d79a13b74c2b5cf8'], '_ansible_item_label': u'gitlab-node1.mayalabs.io', u'end': u'2019-07-03 09:07:47.664761', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', 'item': u'gitlab-node1.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:07:46.573915', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.090846", "end": "2019-07-03 09:07:47.664761", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:46.573915", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8", "stdout_lines": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5', '_ansible_item_result': True, u'delta': u'0:00:01.344620', 'stdout_lines': [u'blockdevice-3700b8e078c27d888ae4492594f5de26', u'blockdevice-67e9022ac51b7b598b8184445dccbbf5'], '_ansible_item_label': u'gitlab-node2.mayalabs.io', u'end': u'2019-07-03 09:07:49.377598', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', 'item': u'gitlab-node2.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:07:48.032978', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.344620", "end": "2019-07-03 09:07:49.377598", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:48.032978", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5", "stdout_lines": ["blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873', '_ansible_item_result': True, u'delta': u'0:00:01.253403', 'stdout_lines': [u'blockdevice-58c877beaa1808d005c6a7d8b4f14c4d', u'blockdevice-59c88695dc6103c1d6f7ea5f609e6873'], '_ansible_item_label': u'gitlab-node3.mayalabs.io', u'end': u'2019-07-03 09:07:50.969138', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', 'item': u'gitlab-node3.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:07:49.715735', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.253403", "end": "2019-07-03 09:07:50.969138", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:49.715735", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873", "stdout_lines": ["blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688', '_ansible_item_result': True, u'delta': u'0:00:01.123375', 'stdout_lines': [u'blockdevice-2337b4e4dce9127489e8d763dfc8ec4e', u'blockdevice-2bc227616a53ce8c7aedb8e32a3fb688'], '_ansible_item_label': u'gitlab-node4.mayalabs.io', u'end': u'2019-07-03 09:07:52.425491', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', 'item': u'gitlab-node4.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:07:51.302116', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.123375", "end": "2019-07-03 09:07:52.425491", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:51.302116", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "stdout_lines": ["blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105', '_ansible_item_result': True, u'delta': u'0:00:01.169445', 'stdout_lines': [u'blockdevice-1608417717855f7bab3f03acdd0f8160', u'blockdevice-509edbbf8e0d1162268b03cfe6e98105'], '_ansible_item_label': u'gitlab-node5.mayalabs.io', u'end': u'2019-07-03 09:07:53.802630', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', 'item': u'gitlab-node5.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 2', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:07:52.633185', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "delta": "0:00:01.169445", "end": "2019-07-03 09:07:53.802630", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 2", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:07:52.633185", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105", "stdout_lines": ["blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105"]}}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-07-03T09:07:54.424098 (delta: 0.264288)         elapsed: 24.608006 ******* 
changed: [127.0.0.1] => (item=blockdevice-0b18c8a56722bf907286610fbc77bc42) => {"backup": "", "changed": true, "item": "blockdevice-0b18c8a56722bf907286610fbc77bc42", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-19e671b7c0078253d79a13b74c2b5cf8) => {"backup": "", "changed": true, "item": "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3700b8e078c27d888ae4492594f5de26) => {"backup": "", "changed": true, "item": "blockdevice-3700b8e078c27d888ae4492594f5de26", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-67e9022ac51b7b598b8184445dccbbf5) => {"backup": "", "changed": true, "item": "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-58c877beaa1808d005c6a7d8b4f14c4d) => {"backup": "", "changed": true, "item": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-59c88695dc6103c1d6f7ea5f609e6873) => {"backup": "", "changed": true, "item": "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-2337b4e4dce9127489e8d763dfc8ec4e) => {"backup": "", "changed": true, "item": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-2bc227616a53ce8c7aedb8e32a3fb688) => {"backup": "", "changed": true, "item": "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-1608417717855f7bab3f03acdd0f8160) => {"backup": "", "changed": true, "item": "blockdevice-1608417717855f7bab3f03acdd0f8160", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-509edbbf8e0d1162268b03cfe6e98105) => {"backup": "", "changed": true, "item": "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "msg": "line added"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-07-03T09:07:57.256953 (delta: 2.832777)         elapsed: 27.440861 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:07:57.488806 (delta: 0.231798)         elapsed: 27.672714 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:07:57.645011 (delta: 0.15611)         elapsed: 27.828919 ******** 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:07:57.783614 (delta: 0.138503)         elapsed: 27.967522 ******* 
skipping: [127.0.0.1] => (item=blockdevice-0b18c8a56722bf907286610fbc77bc42)  => {"changed": false, "item": "blockdevice-0b18c8a56722bf907286610fbc77bc42", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-19e671b7c0078253d79a13b74c2b5cf8)  => {"changed": false, "item": "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3700b8e078c27d888ae4492594f5de26)  => {"changed": false, "item": "blockdevice-3700b8e078c27d888ae4492594f5de26", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-67e9022ac51b7b598b8184445dccbbf5)  => {"changed": false, "item": "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-58c877beaa1808d005c6a7d8b4f14c4d)  => {"changed": false, "item": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-59c88695dc6103c1d6f7ea5f609e6873)  => {"changed": false, "item": "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-2337b4e4dce9127489e8d763dfc8ec4e)  => {"changed": false, "item": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-2bc227616a53ce8c7aedb8e32a3fb688)  => {"changed": false, "item": "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-1608417717855f7bab3f03acdd0f8160)  => {"changed": false, "item": "blockdevice-1608417717855f7bab3f03acdd0f8160", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-509edbbf8e0d1162268b03cfe6e98105)  => {"changed": false, "item": "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-07-03T09:07:57.965861 (delta: 0.182194)         elapsed: 28.149769 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:07:58.111088 (delta: 0.145167)         elapsed: 28.294996 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:07:58.227688 (delta: 0.11652)         elapsed: 28.411596 ******** 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:07:58.428282 (delta: 0.200495)         elapsed: 28.61219 ******** 
skipping: [127.0.0.1] => (item=blockdevice-0b18c8a56722bf907286610fbc77bc42)  => {"changed": false, "item": "blockdevice-0b18c8a56722bf907286610fbc77bc42", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-19e671b7c0078253d79a13b74c2b5cf8)  => {"changed": false, "item": "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3700b8e078c27d888ae4492594f5de26)  => {"changed": false, "item": "blockdevice-3700b8e078c27d888ae4492594f5de26", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-67e9022ac51b7b598b8184445dccbbf5)  => {"changed": false, "item": "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-58c877beaa1808d005c6a7d8b4f14c4d)  => {"changed": false, "item": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-59c88695dc6103c1d6f7ea5f609e6873)  => {"changed": false, "item": "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-2337b4e4dce9127489e8d763dfc8ec4e)  => {"changed": false, "item": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-2bc227616a53ce8c7aedb8e32a3fb688)  => {"changed": false, "item": "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-1608417717855f7bab3f03acdd0f8160)  => {"changed": false, "item": "blockdevice-1608417717855f7bab3f03acdd0f8160", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-509edbbf8e0d1162268b03cfe6e98105)  => {"changed": false, "item": "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-07-03T09:07:58.731704 (delta: 0.303361)         elapsed: 28.915612 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-07-03T09:07:58.906019 (delta: 0.174248)         elapsed: 29.089927 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-07-03T09:07:59.203470 (delta: 0.297357)         elapsed: 29.387378 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-pool-mirrored
spec:
  name: cstor-pool-mirrored
  type: disk
  poolSpec:
    poolType: mirrored
  blockDevices:
    blockDeviceList:
    - blockdevice-509edbbf8e0d1162268b03cfe6e98105
    - blockdevice-1608417717855f7bab3f03acdd0f8160
    - blockdevice-2bc227616a53ce8c7aedb8e32a3fb688
    - blockdevice-2337b4e4dce9127489e8d763dfc8ec4e
    - blockdevice-59c88695dc6103c1d6f7ea5f609e6873
    - blockdevice-58c877beaa1808d005c6a7d8b4f14c4d
    - blockdevice-67e9022ac51b7b598b8184445dccbbf5
    - blockdevice-3700b8e078c27d888ae4492594f5de26
    - blockdevice-19e671b7c0078253d79a13b74c2b5cf8
    - blockdevice-0b18c8a56722bf907286610fbc77bc42

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-disk
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-pool-mirrored
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-pool-mirrored\nspec:\n  name: cstor-pool-mirrored\n  type: disk\n  poolSpec:\n    poolType: mirrored\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-509edbbf8e0d1162268b03cfe6e98105\n    - blockdevice-1608417717855f7bab3f03acdd0f8160\n    - blockdevice-2bc227616a53ce8c7aedb8e32a3fb688\n    - blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\n    - blockdevice-59c88695dc6103c1d6f7ea5f609e6873\n    - blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\n    - blockdevice-67e9022ac51b7b598b8184445dccbbf5\n    - blockdevice-3700b8e078c27d888ae4492594f5de26\n    - blockdevice-19e671b7c0078253d79a13b74c2b5cf8\n    - blockdevice-0b18c8a56722bf907286610fbc77bc42\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-disk\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-pool-mirrored\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-07-03T09:07:59.326084 (delta: 0.122534)         elapsed: 29.509992 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.451687", "end": "2019-07-03 09:08:01.071397", "rc": 0, "start": "2019-07-03 09:07:59.619710", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-pool-mirrored created\nstorageclass.storage.k8s.io/openebs-cstor-disk configured", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-pool-mirrored created", "storageclass.storage.k8s.io/openebs-cstor-disk configured"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-07-03T09:08:01.201296 (delta: 1.875148)         elapsed: 31.385204 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-mirrored --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.185487", "end": "2019-07-03 09:08:14.263540", "rc": 0, "start": "2019-07-03 09:08:13.078053", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-07-03T09:08:14.401360 (delta: 13.199968)         elapsed: 44.585268 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-mirrored --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.300809", "end": "2019-07-03 09:08:16.013484", "rc": 0, "start": "2019-07-03 09:08:14.712675", "stderr": "", "stderr_lines": [], "stdout": "cstor-pool-mirrored-1lih-b4b596545-ppx2l\ncstor-pool-mirrored-du8u-5f74b99fdf-l5g5k\ncstor-pool-mirrored-eq3e-6b87474d78-vvhhh\ncstor-pool-mirrored-of3y-bc59558c-q9xnk\ncstor-pool-mirrored-wj1o-76474f855d-2qvd5", "stdout_lines": ["cstor-pool-mirrored-1lih-b4b596545-ppx2l", "cstor-pool-mirrored-du8u-5f74b99fdf-l5g5k", "cstor-pool-mirrored-eq3e-6b87474d78-vvhhh", "cstor-pool-mirrored-of3y-bc59558c-q9xnk", "cstor-pool-mirrored-wj1o-76474f855d-2qvd5"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-07-03T09:08:16.139493 (delta: 1.73804)         elapsed: 46.323401 ******** 
changed: [127.0.0.1] => (item=cstor-pool-mirrored-1lih-b4b596545-ppx2l) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-mirrored-1lih-b4b596545-ppx2l -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.253694", "end": "2019-07-03 09:08:17.800702", "item": "cstor-pool-mirrored-1lih-b4b596545-ppx2l", "rc": 0, "start": "2019-07-03 09:08:16.547008", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-mirrored-du8u-5f74b99fdf-l5g5k) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-mirrored-du8u-5f74b99fdf-l5g5k -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.004389", "end": "2019-07-03 09:08:19.076841", "item": "cstor-pool-mirrored-du8u-5f74b99fdf-l5g5k", "rc": 0, "start": "2019-07-03 09:08:18.072452", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-mirrored-eq3e-6b87474d78-vvhhh) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-mirrored-eq3e-6b87474d78-vvhhh -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.125033", "end": "2019-07-03 09:08:20.412300", "item": "cstor-pool-mirrored-eq3e-6b87474d78-vvhhh", "rc": 0, "start": "2019-07-03 09:08:19.287267", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-mirrored-of3y-bc59558c-q9xnk) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-mirrored-of3y-bc59558c-q9xnk -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.120556", "end": "2019-07-03 09:08:21.729858", "item": "cstor-pool-mirrored-of3y-bc59558c-q9xnk", "rc": 0, "start": "2019-07-03 09:08:20.609302", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-mirrored-wj1o-76474f855d-2qvd5) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-mirrored-wj1o-76474f855d-2qvd5 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.198006", "end": "2019-07-03 09:08:23.228945", "item": "cstor-pool-mirrored-wj1o-76474f855d-2qvd5", "rc": 0, "start": "2019-07-03 09:08:22.030939", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-07-03T09:08:23.333371 (delta: 7.193751)         elapsed: 53.517279 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-03T09:08:23.428910 (delta: 0.095466)         elapsed: 53.612818 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:08:23.591943 (delta: 0.162975)         elapsed: 53.775851 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:08:23.653747 (delta: 0.061748)         elapsed: 53.837655 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:08:23.768959 (delta: 0.115154)         elapsed: 53.952867 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:08:23.867345 (delta: 0.098324)         elapsed: 54.051253 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1562144903.95-61910789100428/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:08:26.757734 (delta: 2.890317)         elapsed: 56.941642 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.010021", "end": "2019-07-03 09:08:27.999385", "rc": 0, "start": "2019-07-03 09:08:26.989364", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:08:28.070139 (delta: 1.312302)         elapsed: 58.254047 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.381186", "end": "2019-07-03 09:08:29.776394", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:08:28.395208", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=15   unreachable=0    failed=0   

2019-07-03T09:08:29.819074 (delta: 1.748862)         elapsed: 60.002982 ******* 
=============================================================================== 
```
```
root@gitlab-master cstor-block-device-pool]# kubectl get spc
NAME                  AGE
cstor-pool-mirrored   2m
```
```
[root@gitlab-master cstor-block-device-pool]# kubectl get csp
NAME                       AGE
cstor-pool-mirrored-1lih   2m
cstor-pool-mirrored-du8u   2m
cstor-pool-mirrored-eq3e   2m
cstor-pool-mirrored-of3y   2m
cstor-pool-mirrored-wj1o   2m
```
3. RAIDZ1 pool
```
[root@gitlab-master cstor-block-device-pool]# kubectl logs cstor-block-device-pool-provision-mms94-64vr4 -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-03T09:12:01.622538 (delta: 0.07446)         elapsed: 0.07446 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-03T09:12:01.639256 (delta: 0.016665)         elapsed: 0.091178 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-07-03T09:12:10.155046 (delta: 8.515761)         elapsed: 8.606968 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-07-03T09:12:10.304034 (delta: 0.148939)         elapsed: 8.755956 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-03T09:12:10.397567 (delta: 0.093449)         elapsed: 8.849489 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-03T09:12:10.509965 (delta: 0.112331)         elapsed: 8.961887 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:12:10.741090 (delta: 0.231019)         elapsed: 9.193012 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1562145130.81-225146632651238/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:12:11.623645 (delta: 0.882502)         elapsed: 10.075567 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.100379", "end": "2019-07-03 09:12:13.130159", "rc": 0, "start": "2019-07-03 09:12:12.029780", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:12:13.193330 (delta: 1.569626)         elapsed: 11.645252 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.588681", "end": "2019-07-03 09:12:15.081170", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:12:13.492489", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:12:15.229570 (delta: 2.036184)         elapsed: 13.681492 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:12:15.388173 (delta: 0.158501)         elapsed: 13.840095 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:12:15.534317 (delta: 0.146006)         elapsed: 13.986239 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-07-03T09:12:15.615053 (delta: 0.080637)         elapsed: 14.066975 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.296285", "end": "2019-07-03 09:12:17.177127", "rc": 0, "start": "2019-07-03 09:12:15.880842", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node1.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node4.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node1.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node4.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2019-07-03T09:12:17.289464 (delta: 1.674352)         elapsed: 15.741386 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-07-03T09:12:18.003633 (delta: 0.714086)         elapsed: 16.455555 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:12:18.231477 (delta: 0.227766)         elapsed: 16.683399 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:12:18.379124 (delta: 0.147546)         elapsed: 16.831046 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:12:18.648550 (delta: 0.269312)         elapsed: 17.100472 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-07-03T09:12:18.750252 (delta: 0.101591)         elapsed: 17.202174 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:12:18.899637 (delta: 0.149289)         elapsed: 17.351559 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:12:19.033202 (delta: 0.133498)         elapsed: 17.485124 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-07-03T09:12:19.280461 (delta: 0.247143)         elapsed: 17.732383 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-07-03T09:12:19.372177 (delta: 0.091614)         elapsed: 17.824099 ******* 
changed: [127.0.0.1] => (item=gitlab-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.237179", "end": "2019-07-03 09:12:20.992110", "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:19.754931", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3", "stdout_lines": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3"]}
changed: [127.0.0.1] => (item=gitlab-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.135892", "end": "2019-07-03 09:12:22.454120", "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:21.318228", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "stdout_lines": ["blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8"]}
changed: [127.0.0.1] => (item=gitlab-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.159287", "end": "2019-07-03 09:12:23.981760", "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:22.822473", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "stdout_lines": ["blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f"]}
changed: [127.0.0.1] => (item=gitlab-node4.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.281701", "end": "2019-07-03 09:12:25.514396", "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:24.232695", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30", "stdout_lines": ["blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30"]}
changed: [127.0.0.1] => (item=gitlab-node5.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.335913", "end": "2019-07-03 09:12:27.102807", "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:25.766894", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd", "stdout_lines": ["blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd"]}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:12:27.172838 (delta: 7.800603)         elapsed: 25.62476 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:12:27.413889 (delta: 0.240993)         elapsed: 25.865811 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3', '_ansible_item_result': True, u'delta': u'0:00:01.237179', 'stdout_lines': [u'blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf', u'blockdevice-3850499c1621127269c18dd759047c73', u'blockdevice-5f5604843e5c0d03307d6e1546c750a3'], '_ansible_item_label': u'gitlab-node1.mayalabs.io', u'end': u'2019-07-03 09:12:20.992110', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', 'item': u'gitlab-node1.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:12:19.754931', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.237179", "end": "2019-07-03 09:12:20.992110", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:19.754931", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3", "stdout_lines": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8', '_ansible_item_result': True, u'delta': u'0:00:01.135892', 'stdout_lines': [u'blockdevice-6ba87bc42746b6a572c005e2bf90ea22', u'blockdevice-7310e793d62856fd19694bdc19c4f19c', u'blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8'], '_ansible_item_label': u'gitlab-node2.mayalabs.io', u'end': u'2019-07-03 09:12:22.454120', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', 'item': u'gitlab-node2.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:12:21.318228', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.135892", "end": "2019-07-03 09:12:22.454120", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:21.318228", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "stdout_lines": ["blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f', '_ansible_item_result': True, u'delta': u'0:00:01.159287', 'stdout_lines': [u'blockdevice-6814ed9ee317c3c23556eaddee85aef8', u'blockdevice-7b608b50c5fd29e45144768ee53ea692', u'blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f'], '_ansible_item_label': u'gitlab-node3.mayalabs.io', u'end': u'2019-07-03 09:12:23.981760', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', 'item': u'gitlab-node3.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:12:22.822473', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.159287", "end": "2019-07-03 09:12:23.981760", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:22.822473", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "stdout_lines": ["blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30', '_ansible_item_result': True, u'delta': u'0:00:01.281701', 'stdout_lines': [u'blockdevice-353a848af8fd1c3e9b99bc98624ac4cf', u'blockdevice-394aaedd6243a32f07355d9219f39816', u'blockdevice-3ae176a78d41cba7324d85fb01fb2f30'], '_ansible_item_label': u'gitlab-node4.mayalabs.io', u'end': u'2019-07-03 09:12:25.514396', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', 'item': u'gitlab-node4.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:12:24.232695', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.281701", "end": "2019-07-03 09:12:25.514396", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:24.232695", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30", "stdout_lines": ["blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd', '_ansible_item_result': True, u'delta': u'0:00:01.335913', 'stdout_lines': [u'blockdevice-5eff6e58ae82c9b2e81811cc728df4f0', u'blockdevice-6c54393992bbd43ecab8853b423a9c79', u'blockdevice-9b8ae7603686ec07d0571d205e5b89fd'], '_ansible_item_label': u'gitlab-node5.mayalabs.io', u'end': u'2019-07-03 09:12:27.102807', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', 'item': u'gitlab-node5.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 3', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:12:25.766894', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "delta": "0:00:01.335913", "end": "2019-07-03 09:12:27.102807", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 3", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:12:25.766894", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd", "stdout_lines": ["blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd"]}}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:12:27.690984 (delta: 0.276905)         elapsed: 26.142906 ******* 
changed: [127.0.0.1] => (item=blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf) => {"backup": "", "changed": true, "item": "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3850499c1621127269c18dd759047c73) => {"backup": "", "changed": true, "item": "blockdevice-3850499c1621127269c18dd759047c73", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-5f5604843e5c0d03307d6e1546c750a3) => {"backup": "", "changed": true, "item": "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6ba87bc42746b6a572c005e2bf90ea22) => {"backup": "", "changed": true, "item": "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-7310e793d62856fd19694bdc19c4f19c) => {"backup": "", "changed": true, "item": "blockdevice-7310e793d62856fd19694bdc19c4f19c", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8) => {"backup": "", "changed": true, "item": "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6814ed9ee317c3c23556eaddee85aef8) => {"backup": "", "changed": true, "item": "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-7b608b50c5fd29e45144768ee53ea692) => {"backup": "", "changed": true, "item": "blockdevice-7b608b50c5fd29e45144768ee53ea692", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f) => {"backup": "", "changed": true, "item": "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-353a848af8fd1c3e9b99bc98624ac4cf) => {"backup": "", "changed": true, "item": "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-394aaedd6243a32f07355d9219f39816) => {"backup": "", "changed": true, "item": "blockdevice-394aaedd6243a32f07355d9219f39816", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3ae176a78d41cba7324d85fb01fb2f30) => {"backup": "", "changed": true, "item": "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-5eff6e58ae82c9b2e81811cc728df4f0) => {"backup": "", "changed": true, "item": "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6c54393992bbd43ecab8853b423a9c79) => {"backup": "", "changed": true, "item": "blockdevice-6c54393992bbd43ecab8853b423a9c79", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-9b8ae7603686ec07d0571d205e5b89fd) => {"backup": "", "changed": true, "item": "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-07-03T09:12:31.477099 (delta: 3.786038)         elapsed: 29.929021 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:12:31.611521 (delta: 0.13437)         elapsed: 30.063443 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:12:31.702072 (delta: 0.090492)         elapsed: 30.153994 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:12:31.973429 (delta: 0.271266)         elapsed: 30.425351 ******* 
skipping: [127.0.0.1] => (item=blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf)  => {"changed": false, "item": "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3850499c1621127269c18dd759047c73)  => {"changed": false, "item": "blockdevice-3850499c1621127269c18dd759047c73", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-5f5604843e5c0d03307d6e1546c750a3)  => {"changed": false, "item": "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-6ba87bc42746b6a572c005e2bf90ea22)  => {"changed": false, "item": "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-7310e793d62856fd19694bdc19c4f19c)  => {"changed": false, "item": "blockdevice-7310e793d62856fd19694bdc19c4f19c", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8)  => {"changed": false, "item": "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-6814ed9ee317c3c23556eaddee85aef8)  => {"changed": false, "item": "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-7b608b50c5fd29e45144768ee53ea692)  => {"changed": false, "item": "blockdevice-7b608b50c5fd29e45144768ee53ea692", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f)  => {"changed": false, "item": "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-353a848af8fd1c3e9b99bc98624ac4cf)  => {"changed": false, "item": "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-394aaedd6243a32f07355d9219f39816)  => {"changed": false, "item": "blockdevice-394aaedd6243a32f07355d9219f39816", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-3ae176a78d41cba7324d85fb01fb2f30)  => {"changed": false, "item": "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-5eff6e58ae82c9b2e81811cc728df4f0)  => {"changed": false, "item": "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-6c54393992bbd43ecab8853b423a9c79)  => {"changed": false, "item": "blockdevice-6c54393992bbd43ecab8853b423a9c79", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-9b8ae7603686ec07d0571d205e5b89fd)  => {"changed": false, "item": "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-07-03T09:12:32.252179 (delta: 0.278652)         elapsed: 30.704101 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-07-03T09:12:32.364958 (delta: 0.112706)         elapsed: 30.81688 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-07-03T09:12:32.795221 (delta: 0.430147)         elapsed: 31.247143 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-pool-raidz1
spec:
  name: cstor-pool-raidz1
  type: disk
  poolSpec:
    poolType: raidz
  blockDevices:
    blockDeviceList:
    - blockdevice-9b8ae7603686ec07d0571d205e5b89fd
    - blockdevice-6c54393992bbd43ecab8853b423a9c79
    - blockdevice-5eff6e58ae82c9b2e81811cc728df4f0
    - blockdevice-3ae176a78d41cba7324d85fb01fb2f30
    - blockdevice-394aaedd6243a32f07355d9219f39816
    - blockdevice-353a848af8fd1c3e9b99bc98624ac4cf
    - blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f
    - blockdevice-7b608b50c5fd29e45144768ee53ea692
    - blockdevice-6814ed9ee317c3c23556eaddee85aef8
    - blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8
    - blockdevice-7310e793d62856fd19694bdc19c4f19c
    - blockdevice-6ba87bc42746b6a572c005e2bf90ea22
    - blockdevice-5f5604843e5c0d03307d6e1546c750a3
    - blockdevice-3850499c1621127269c18dd759047c73
    - blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-disk
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-pool-raidz1
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-pool-raidz1\nspec:\n  name: cstor-pool-raidz1\n  type: disk\n  poolSpec:\n    poolType: raidz\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-9b8ae7603686ec07d0571d205e5b89fd\n    - blockdevice-6c54393992bbd43ecab8853b423a9c79\n    - blockdevice-5eff6e58ae82c9b2e81811cc728df4f0\n    - blockdevice-3ae176a78d41cba7324d85fb01fb2f30\n    - blockdevice-394aaedd6243a32f07355d9219f39816\n    - blockdevice-353a848af8fd1c3e9b99bc98624ac4cf\n    - blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f\n    - blockdevice-7b608b50c5fd29e45144768ee53ea692\n    - blockdevice-6814ed9ee317c3c23556eaddee85aef8\n    - blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8\n    - blockdevice-7310e793d62856fd19694bdc19c4f19c\n    - blockdevice-6ba87bc42746b6a572c005e2bf90ea22\n    - blockdevice-5f5604843e5c0d03307d6e1546c750a3\n    - blockdevice-3850499c1621127269c18dd759047c73\n    - blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-disk\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-pool-raidz1\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-07-03T09:12:33.023130 (delta: 0.227818)         elapsed: 31.475052 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.489082", "end": "2019-07-03 09:12:34.725619", "rc": 0, "start": "2019-07-03 09:12:33.236537", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-pool-raidz1 created\nstorageclass.storage.k8s.io/openebs-cstor-disk configured", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-pool-raidz1 created", "storageclass.storage.k8s.io/openebs-cstor-disk configured"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-07-03T09:12:34.812779 (delta: 1.789518)         elapsed: 33.264701 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-raidz1 --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.033905", "end": "2019-07-03 09:12:48.599333", "rc": 0, "start": "2019-07-03 09:12:47.565428", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-07-03T09:12:48.681346 (delta: 13.868514)         elapsed: 47.133268 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-raidz1 --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.005143", "end": "2019-07-03 09:12:49.884701", "rc": 0, "start": "2019-07-03 09:12:48.879558", "stderr": "", "stderr_lines": [], "stdout": "cstor-pool-raidz1-3ovx-554bfd55c9-s87nr\ncstor-pool-raidz1-ua8e-64585ff856-fv2h2\ncstor-pool-raidz1-uf79-549dfdc579-lfjd5\ncstor-pool-raidz1-w7qj-6cb6fcf787-m97hc\ncstor-pool-raidz1-xm4a-b546d588-gth9h", "stdout_lines": ["cstor-pool-raidz1-3ovx-554bfd55c9-s87nr", "cstor-pool-raidz1-ua8e-64585ff856-fv2h2", "cstor-pool-raidz1-uf79-549dfdc579-lfjd5", "cstor-pool-raidz1-w7qj-6cb6fcf787-m97hc", "cstor-pool-raidz1-xm4a-b546d588-gth9h"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-07-03T09:12:49.952493 (delta: 1.271081)         elapsed: 48.404415 ******* 
changed: [127.0.0.1] => (item=cstor-pool-raidz1-3ovx-554bfd55c9-s87nr) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz1-3ovx-554bfd55c9-s87nr -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.159611", "end": "2019-07-03 09:12:51.316920", "item": "cstor-pool-raidz1-3ovx-554bfd55c9-s87nr", "rc": 0, "start": "2019-07-03 09:12:50.157309", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz1-ua8e-64585ff856-fv2h2) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz1-ua8e-64585ff856-fv2h2 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.198912", "end": "2019-07-03 09:12:52.706260", "item": "cstor-pool-raidz1-ua8e-64585ff856-fv2h2", "rc": 0, "start": "2019-07-03 09:12:51.507348", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz1-uf79-549dfdc579-lfjd5) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz1-uf79-549dfdc579-lfjd5 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.271120", "end": "2019-07-03 09:12:54.315699", "item": "cstor-pool-raidz1-uf79-549dfdc579-lfjd5", "rc": 0, "start": "2019-07-03 09:12:53.044579", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz1-w7qj-6cb6fcf787-m97hc) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz1-w7qj-6cb6fcf787-m97hc -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.192493", "end": "2019-07-03 09:12:55.802169", "item": "cstor-pool-raidz1-w7qj-6cb6fcf787-m97hc", "rc": 0, "start": "2019-07-03 09:12:54.609676", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz1-xm4a-b546d588-gth9h) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz1-xm4a-b546d588-gth9h -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.188012", "end": "2019-07-03 09:12:57.302787", "item": "cstor-pool-raidz1-xm4a-b546d588-gth9h", "rc": 0, "start": "2019-07-03 09:12:56.114775", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-07-03T09:12:57.454962 (delta: 7.502416)         elapsed: 55.906884 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-03T09:12:57.562212 (delta: 0.107169)         elapsed: 56.014134 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:12:57.680024 (delta: 0.117743)         elapsed: 56.131946 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:12:57.742492 (delta: 0.062414)         elapsed: 56.194414 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:12:57.811075 (delta: 0.06853)         elapsed: 56.262997 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:12:57.880685 (delta: 0.069538)         elapsed: 56.332607 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1562145177.95-179954350884877/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:13:00.559597 (delta: 2.678854)         elapsed: 59.011519 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.818317", "end": "2019-07-03 09:13:01.619936", "rc": 0, "start": "2019-07-03 09:13:00.801619", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:13:01.695117 (delta: 1.135449)         elapsed: 60.147039 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.472489", "end": "2019-07-03 09:13:03.494419", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:13:02.021930", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=15   unreachable=0    failed=0   

2019-07-03T09:13:03.569829 (delta: 1.874659)         elapsed: 62.021751 ******* 
=============================================================================== 
```
```
[root@gitlab-master cstor-block-device-pool]# kubectl get spc
NAME                  AGE
cstor-pool-raidz1     2m
```
```
[root@gitlab-master cstor-block-device-pool]# kubectl get csp
NAME                       AGE
cstor-pool-raidz1-3ovx     2m
cstor-pool-raidz1-ua8e     2m
cstor-pool-raidz1-uf79     2m
cstor-pool-raidz1-w7qj     2m
cstor-pool-raidz1-xm4a     2m
```
4. RAIDZ2 pool
```
[root@gitlab-master cstor-block-device-pool]# kubectl logs cstor-block-device-pool-provision-p9v9g-bg5m4 -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-03T09:18:19.214672 (delta: 0.060045)         elapsed: 0.060045 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-03T09:18:19.229989 (delta: 0.015246)         elapsed: 0.075362 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-07-03T09:18:27.755546 (delta: 8.525537)         elapsed: 8.600919 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-07-03T09:18:27.908652 (delta: 0.153031)         elapsed: 8.754025 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-03T09:18:27.977324 (delta: 0.068612)         elapsed: 8.822697 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-03T09:18:28.078056 (delta: 0.100659)         elapsed: 8.923429 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:18:28.278381 (delta: 0.200256)         elapsed: 9.123754 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1562145508.35-26416201069127/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:18:29.304641 (delta: 1.026198)         elapsed: 10.150014 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.955482", "end": "2019-07-03 09:18:30.728692", "rc": 0, "start": "2019-07-03 09:18:29.773210", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:18:30.794598 (delta: 1.489896)         elapsed: 11.639971 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.744986", "end": "2019-07-03 09:18:33.799407", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:18:31.054421", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision unchanged", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:18:33.947043 (delta: 3.152392)         elapsed: 14.792416 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:18:34.077631 (delta: 0.130492)         elapsed: 14.923004 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:18:34.207910 (delta: 0.13018)         elapsed: 15.053283 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-07-03T09:18:34.351816 (delta: 0.14381)         elapsed: 15.197189 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.206882", "end": "2019-07-03 09:18:35.853894", "rc": 0, "start": "2019-07-03 09:18:34.647012", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node1.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node4.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node1.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node4.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2019-07-03T09:18:35.950466 (delta: 1.598552)         elapsed: 16.795839 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-07-03T09:18:36.437747 (delta: 0.487211)         elapsed: 17.28312 ******** 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:18:36.574138 (delta: 0.136336)         elapsed: 17.419511 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:18:36.678971 (delta: 0.104775)         elapsed: 17.524344 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:18:36.870370 (delta: 0.1913)         elapsed: 17.715743 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-07-03T09:18:36.981656 (delta: 0.111203)         elapsed: 17.827029 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:18:37.200758 (delta: 0.21902)         elapsed: 18.046131 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:18:37.287308 (delta: 0.086452)         elapsed: 18.132681 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-07-03T09:18:37.447295 (delta: 0.159933)         elapsed: 18.292668 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-07-03T09:18:37.613074 (delta: 0.165712)         elapsed: 18.458447 ******* 
skipping: [127.0.0.1] => (item=gitlab-node1.mayalabs.io)  => {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node2.mayalabs.io)  => {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node3.mayalabs.io)  => {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node4.mayalabs.io)  => {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=gitlab-node5.mayalabs.io)  => {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:18:37.848459 (delta: 0.235297)         elapsed: 18.693832 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:18:37.999135 (delta: 0.150577)         elapsed: 18.844508 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'gitlab-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'gitlab-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "gitlab-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:18:38.281437 (delta: 0.282202)         elapsed: 19.12681 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-07-03T09:18:38.361232 (delta: 0.079712)         elapsed: 19.206605 ******* 
changed: [127.0.0.1] => (item=gitlab-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.063336", "end": "2019-07-03 09:18:39.703551", "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:38.640215", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8\nblockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3\nblockdevice-6a06573cc750b81fcab00e129a51d976", "stdout_lines": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976"]}
changed: [127.0.0.1] => (item=gitlab-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.044312", "end": "2019-07-03 09:18:41.039107", "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:39.994795", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5\nblockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8\nblockdevice-917c5055872b8a3011d4403ba526944b", "stdout_lines": ["blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b"]}
changed: [127.0.0.1] => (item=gitlab-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.328543", "end": "2019-07-03 09:18:42.616597", "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:41.288054", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873\nblockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f\nblockdevice-adecd32f0c0528e28aab7adf432bb578", "stdout_lines": ["blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-adecd32f0c0528e28aab7adf432bb578"]}
changed: [127.0.0.1] => (item=gitlab-node4.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.025715", "end": "2019-07-03 09:18:44.004438", "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:42.978723", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688\nblockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30\nblockdevice-43e91227f3ccd9f11dfb903f2c53b31e", "stdout_lines": ["blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "blockdevice-43e91227f3ccd9f11dfb903f2c53b31e"]}
changed: [127.0.0.1] => (item=gitlab-node5.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.042680", "end": "2019-07-03 09:18:45.220078", "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:44.177398", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105\nblockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd\nblockdevice-c063ae7a8ff9114a2917f632c9463660", "stdout_lines": ["blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "blockdevice-c063ae7a8ff9114a2917f632c9463660"]}

TASK [Initialize an empty list to store block device names] ********************
2019-07-03T09:18:45.385361 (delta: 7.02403)         elapsed: 26.230734 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-07-03T09:18:45.676341 (delta: 0.290878)         elapsed: 26.521714 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8\nblockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3\nblockdevice-6a06573cc750b81fcab00e129a51d976', '_ansible_item_result': True, u'delta': u'0:00:01.063336', 'stdout_lines': [u'blockdevice-0b18c8a56722bf907286610fbc77bc42', u'blockdevice-19e671b7c0078253d79a13b74c2b5cf8', u'blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf', u'blockdevice-3850499c1621127269c18dd759047c73', u'blockdevice-5f5604843e5c0d03307d6e1546c750a3', u'blockdevice-6a06573cc750b81fcab00e129a51d976'], '_ansible_item_label': u'gitlab-node1.mayalabs.io', u'end': u'2019-07-03 09:18:39.703551', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', 'item': u'gitlab-node1.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:18:38.640215', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.063336", "end": "2019-07-03 09:18:39.703551", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node1.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:38.640215", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0b18c8a56722bf907286610fbc77bc42\nblockdevice-19e671b7c0078253d79a13b74c2b5cf8\nblockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\nblockdevice-3850499c1621127269c18dd759047c73\nblockdevice-5f5604843e5c0d03307d6e1546c750a3\nblockdevice-6a06573cc750b81fcab00e129a51d976", "stdout_lines": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5\nblockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8\nblockdevice-917c5055872b8a3011d4403ba526944b', '_ansible_item_result': True, u'delta': u'0:00:01.044312', 'stdout_lines': [u'blockdevice-3700b8e078c27d888ae4492594f5de26', u'blockdevice-67e9022ac51b7b598b8184445dccbbf5', u'blockdevice-6ba87bc42746b6a572c005e2bf90ea22', u'blockdevice-7310e793d62856fd19694bdc19c4f19c', u'blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8', u'blockdevice-917c5055872b8a3011d4403ba526944b'], '_ansible_item_label': u'gitlab-node2.mayalabs.io', u'end': u'2019-07-03 09:18:41.039107', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', 'item': u'gitlab-node2.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:18:39.994795', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.044312", "end": "2019-07-03 09:18:41.039107", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node2.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:39.994795", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-3700b8e078c27d888ae4492594f5de26\nblockdevice-67e9022ac51b7b598b8184445dccbbf5\nblockdevice-6ba87bc42746b6a572c005e2bf90ea22\nblockdevice-7310e793d62856fd19694bdc19c4f19c\nblockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8\nblockdevice-917c5055872b8a3011d4403ba526944b", "stdout_lines": ["blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873\nblockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f\nblockdevice-adecd32f0c0528e28aab7adf432bb578', '_ansible_item_result': True, u'delta': u'0:00:01.328543', 'stdout_lines': [u'blockdevice-58c877beaa1808d005c6a7d8b4f14c4d', u'blockdevice-59c88695dc6103c1d6f7ea5f609e6873', u'blockdevice-6814ed9ee317c3c23556eaddee85aef8', u'blockdevice-7b608b50c5fd29e45144768ee53ea692', u'blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f', u'blockdevice-adecd32f0c0528e28aab7adf432bb578'], '_ansible_item_label': u'gitlab-node3.mayalabs.io', u'end': u'2019-07-03 09:18:42.616597', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', 'item': u'gitlab-node3.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:18:41.288054', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-adecd32f0c0528e28aab7adf432bb578"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.328543", "end": "2019-07-03 09:18:42.616597", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node3.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:41.288054", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\nblockdevice-59c88695dc6103c1d6f7ea5f609e6873\nblockdevice-6814ed9ee317c3c23556eaddee85aef8\nblockdevice-7b608b50c5fd29e45144768ee53ea692\nblockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f\nblockdevice-adecd32f0c0528e28aab7adf432bb578", "stdout_lines": ["blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-adecd32f0c0528e28aab7adf432bb578"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688\nblockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30\nblockdevice-43e91227f3ccd9f11dfb903f2c53b31e', '_ansible_item_result': True, u'delta': u'0:00:01.025715', 'stdout_lines': [u'blockdevice-2337b4e4dce9127489e8d763dfc8ec4e', u'blockdevice-2bc227616a53ce8c7aedb8e32a3fb688', u'blockdevice-353a848af8fd1c3e9b99bc98624ac4cf', u'blockdevice-394aaedd6243a32f07355d9219f39816', u'blockdevice-3ae176a78d41cba7324d85fb01fb2f30', u'blockdevice-43e91227f3ccd9f11dfb903f2c53b31e'], '_ansible_item_label': u'gitlab-node4.mayalabs.io', u'end': u'2019-07-03 09:18:44.004438', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', 'item': u'gitlab-node4.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:18:42.978723', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-adecd32f0c0528e28aab7adf432bb578", "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "blockdevice-43e91227f3ccd9f11dfb903f2c53b31e"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.025715", "end": "2019-07-03 09:18:44.004438", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node4.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:42.978723", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\nblockdevice-2bc227616a53ce8c7aedb8e32a3fb688\nblockdevice-353a848af8fd1c3e9b99bc98624ac4cf\nblockdevice-394aaedd6243a32f07355d9219f39816\nblockdevice-3ae176a78d41cba7324d85fb01fb2f30\nblockdevice-43e91227f3ccd9f11dfb903f2c53b31e", "stdout_lines": ["blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "blockdevice-43e91227f3ccd9f11dfb903f2c53b31e"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105\nblockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd\nblockdevice-c063ae7a8ff9114a2917f632c9463660', '_ansible_item_result': True, u'delta': u'0:00:01.042680', 'stdout_lines': [u'blockdevice-1608417717855f7bab3f03acdd0f8160', u'blockdevice-509edbbf8e0d1162268b03cfe6e98105', u'blockdevice-5eff6e58ae82c9b2e81811cc728df4f0', u'blockdevice-6c54393992bbd43ecab8853b423a9c79', u'blockdevice-9b8ae7603686ec07d0571d205e5b89fd', u'blockdevice-c063ae7a8ff9114a2917f632c9463660'], '_ansible_item_label': u'gitlab-node5.mayalabs.io', u'end': u'2019-07-03 09:18:45.220078', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', 'item': u'gitlab-node5.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 6', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-03 09:18:44.177398', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0b18c8a56722bf907286610fbc77bc42", "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "blockdevice-3850499c1621127269c18dd759047c73", "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "blockdevice-6a06573cc750b81fcab00e129a51d976", "blockdevice-3700b8e078c27d888ae4492594f5de26", "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "blockdevice-7310e793d62856fd19694bdc19c4f19c", "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "blockdevice-917c5055872b8a3011d4403ba526944b", "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "blockdevice-7b608b50c5fd29e45144768ee53ea692", "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "blockdevice-adecd32f0c0528e28aab7adf432bb578", "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "blockdevice-394aaedd6243a32f07355d9219f39816", "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "blockdevice-43e91227f3ccd9f11dfb903f2c53b31e", "blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "blockdevice-c063ae7a8ff9114a2917f632c9463660"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "delta": "0:00:01.042680", "end": "2019-07-03 09:18:45.220078", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gitlab-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 6", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "gitlab-node5.mayalabs.io", "rc": 0, "start": "2019-07-03 09:18:44.177398", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1608417717855f7bab3f03acdd0f8160\nblockdevice-509edbbf8e0d1162268b03cfe6e98105\nblockdevice-5eff6e58ae82c9b2e81811cc728df4f0\nblockdevice-6c54393992bbd43ecab8853b423a9c79\nblockdevice-9b8ae7603686ec07d0571d205e5b89fd\nblockdevice-c063ae7a8ff9114a2917f632c9463660", "stdout_lines": ["blockdevice-1608417717855f7bab3f03acdd0f8160", "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "blockdevice-6c54393992bbd43ecab8853b423a9c79", "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "blockdevice-c063ae7a8ff9114a2917f632c9463660"]}}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-03T09:18:45.990443 (delta: 0.314007)         elapsed: 26.835816 ******* 
changed: [127.0.0.1] => (item=blockdevice-0b18c8a56722bf907286610fbc77bc42) => {"backup": "", "changed": true, "item": "blockdevice-0b18c8a56722bf907286610fbc77bc42", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-19e671b7c0078253d79a13b74c2b5cf8) => {"backup": "", "changed": true, "item": "blockdevice-19e671b7c0078253d79a13b74c2b5cf8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf) => {"backup": "", "changed": true, "item": "blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3850499c1621127269c18dd759047c73) => {"backup": "", "changed": true, "item": "blockdevice-3850499c1621127269c18dd759047c73", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-5f5604843e5c0d03307d6e1546c750a3) => {"backup": "", "changed": true, "item": "blockdevice-5f5604843e5c0d03307d6e1546c750a3", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6a06573cc750b81fcab00e129a51d976) => {"backup": "", "changed": true, "item": "blockdevice-6a06573cc750b81fcab00e129a51d976", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3700b8e078c27d888ae4492594f5de26) => {"backup": "", "changed": true, "item": "blockdevice-3700b8e078c27d888ae4492594f5de26", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-67e9022ac51b7b598b8184445dccbbf5) => {"backup": "", "changed": true, "item": "blockdevice-67e9022ac51b7b598b8184445dccbbf5", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6ba87bc42746b6a572c005e2bf90ea22) => {"backup": "", "changed": true, "item": "blockdevice-6ba87bc42746b6a572c005e2bf90ea22", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-7310e793d62856fd19694bdc19c4f19c) => {"backup": "", "changed": true, "item": "blockdevice-7310e793d62856fd19694bdc19c4f19c", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8) => {"backup": "", "changed": true, "item": "blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-917c5055872b8a3011d4403ba526944b) => {"backup": "", "changed": true, "item": "blockdevice-917c5055872b8a3011d4403ba526944b", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-58c877beaa1808d005c6a7d8b4f14c4d) => {"backup": "", "changed": true, "item": "blockdevice-58c877beaa1808d005c6a7d8b4f14c4d", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-59c88695dc6103c1d6f7ea5f609e6873) => {"backup": "", "changed": true, "item": "blockdevice-59c88695dc6103c1d6f7ea5f609e6873", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6814ed9ee317c3c23556eaddee85aef8) => {"backup": "", "changed": true, "item": "blockdevice-6814ed9ee317c3c23556eaddee85aef8", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-7b608b50c5fd29e45144768ee53ea692) => {"backup": "", "changed": true, "item": "blockdevice-7b608b50c5fd29e45144768ee53ea692", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f) => {"backup": "", "changed": true, "item": "blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-adecd32f0c0528e28aab7adf432bb578) => {"backup": "", "changed": true, "item": "blockdevice-adecd32f0c0528e28aab7adf432bb578", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-2337b4e4dce9127489e8d763dfc8ec4e) => {"backup": "", "changed": true, "item": "blockdevice-2337b4e4dce9127489e8d763dfc8ec4e", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-2bc227616a53ce8c7aedb8e32a3fb688) => {"backup": "", "changed": true, "item": "blockdevice-2bc227616a53ce8c7aedb8e32a3fb688", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-353a848af8fd1c3e9b99bc98624ac4cf) => {"backup": "", "changed": true, "item": "blockdevice-353a848af8fd1c3e9b99bc98624ac4cf", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-394aaedd6243a32f07355d9219f39816) => {"backup": "", "changed": true, "item": "blockdevice-394aaedd6243a32f07355d9219f39816", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-3ae176a78d41cba7324d85fb01fb2f30) => {"backup": "", "changed": true, "item": "blockdevice-3ae176a78d41cba7324d85fb01fb2f30", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-43e91227f3ccd9f11dfb903f2c53b31e) => {"backup": "", "changed": true, "item": "blockdevice-43e91227f3ccd9f11dfb903f2c53b31e", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-1608417717855f7bab3f03acdd0f8160) => {"backup": "", "changed": true, "item": "blockdevice-1608417717855f7bab3f03acdd0f8160", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-509edbbf8e0d1162268b03cfe6e98105) => {"backup": "", "changed": true, "item": "blockdevice-509edbbf8e0d1162268b03cfe6e98105", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-5eff6e58ae82c9b2e81811cc728df4f0) => {"backup": "", "changed": true, "item": "blockdevice-5eff6e58ae82c9b2e81811cc728df4f0", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-6c54393992bbd43ecab8853b423a9c79) => {"backup": "", "changed": true, "item": "blockdevice-6c54393992bbd43ecab8853b423a9c79", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-9b8ae7603686ec07d0571d205e5b89fd) => {"backup": "", "changed": true, "item": "blockdevice-9b8ae7603686ec07d0571d205e5b89fd", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-c063ae7a8ff9114a2917f632c9463660) => {"backup": "", "changed": true, "item": "blockdevice-c063ae7a8ff9114a2917f632c9463660", "msg": "line added"}

TASK [set_fact] ****************************************************************
2019-07-03T09:18:53.505494 (delta: 7.51499)         elapsed: 34.350867 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-07-03T09:18:53.624462 (delta: 0.118916)         elapsed: 34.469835 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-07-03T09:18:53.952532 (delta: 0.327996)         elapsed: 34.797905 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-pool-raidz2
spec:
  name: cstor-pool-raidz2
  type: disk
  poolSpec:
    poolType: raidz2
  blockDevices:
    blockDeviceList:
    - blockdevice-c063ae7a8ff9114a2917f632c9463660
    - blockdevice-9b8ae7603686ec07d0571d205e5b89fd
    - blockdevice-6c54393992bbd43ecab8853b423a9c79
    - blockdevice-5eff6e58ae82c9b2e81811cc728df4f0
    - blockdevice-509edbbf8e0d1162268b03cfe6e98105
    - blockdevice-1608417717855f7bab3f03acdd0f8160
    - blockdevice-43e91227f3ccd9f11dfb903f2c53b31e
    - blockdevice-3ae176a78d41cba7324d85fb01fb2f30
    - blockdevice-394aaedd6243a32f07355d9219f39816
    - blockdevice-353a848af8fd1c3e9b99bc98624ac4cf
    - blockdevice-2bc227616a53ce8c7aedb8e32a3fb688
    - blockdevice-2337b4e4dce9127489e8d763dfc8ec4e
    - blockdevice-adecd32f0c0528e28aab7adf432bb578
    - blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f
    - blockdevice-7b608b50c5fd29e45144768ee53ea692
    - blockdevice-6814ed9ee317c3c23556eaddee85aef8
    - blockdevice-59c88695dc6103c1d6f7ea5f609e6873
    - blockdevice-58c877beaa1808d005c6a7d8b4f14c4d
    - blockdevice-917c5055872b8a3011d4403ba526944b
    - blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8
    - blockdevice-7310e793d62856fd19694bdc19c4f19c
    - blockdevice-6ba87bc42746b6a572c005e2bf90ea22
    - blockdevice-67e9022ac51b7b598b8184445dccbbf5
    - blockdevice-3700b8e078c27d888ae4492594f5de26
    - blockdevice-6a06573cc750b81fcab00e129a51d976
    - blockdevice-5f5604843e5c0d03307d6e1546c750a3
    - blockdevice-3850499c1621127269c18dd759047c73
    - blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf
    - blockdevice-19e671b7c0078253d79a13b74c2b5cf8
    - blockdevice-0b18c8a56722bf907286610fbc77bc42

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-disk
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-pool-raidz2
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-pool-raidz2\nspec:\n  name: cstor-pool-raidz2\n  type: disk\n  poolSpec:\n    poolType: raidz2\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-c063ae7a8ff9114a2917f632c9463660\n    - blockdevice-9b8ae7603686ec07d0571d205e5b89fd\n    - blockdevice-6c54393992bbd43ecab8853b423a9c79\n    - blockdevice-5eff6e58ae82c9b2e81811cc728df4f0\n    - blockdevice-509edbbf8e0d1162268b03cfe6e98105\n    - blockdevice-1608417717855f7bab3f03acdd0f8160\n    - blockdevice-43e91227f3ccd9f11dfb903f2c53b31e\n    - blockdevice-3ae176a78d41cba7324d85fb01fb2f30\n    - blockdevice-394aaedd6243a32f07355d9219f39816\n    - blockdevice-353a848af8fd1c3e9b99bc98624ac4cf\n    - blockdevice-2bc227616a53ce8c7aedb8e32a3fb688\n    - blockdevice-2337b4e4dce9127489e8d763dfc8ec4e\n    - blockdevice-adecd32f0c0528e28aab7adf432bb578\n    - blockdevice-a7f90bf5a03e9c6f5f7c3e5015bc230f\n    - blockdevice-7b608b50c5fd29e45144768ee53ea692\n    - blockdevice-6814ed9ee317c3c23556eaddee85aef8\n    - blockdevice-59c88695dc6103c1d6f7ea5f609e6873\n    - blockdevice-58c877beaa1808d005c6a7d8b4f14c4d\n    - blockdevice-917c5055872b8a3011d4403ba526944b\n    - blockdevice-8e900b0da4154cd5c3b8da2ed8a16fe8\n    - blockdevice-7310e793d62856fd19694bdc19c4f19c\n    - blockdevice-6ba87bc42746b6a572c005e2bf90ea22\n    - blockdevice-67e9022ac51b7b598b8184445dccbbf5\n    - blockdevice-3700b8e078c27d888ae4492594f5de26\n    - blockdevice-6a06573cc750b81fcab00e129a51d976\n    - blockdevice-5f5604843e5c0d03307d6e1546c750a3\n    - blockdevice-3850499c1621127269c18dd759047c73\n    - blockdevice-28bfdfd4b8fe0dbd8ec8ac0238e911cf\n    - blockdevice-19e671b7c0078253d79a13b74c2b5cf8\n    - blockdevice-0b18c8a56722bf907286610fbc77bc42\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-disk\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-pool-raidz2\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-07-03T09:18:54.080107 (delta: 0.127524)         elapsed: 34.92548 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.358797", "end": "2019-07-03 09:18:55.681220", "rc": 0, "start": "2019-07-03 09:18:54.322423", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-pool-raidz2 configured\nstorageclass.storage.k8s.io/openebs-cstor-disk unchanged", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-pool-raidz2 configured", "storageclass.storage.k8s.io/openebs-cstor-disk unchanged"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-07-03T09:18:55.779003 (delta: 1.69883)         elapsed: 36.624376 ******** 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-raidz2 --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.166066", "end": "2019-07-03 09:19:08.788997", "rc": 0, "start": "2019-07-03 09:19:07.622931", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-07-03T09:19:08.879442 (delta: 13.100345)         elapsed: 49.724815 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-pool-raidz2 --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.249078", "end": "2019-07-03 09:19:10.495790", "rc": 0, "start": "2019-07-03 09:19:09.246712", "stderr": "", "stderr_lines": [], "stdout": "cstor-pool-raidz2-05to-6777d8fccf-vwlll\ncstor-pool-raidz2-3irm-79db577957-nqwkc\ncstor-pool-raidz2-lk7a-65cfbb578-jxh7c\ncstor-pool-raidz2-wkh6-bd57b9659-m2nrj\ncstor-pool-raidz2-wt4v-59f684c4c9-h8xgp", "stdout_lines": ["cstor-pool-raidz2-05to-6777d8fccf-vwlll", "cstor-pool-raidz2-3irm-79db577957-nqwkc", "cstor-pool-raidz2-lk7a-65cfbb578-jxh7c", "cstor-pool-raidz2-wkh6-bd57b9659-m2nrj", "cstor-pool-raidz2-wt4v-59f684c4c9-h8xgp"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-07-03T09:19:10.592097 (delta: 1.712562)         elapsed: 51.43747 ******** 
changed: [127.0.0.1] => (item=cstor-pool-raidz2-05to-6777d8fccf-vwlll) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz2-05to-6777d8fccf-vwlll -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.079610", "end": "2019-07-03 09:19:12.044154", "item": "cstor-pool-raidz2-05to-6777d8fccf-vwlll", "rc": 0, "start": "2019-07-03 09:19:10.964544", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz2-3irm-79db577957-nqwkc) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz2-3irm-79db577957-nqwkc -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.218302", "end": "2019-07-03 09:19:13.600993", "item": "cstor-pool-raidz2-3irm-79db577957-nqwkc", "rc": 0, "start": "2019-07-03 09:19:12.382691", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz2-lk7a-65cfbb578-jxh7c) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz2-lk7a-65cfbb578-jxh7c -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.088992", "end": "2019-07-03 09:19:14.968703", "item": "cstor-pool-raidz2-lk7a-65cfbb578-jxh7c", "rc": 0, "start": "2019-07-03 09:19:13.879711", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz2-wkh6-bd57b9659-m2nrj) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz2-wkh6-bd57b9659-m2nrj -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.205711", "end": "2019-07-03 09:19:16.527205", "item": "cstor-pool-raidz2-wkh6-bd57b9659-m2nrj", "rc": 0, "start": "2019-07-03 09:19:15.321494", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-pool-raidz2-wt4v-59f684c4c9-h8xgp) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-pool-raidz2-wt4v-59f684c4c9-h8xgp -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.229300", "end": "2019-07-03 09:19:18.038349", "item": "cstor-pool-raidz2-wt4v-59f684c4c9-h8xgp", "rc": 0, "start": "2019-07-03 09:19:16.809049", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-07-03T09:19:18.176925 (delta: 7.584759)         elapsed: 59.022298 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-03T09:19:18.333697 (delta: 0.156683)         elapsed: 59.17907 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-03T09:19:18.507232 (delta: 0.173454)         elapsed: 59.352605 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:19:18.574269 (delta: 0.06696)         elapsed: 59.419642 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:19:18.641058 (delta: 0.066733)         elapsed: 59.486431 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-03T09:19:18.707800 (delta: 0.066685)         elapsed: 59.553173 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1562145558.76-276181130652942/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-03T09:19:20.935704 (delta: 2.227846)         elapsed: 61.781077 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.876469", "end": "2019-07-03 09:19:22.142462", "rc": 0, "start": "2019-07-03 09:19:21.265993", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-03T09:19:22.216134 (delta: 1.280335)         elapsed: 63.061507 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.560714", "end": "2019-07-03 09:19:24.102607", "failed_when_result": false, "rc": 0, "start": "2019-07-03 09:19:22.541893", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=15   unreachable=0    failed=0   

2019-07-03T09:19:24.163399 (delta: 1.947198)         elapsed: 65.008772 ******* 
=============================================================================== 
```
```
root@gitlab-master cstor-block-device-pool]# kubectl get spc
NAME                 AGE
cstor-pool-raidz2    7m
```
```
[root@gitlab-master cstor-block-device-pool]# kubectl get csp
NAME                      AGE
cstor-pool-raidz2-05to    4m
cstor-pool-raidz2-3irm    4m
cstor-pool-raidz2-lk7a    4m
cstor-pool-raidz2-wkh6    4m
cstor-pool-raidz2-wt4v    4m
```

- Negative test:
  The minimum number of disks for each type of pool is :
   striped    - 1
   mirrored  - 2
   raidz1      - 3
   raidz2      - 6
The corresponding pools will not be created if less number of unclaimed bds are taken from each node( It is tested by giving less number in test.yml)
 
* For the chaos experiment app_node_failure_diff_aws corrected the folder name in run_litmus_test.yml. Following file is modified:
   /litmus/experiments/chaos/app_node_failure_diff_aws/run_litmus_test.yml
   