### PR TITLE
Refactored litmus books to take storage class name as env

### DIFF
--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -35,7 +35,7 @@ spec:
             
            # Provide the name of STORAGE_CLASS 
           - name: STORAGE_CLASS
-            value: openebs-cstor-striped
+            value: openebs-cstor-disk
 
           - name: OPERATOR_NS
             value: openebs

--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -32,6 +32,10 @@ spec:
            # Supported values: striped, mirrored, raidz ,raidz2
           - name: POOL_TYPE
             value: striped
+            
+           # Provide the name of STORAGE_CLASS 
+          - name: STORAGE_CLASS
+            value: openebs-cstor-striped
 
           - name: OPERATOR_NS
             value: openebs

--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -14,7 +14,7 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: openebs-cstor-disk
+  name: sc-name
   annotations:
     openebs.io/cas-type: cstor
     cas.openebs.io/config: |

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -139,6 +139,12 @@
             regexp: "pool-name"
             replace: "{{ pool_name }}"
 
+        - name: Replacing the storage class name in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "sc-name"
+            replace: "{{ sc_name }}"
+
         - name: Display spc.yml for verification 
           debug: var=item
           with_file:

--- a/providers/cstor/cstor-block-device-pool/test_vars.yml
+++ b/providers/cstor/cstor-block-device-pool/test_vars.yml
@@ -4,5 +4,6 @@ operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 test_name: cstor-block-device-pool-provision
 pool_name: "{{ lookup('env','POOL_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
+sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
 


### PR DESCRIPTION
* Storage class name is taken as environmental variable.
* The storage class with name specified in run_litmus_test ( specified value in STORAGE_CLASS) will be created along with csps when run_litmus_test.yml is applied.
* The following files are modified.
        modified:   providers/cstor/cstor-block-device-pool/run_litmus_test.yml
	modified:   providers/cstor/cstor-block-device-pool/spc.yml
	modified:   providers/cstor/cstor-block-device-pool/test.yml
	modified:   providers/cstor/cstor-block-device-pool/test_vars.yml

The litmus books are tested for by creating striped pool and corresponding storage class by applying run_litmus_test.yml. Here is the log:
```
[root@master-1558702621 cstor-block-device-pool]# kubectl logs cstor-block-device-pool-provision-2xt7f-dcjvk -n litmus -f
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-04T12:08:51.780391 (delta: 0.073301)         elapsed: 0.073301 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-04T12:08:51.795363 (delta: 0.014911)         elapsed: 0.088273 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-07-04T12:09:01.209384 (delta: 9.413985)         elapsed: 9.502294 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-07-04T12:09:01.364756 (delta: 0.155308)         elapsed: 9.657666 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-04T12:09:01.467341 (delta: 0.102499)         elapsed: 9.760251 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-04T12:09:01.588098 (delta: 0.120672)         elapsed: 9.881008 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-04T12:09:01.752591 (delta: 0.164377)         elapsed: 10.045501 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1562242141.83-116689758429919/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-04T12:09:02.753861 (delta: 1.001158)         elapsed: 11.046771 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.070893", "end": "2019-07-04 12:09:04.307408", "rc": 0, "start": "2019-07-04 12:09:03.236515", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-04T12:09:04.373097 (delta: 1.619166)         elapsed: 12.666007 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.767257", "end": "2019-07-04 12:09:06.379199", "failed_when_result": false, "rc": 0, "start": "2019-07-04 12:09:04.611942", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-04T12:09:06.502083 (delta: 2.128904)         elapsed: 14.794993 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-04T12:09:06.613781 (delta: 0.111612)         elapsed: 14.906691 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-04T12:09:06.708769 (delta: 0.094868)         elapsed: 15.001679 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-07-04T12:09:06.816018 (delta: 0.107164)         elapsed: 15.108928 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.304871", "end": "2019-07-04 12:09:08.491344", "rc": 0, "start": "2019-07-04 12:09:07.186473", "stderr": "", "stderr_lines": [], "stdout": "node1-1558702621.mayalabs.io\nnode2-1558702621.mayalabs.io\nnode3-1558702621.mayalabs.io", "stdout_lines": ["node1-1558702621.mayalabs.io", "node2-1558702621.mayalabs.io", "node3-1558702621.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2019-07-04T12:09:08.563123 (delta: 1.74702)         elapsed: 16.856033 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-07-04T12:09:09.151013 (delta: 0.587802)         elapsed: 17.443923 ******* 
changed: [127.0.0.1] => (item=node1-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.420829", "end": "2019-07-04 12:09:10.885292", "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:09.464463", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "stdout_lines": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}
changed: [127.0.0.1] => (item=node2-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.265257", "end": "2019-07-04 12:09:12.422686", "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:11.157429", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "stdout_lines": ["blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}
changed: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.287966", "end": "2019-07-04 12:09:14.046221", "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:12.758255", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "stdout_lines": ["blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}

TASK [Initialize an empty list to store block device names] ********************
2019-07-04T12:09:14.124921 (delta: 4.973846)         elapsed: 22.417831 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-07-04T12:09:14.268168 (delta: 0.143177)         elapsed: 22.561078 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-02e3b9154843d37193dfca5c9b57898b', '_ansible_item_result': True, u'delta': u'0:00:01.420829', 'stdout_lines': [u'blockdevice-02e3b9154843d37193dfca5c9b57898b'], '_ansible_item_label': u'node1-1558702621.mayalabs.io', u'end': u'2019-07-04 12:09:10.885292', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node1-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-04 12:09:09.464463', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.420829", "end": "2019-07-04 12:09:10.885292", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:09.464463", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "stdout_lines": ["blockdevice-02e3b9154843d37193dfca5c9b57898b"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-90f2c077b9a006599c5b0392c29c01f0', '_ansible_item_result': True, u'delta': u'0:00:01.265257', 'stdout_lines': [u'blockdevice-90f2c077b9a006599c5b0392c29c01f0'], '_ansible_item_label': u'node2-1558702621.mayalabs.io', u'end': u'2019-07-04 12:09:12.422686', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node2-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-04 12:09:11.157429', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-02e3b9154843d37193dfca5c9b57898b", "blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.265257", "end": "2019-07-04 12:09:12.422686", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:11.157429", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "stdout_lines": ["blockdevice-90f2c077b9a006599c5b0392c29c01f0"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0', '_ansible_item_result': True, u'delta': u'0:00:01.287966', 'stdout_lines': [u'blockdevice-bc4fe53d881d0e06c41ba19db67b20d0'], '_ansible_item_label': u'node3-1558702621.mayalabs.io', u'end': u'2019-07-04 12:09:14.046221', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'node3-1558702621.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-07-04 12:09:12.758255', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-02e3b9154843d37193dfca5c9b57898b", "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.287966", "end": "2019-07-04 12:09:14.046221", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-07-04 12:09:12.758255", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "stdout_lines": ["blockdevice-bc4fe53d881d0e06c41ba19db67b20d0"]}}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-04T12:09:14.491724 (delta: 0.223465)         elapsed: 22.784634 ******* 
changed: [127.0.0.1] => (item=blockdevice-02e3b9154843d37193dfca5c9b57898b) => {"backup": "", "changed": true, "item": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-90f2c077b9a006599c5b0392c29c01f0) => {"backup": "", "changed": true, "item": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-bc4fe53d881d0e06c41ba19db67b20d0) => {"backup": "", "changed": true, "item": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "msg": "line added"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-07-04T12:09:15.797209 (delta: 1.305399)         elapsed: 24.090119 ******* 
skipping: [127.0.0.1] => (item=node1-1558702621.mayalabs.io)  => {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node2-1558702621.mayalabs.io)  => {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node3-1558702621.mayalabs.io)  => {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-04T12:09:15.918338 (delta: 0.121062)         elapsed: 24.211248 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-04T12:09:16.009340 (delta: 0.090927)         elapsed: 24.30225 ******** 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node1-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node1-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node2-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node2-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node3-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node3-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-07-04T12:09:16.164032 (delta: 0.154603)         elapsed: 24.456942 ******* 
skipping: [127.0.0.1] => (item=blockdevice-02e3b9154843d37193dfca5c9b57898b)  => {"changed": false, "item": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-90f2c077b9a006599c5b0392c29c01f0)  => {"changed": false, "item": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-bc4fe53d881d0e06c41ba19db67b20d0)  => {"changed": false, "item": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-07-04T12:09:16.325864 (delta: 0.161746)         elapsed: 24.618774 ******* 
skipping: [127.0.0.1] => (item=node1-1558702621.mayalabs.io)  => {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node2-1558702621.mayalabs.io)  => {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node3-1558702621.mayalabs.io)  => {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-04T12:09:16.486361 (delta: 0.160417)         elapsed: 24.779271 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-04T12:09:16.583526 (delta: 0.09708)         elapsed: 24.876436 ******** 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node1-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node1-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node2-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node2-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node3-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node3-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-04T12:09:16.742399 (delta: 0.158785)         elapsed: 25.035309 ******* 
skipping: [127.0.0.1] => (item=blockdevice-02e3b9154843d37193dfca5c9b57898b)  => {"changed": false, "item": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-90f2c077b9a006599c5b0392c29c01f0)  => {"changed": false, "item": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-bc4fe53d881d0e06c41ba19db67b20d0)  => {"changed": false, "item": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-07-04T12:09:16.910453 (delta: 0.167935)         elapsed: 25.203363 ******* 
skipping: [127.0.0.1] => (item=node1-1558702621.mayalabs.io)  => {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node2-1558702621.mayalabs.io)  => {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=node3-1558702621.mayalabs.io)  => {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-07-04T12:09:17.108473 (delta: 0.197904)         elapsed: 25.401383 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-07-04T12:09:17.202052 (delta: 0.093479)         elapsed: 25.494962 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node1-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node1-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node1-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node2-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node2-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node2-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'node3-1558702621.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'node3-1558702621.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "node3-1558702621.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-07-04T12:09:17.292792 (delta: 0.090674)         elapsed: 25.585702 ******* 
skipping: [127.0.0.1] => (item=blockdevice-02e3b9154843d37193dfca5c9b57898b)  => {"changed": false, "item": "blockdevice-02e3b9154843d37193dfca5c9b57898b", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-90f2c077b9a006599c5b0392c29c01f0)  => {"changed": false, "item": "blockdevice-90f2c077b9a006599c5b0392c29c01f0", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-bc4fe53d881d0e06c41ba19db67b20d0)  => {"changed": false, "item": "blockdevice-bc4fe53d881d0e06c41ba19db67b20d0", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-07-04T12:09:17.378896 (delta: 0.086045)         elapsed: 25.671806 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-07-04T12:09:17.487394 (delta: 0.10844)         elapsed: 25.780304 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the storage class name in SPC spec] ****************************
2019-07-04T12:09:17.844484 (delta: 0.357016)         elapsed: 26.137394 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-07-04T12:09:18.251699 (delta: 0.40713)         elapsed: 26.544609 ******** 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-block-disk-pool-striped
spec:
  name: cstor-block-disk-pool-striped
  type: disk
  poolSpec:
    poolType: striped
  blockDevices:
    blockDeviceList:
    - blockdevice-bc4fe53d881d0e06c41ba19db67b20d0
    - blockdevice-90f2c077b9a006599c5b0392c29c01f0
    - blockdevice-02e3b9154843d37193dfca5c9b57898b

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-striped
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-block-disk-pool-striped
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-block-disk-pool-striped\nspec:\n  name: cstor-block-disk-pool-striped\n  type: disk\n  poolSpec:\n    poolType: striped\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-bc4fe53d881d0e06c41ba19db67b20d0\n    - blockdevice-90f2c077b9a006599c5b0392c29c01f0\n    - blockdevice-02e3b9154843d37193dfca5c9b57898b\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-striped\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-block-disk-pool-striped\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-07-04T12:09:18.394330 (delta: 0.142567)         elapsed: 26.68724 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.472332", "end": "2019-07-04 12:09:20.167170", "rc": 0, "start": "2019-07-04 12:09:18.694838", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-block-disk-pool-striped created\nstorageclass.storage.k8s.io/openebs-cstor-striped configured", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-block-disk-pool-striped created", "storageclass.storage.k8s.io/openebs-cstor-striped configured"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-07-04T12:09:20.268215 (delta: 1.873786)         elapsed: 28.561125 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool-striped --no-headers -o custom-columns=:status.phase", "delta": "0:00:02.336174", "end": "2019-07-04 12:09:34.399048", "rc": 0, "start": "2019-07-04 12:09:32.062874", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-07-04T12:09:34.498198 (delta: 14.22989)         elapsed: 42.791108 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool-striped --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.238555", "end": "2019-07-04 12:09:36.093178", "rc": 0, "start": "2019-07-04 12:09:34.854623", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-striped-7snt-6bcd9cd956-prlkp\ncstor-block-disk-pool-striped-bn9x-86768bbcf4-6rjnv\ncstor-block-disk-pool-striped-md8c-69bfbb5f58-wns72", "stdout_lines": ["cstor-block-disk-pool-striped-7snt-6bcd9cd956-prlkp", "cstor-block-disk-pool-striped-bn9x-86768bbcf4-6rjnv", "cstor-block-disk-pool-striped-md8c-69bfbb5f58-wns72"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-07-04T12:09:36.184965 (delta: 1.686686)         elapsed: 44.477875 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-striped-7snt-6bcd9cd956-prlkp) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-striped-7snt-6bcd9cd956-prlkp -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.319375", "end": "2019-07-04 12:09:37.858271", "item": "cstor-block-disk-pool-striped-7snt-6bcd9cd956-prlkp", "rc": 0, "start": "2019-07-04 12:09:36.538896", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-striped-bn9x-86768bbcf4-6rjnv) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-striped-bn9x-86768bbcf4-6rjnv -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.256623", "end": "2019-07-04 12:09:39.446153", "item": "cstor-block-disk-pool-striped-bn9x-86768bbcf4-6rjnv", "rc": 0, "start": "2019-07-04 12:09:38.189530", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-striped-md8c-69bfbb5f58-wns72) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-striped-md8c-69bfbb5f58-wns72 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.511942", "end": "2019-07-04 12:09:41.258897", "item": "cstor-block-disk-pool-striped-md8c-69bfbb5f58-wns72", "rc": 0, "start": "2019-07-04 12:09:39.746955", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2019-07-04T12:09:41.339589 (delta: 5.15451)         elapsed: 49.632499 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-04T12:09:41.467829 (delta: 0.128137)         elapsed: 49.760739 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-04T12:09:41.637071 (delta: 0.16912)         elapsed: 49.929981 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-04T12:09:41.743619 (delta: 0.106421)         elapsed: 50.036529 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-04T12:09:41.834573 (delta: 0.090834)         elapsed: 50.127483 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-04T12:09:41.930186 (delta: 0.095467)         elapsed: 50.223096 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1562242182.07-134145570624448/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-04T12:09:44.934731 (delta: 3.004403)         elapsed: 53.227641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.140219", "end": "2019-07-04 12:09:46.444109", "rc": 0, "start": "2019-07-04 12:09:45.303890", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-04T12:09:46.499882 (delta: 1.565067)         elapsed: 54.792792 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.505251", "end": "2019-07-04 12:09:48.250119", "failed_when_result": false, "rc": 0, "start": "2019-07-04 12:09:46.744868", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=25   changed=16   unreachable=0    failed=0   

2019-07-04T12:09:48.322221 (delta: 1.822283)         elapsed: 56.615131 ******* 
=============================================================================== 
```
```
[root@master-1558702621 cstor-block-device-pool]# kubectl get spc
NAME                            AGE
cstor-block-disk-pool-striped   48s
[root@master-1558702621 cstor-block-device-pool]# kubectl get csp
NAME                                 AGE
cstor-block-disk-pool-striped-7snt   52s
cstor-block-disk-pool-striped-bn9x   53s
cstor-block-disk-pool-striped-md8c   53s
```
```
[root@master-1558702621 cstor-block-device-pool]# kubectl get sc
NAME                        PROVISIONER                                                AGE
openebs-cstor-striped       openebs.io/provisioner-iscsi                               19m
```