### PR TITLE
Modified the percona workload litmusbook to replace the default values in config file

### DIFF
--- a/apps/percona/workload/run_litmus_test.yml
+++ b/apps/percona/workload/run_litmus_test.yml
@@ -48,5 +48,17 @@ spec:
           - name: LOAD_DURATION
             value: "600"
 
+          - name: TPCC_WAREHOUSES
+            value: "1"
+
+          - name: TPCC_CONNECTIONS
+            value: "18"
+
+          - name: TPCC_WARMUP_PERIOD
+            value: "10"
+
+          - name: LOAD_INTERVAL
+            value: "10"                                    
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/percona/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -71,6 +71,30 @@
             regexp: "test_duration"
             replace: "{{ load_duration }}"
 
+        - name: Replace the warehouse placeholder in tpcc-config file
+          replace:
+            path: "{{ tpcc_conf }}"
+            regexp: "test_warehouse"
+            replace: "{{ test_warehouse }}"
+
+        - name: Replace the test connections placeholder in tpcc-config file
+          replace:
+            path: "{{ tpcc_conf }}"
+            regexp: "test_connections"
+            replace: "{{ test_connections }}"
+
+        - name: Replace the test warmup-period placeholder in tpcc-config file
+          replace:
+            path: "{{ tpcc_conf }}"
+            regexp: "test_warmup_period"
+            replace: "{{ test_warmup_period }}"
+
+        - name: Replace the test interval placeholder in tpcc-config file
+          replace:
+            path: "{{ tpcc_conf }}"
+            regexp: "test_interval"
+            replace: "{{ test_interval }}"            
+
         - name: Getting the Service IP of Application
           shell: kubectl get svc -n {{ namespace }} -l {{ app_service_label }} -o jsonpath='{.items[0].spec.clusterIP}'
           register: ip

--- a/apps/percona/workload/test_vars.yml
+++ b/apps/percona/workload/test_vars.yml
@@ -7,4 +7,8 @@ db_user: "{{ lookup('env','DB_USER') }}"
 db_password: "{{ lookup('env','DB_PASSWORD') }}"
 app_label: "{{ lookup('env','APP_LABEL') }}"
 load_duration: "{{ lookup('env','LOAD_DURATION') }}"
+test_warehouse: "{{ lookup('env','TPCC_WAREHOUSES') }}"
+test_connections: "{{ lookup('env','TPCC_CONNECTIONS') }}"
+test_warmup_period: "{{ lookup('env','TPCC_WARMUP_PERIOD') }}"
+test_interval: "{{ lookup('env','LOAD_INTERVAL') }}"
 tpcc_conf: tpcc.conf

--- a/apps/percona/workload/tpcc.conf
+++ b/apps/percona/workload/tpcc.conf
@@ -1,9 +1,9 @@
 {
   "db_user": "test_user",
   "db_password": "test_password",
-  "warehouses": "1",
-  "connections": "18",
-  "warmup_period": "10",
+  "warehouses": "test_warehouse",
+  "connections": "test_connections",
+  "warmup_period": "test_warmup_period",
   "run_duration": "test_duration",
-  "interval": "10" 
+  "interval": "test_interval"
 }


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included tasks to replace the parameters in tpcc.conf file
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-07-09T15:22:19.228843 (delta: 0.074773)         elapsed: 0.074773 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-07-09T15:22:19.248779 (delta: 0.019883)         elapsed: 0.094709 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2019-07-09T15:22:29.016887 (delta: 9.768068)         elapsed: 9.862817 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-07-09T15:22:29.114902 (delta: 0.097965)         elapsed: 9.960832 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-07-09T15:22:29.237713 (delta: 0.122742)         elapsed: 10.083643 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-09T15:22:29.474834 (delta: 0.237037)         elapsed: 10.320764 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "e2a8bbcc65577a46d465c968879c892833f16089", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f40274fe56cca39bea71d21eff72f52", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1562685749.55-260279930820387/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-09T15:22:30.440625 (delta: 0.965729)         elapsed: 11.286555 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.051643", "end": "2019-07-09 15:22:31.931262", "rc": 0, "start": "2019-07-09 15:22:30.879619", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-loadgen \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-loadgen ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-09T15:22:32.013552 (delta: 1.572844)         elapsed: 12.859482 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.789401", "end": "2019-07-09 15:22:34.068951", "failed_when_result": false, "rc": 0, "start": "2019-07-09 15:22:32.279550", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/percona-loadgen created", "stdout_lines": ["litmusresult.litmus.io/percona-loadgen created"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-09T15:22:34.171220 (delta: 2.157606)         elapsed: 15.01715 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-09T15:22:34.268959 (delta: 0.097653)         elapsed: 15.114889 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-09T15:22:34.384050 (delta: 0.115008)         elapsed: 15.22998 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of test specific namespace.] *************************
2019-07-09T15:22:34.592016 (delta: 0.207878)         elapsed: 15.437946 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-percona-ns -o jsonpath='{.status.phase}'", "delta": "0:00:01.269616", "end": "2019-07-09 15:22:36.243342", "rc": 0, "start": "2019-07-09 15:22:34.973726", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Checking whether application is running] *********************************
2019-07-09T15:22:36.362070 (delta: 1.76994)         elapsed: 17.208 *********** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=percona", "delta": "0:00:01.179817", "end": "2019-07-09 15:22:37.899733", "rc": 0, "start": "2019-07-09 15:22:36.719916", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-qd26x   1/1     Running   0          1m", "stdout_lines": ["NAME                      READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-qd26x   1/1     Running   0          1m"]}

TASK [Obtaining the loadgen pod label from env.] *******************************
2019-07-09T15:22:37.995685 (delta: 1.633502)         elapsed: 18.841615 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"loadgen_lkey": "loadgen", "loadgen_lvalue": "percona-loadgen"}, "changed": false}

TASK [Replace the label in loadgen job spec.] **********************************
2019-07-09T15:22:38.125778 (delta: 0.13003)         elapsed: 18.971708 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the db-user placeholder in tpcc-config file] *********************
2019-07-09T15:22:38.759109 (delta: 0.633235)         elapsed: 19.605039 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the password placeholder in tpcc-config file] ********************
2019-07-09T15:22:39.151765 (delta: 0.392583)         elapsed: 19.997695 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the duration placeholder in tpcc-config file] ********************
2019-07-09T15:22:39.530061 (delta: 0.378232)         elapsed: 20.375991 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the warehouse placeholder in tpcc-config file] *******************
2019-07-09T15:22:40.020866 (delta: 0.490715)         elapsed: 20.866796 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the test connections placeholder in tpcc-config file] ************
2019-07-09T15:22:40.440841 (delta: 0.419912)         elapsed: 21.286771 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the test warmup-period placeholder in tpcc-config file] **********
2019-07-09T15:22:40.825497 (delta: 0.384533)         elapsed: 21.671427 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the test interval placeholder in tpcc-config file] ***************
2019-07-09T15:22:41.175776 (delta: 0.35022)         elapsed: 22.021706 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Service IP of Application] ***********************************
2019-07-09T15:22:41.548504 (delta: 0.372658)         elapsed: 22.394434 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -n app-percona-ns -l name=percona -o jsonpath='{.items[0].spec.clusterIP}'", "delta": "0:00:01.320733", "end": "2019-07-09 15:22:43.085845", "rc": 0, "start": "2019-07-09 15:22:41.765112", "stderr": "", "stderr_lines": [], "stdout": "172.24.100.93", "stdout_lines": ["172.24.100.93"]}

TASK [Replace the Service IP placeholder] **************************************
2019-07-09T15:22:43.187228 (delta: 1.63867)         elapsed: 24.033158 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Checking for configmap] **************************************************
2019-07-09T15:22:43.628334 (delta: 0.441027)         elapsed: 24.474264 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get configmap -n app-percona-ns", "delta": "0:00:01.467066", "end": "2019-07-09 15:22:45.391998", "rc": 0, "start": "2019-07-09 15:22:43.924932", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Creating a kubernetes config map to hold the tpcc benchmark config] ******
2019-07-09T15:22:45.476845 (delta: 1.848423)         elapsed: 26.322775 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create configmap tpcc-config --from-file tpcc.conf -n app-percona-ns", "delta": "0:00:01.307317", "end": "2019-07-09 15:22:47.017262", "rc": 0, "start": "2019-07-09 15:22:45.709945", "stderr": "", "stderr_lines": [], "stdout": "configmap/tpcc-config created", "stdout_lines": ["configmap/tpcc-config created"]}

TASK [Verifying successful creation of the configmap] **************************
2019-07-09T15:22:47.126985 (delta: 1.650074)         elapsed: 27.972915 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe configmap -n app-percona-ns", "delta": "0:00:01.382651", "end": "2019-07-09 15:22:48.811129", "rc": 0, "start": "2019-07-09 15:22:47.428478", "stderr": "", "stderr_lines": [], "stdout": "Name:         tpcc-config\nNamespace:    app-percona-ns\nLabels:       <none>\nAnnotations:  <none>\n\nData\n====\ntpcc.conf:\n----\n{\n  \"db_user\": \"root\",\n  \"db_password\": \"k8sDem0\",\n  \"warehouses\": \"1\",\n  \"connections\": \"18\",\n  \"warmup_period\": \"10\",\n  \"run_duration\": \"600\",\n  \"interval\": \"10\"\n}\n\nEvents:  <none>", "stdout_lines": ["Name:         tpcc-config", "Namespace:    app-percona-ns", "Labels:       <none>", "Annotations:  <none>", "", "Data", "====", "tpcc.conf:", "----", "{", "  \"db_user\": \"root\",", "  \"db_password\": \"k8sDem0\",", "  \"warehouses\": \"1\",", "  \"connections\": \"18\",", "  \"warmup_period\": \"10\",", "  \"run_duration\": \"600\",", "  \"interval\": \"10\"", "}", "", "Events:  <none>"]}

TASK [Create Percona Loadgen Job] **********************************************
2019-07-09T15:22:48.943089 (delta: 1.815984)         elapsed: 29.789019 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f tpcc_bench.yml -n app-percona-ns", "delta": "0:00:01.448536", "end": "2019-07-09 15:22:50.716680", "rc": 0, "start": "2019-07-09 15:22:49.268144", "stderr": "", "stderr_lines": [], "stdout": "job.batch/tpcc-bench created", "stdout_lines": ["job.batch/tpcc-bench created"]}

TASK [Verify load-gen pod is running] ******************************************
2019-07-09T15:22:50.792533 (delta: 1.849363)         elapsed: 31.638463 ******* 
FAILED - RETRYING: Verify load-gen pod is running (60 retries left).
FAILED - RETRYING: Verify load-gen pod is running (59 retries left).
FAILED - RETRYING: Verify load-gen pod is running (58 retries left).
FAILED - RETRYING: Verify load-gen pod is running (57 retries left).
FAILED - RETRYING: Verify load-gen pod is running (56 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l loadgen=percona-loadgen -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.356673", "end": "2019-07-09 15:23:25.971299", "rc": 0, "start": "2019-07-09 15:23:24.614626", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Getting the Percona POD name] ********************************************
2019-07-09T15:23:26.085082 (delta: 35.292493)         elapsed: 66.931012 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n app-percona-ns -l name=percona -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.357226", "end": "2019-07-09 15:23:27.741256", "rc": 0, "start": "2019-07-09 15:23:26.384030", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-qd26x", "stdout_lines": ["percona-cb697f8b4-qd26x"]}

TASK [Verifying load-generation] ***********************************************
2019-07-09T15:23:27.837928 (delta: 1.752744)         elapsed: 68.683858 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it percona-cb697f8b4-qd26x -n app-percona-ns -- mysql -uroot -pk8sDem0 -e \"show databases\"", "delta": "0:00:01.655646", "end": "2019-07-09 15:23:29.870822", "rc": 0, "start": "2019-07-09 15:23:28.215176", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Database\ninformation_schema\nmysql\nperformance_schema\nsys\ntpcc-TBDVflXb1Q", "stdout_lines": ["Database", "information_schema", "mysql", "performance_schema", "sys", "tpcc-TBDVflXb1Q"]}

TASK [set_fact] ****************************************************************
2019-07-09T15:23:30.086660 (delta: 2.248651)         elapsed: 70.93259 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-07-09T15:23:30.245340 (delta: 0.158575)         elapsed: 71.09127 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-07-09T15:23:30.384189 (delta: 0.138787)         elapsed: 71.230119 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-07-09T15:23:30.478075 (delta: 0.093798)         elapsed: 71.324005 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-07-09T15:23:30.566771 (delta: 0.088598)         elapsed: 71.412701 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-07-09T15:23:30.654112 (delta: 0.087279)         elapsed: 71.500042 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "f0b8858c21c00b2c0d69c06f49631ffd57e00e57", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5a06acf8c709510b4d13d86641689759", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1562685810.74-140039475603135/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-07-09T15:23:33.786966 (delta: 3.132786)         elapsed: 74.632896 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.085160", "end": "2019-07-09 15:23:35.161021", "rc": 0, "start": "2019-07-09 15:23:34.075861", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-loadgen \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-loadgen ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-07-09T15:23:35.245004 (delta: 1.457944)         elapsed: 76.090934 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.686917", "end": "2019-07-09 15:23:37.246490", "failed_when_result": false, "rc": 0, "start": "2019-07-09 15:23:35.559573", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/percona-loadgen configured", "stdout_lines": ["litmusresult.litmus.io/percona-loadgen configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=30   changed=25   unreachable=0    failed=0   

2019-07-09T15:23:37.288971 (delta: 2.043905)         elapsed: 78.134901 ******* 
=============================================================================== 
```