### PR TITLE
feat[yaml]: Litmus book for scheduling target pod on specified node

### DIFF
--- a/experiments/functional/schedule-target-pod/busybox_deployment.yml
+++ b/experiments/functional/schedule-target-pod/busybox_deployment.yml
@@ -35,5 +35,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5G
+      storage: teststorage
 

--- a/experiments/functional/schedule-target-pod/busybox_deployment.yml
+++ b/experiments/functional/schedule-target-pod/busybox_deployment.yml
@@ -36,4 +36,3 @@ spec:
   resources:
     requests:
       storage: teststorage
-

--- a/experiments/functional/schedule-target-pod/busybox_deployment.yml
+++ b/experiments/functional/schedule-target-pod/busybox_deployment.yml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: app-busybox
+  labels:
+    lkey: lvalue
+spec:
+  template:
+    metadata:
+      labels:
+        lkey: lvalue
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: testclaim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -56,7 +56,7 @@ spec:
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-cstor-sc
             
-            # Provide name POOL_NAME for the cstor-pool
+            # Provide name POOL_NAME 
           - name: POOL_NAME
             value: cstor-block-disk-pool
 

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -1,0 +1,63 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-target-pod-schedule
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-target-schedule
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns
+
+          - name: APP_LABEL
+            value: app=busybox-deploy
+
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: APP_PVC
+            value: openebs-busybox
+
+          - name: DEPLOY_TYPE
+            value: deployment
+            
+            # Give the node name where target pod should be scheduled
+          - name: TARGET_NODE
+            value: node1-1558702621.mayalabs.io
+           
+            # Provide the node label 
+          - name: NODE_LABEL
+            value: node=appnode
+
+            # Provide the name of STORAGE_CLASS 
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-cstor-sc
+            
+            # Provide name POOL_NAME for the cstor-pool
+          - name: POOL_NAME
+            value: cstor-block-disk-pool
+
+          - name: PV_CAPACITY
+            value: 5G
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: litmus-target-pod-schedule
+  generateName: litmus-target-pod-schedule-
   namespace: litmus
 spec:
   template:

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -41,8 +41,12 @@ spec:
             value: deployment
             
             # Give the node name where target pod should be scheduled
+            # If the node name is not given, random node is selected 
           - name: TARGET_NODE
-            value: node1
+            value: 
+
+          - name: REPLICA_COUNT
+            value: "3"
            
             # Provide the node label 
           - name: NODE_LABEL
@@ -60,4 +64,4 @@ spec:
             value: 5G
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/task2.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -42,7 +42,7 @@ spec:
             
             # Give the node name where target pod should be scheduled
           - name: TARGET_NODE
-            value: node1-1558702621.mayalabs.io
+            value: node1
            
             # Provide the node label 
           - name: NODE_LABEL

--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -40,7 +40,7 @@ spec:
           - name: DEPLOY_TYPE
             value: deployment
             
-            # Give the node name where target pod should be scheduled
+            # Provide the node name where target pod should be scheduled
             # If the node name is not given, random node is selected 
           - name: TARGET_NODE
             value: 
@@ -48,7 +48,7 @@ spec:
           - name: REPLICA_COUNT
             value: "3"
            
-            # Provide the node label 
+            # Provide the value to label the node
           - name: NODE_LABEL
             value: node=appnode
 
@@ -64,4 +64,4 @@ spec:
             value: 5G
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/task2.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/task.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/schedule-target-pod/storage_class.j2
+++ b/experiments/functional/schedule-target-pod/storage_class.j2
@@ -1,14 +1,14 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: sc-name
+  name: "{{ sc_name }}"
   annotations:
     openebs.io/cas-type: cstor
     cas.openebs.io/config: |
       - name: StoragePoolClaim
-        value: pool-name
+        value: "{{ pool_name }}"
       - name: ReplicaCount
-        value: "3"
+        value: "{{ replica_count }}"
       - name: TargetNodeSelector
         value: |-
             lkey: lvalue

--- a/experiments/functional/schedule-target-pod/storage_class.j2
+++ b/experiments/functional/schedule-target-pod/storage_class.j2
@@ -11,5 +11,5 @@ metadata:
         value: "{{ replica_count }}"
       - name: TargetNodeSelector
         value: |-
-            lkey: lvalue
+            lkey: lvalue     
 provisioner: openebs.io/provisioner-iscsi

--- a/experiments/functional/schedule-target-pod/storage_class.yml
+++ b/experiments/functional/schedule-target-pod/storage_class.yml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sc-name
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: pool-name
+      - name: ReplicaCount
+        value: "3"
+      - name: TargetNodeSelector
+        value: |-
+            lkey: lvalue
+#      - name: VolumeControllerImage
+#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
+#      - name: VolumeTargetImage
+#        value: openebs/cstor-istgt:{{ cstor_image }}
+#      - name: VolumeMonitorImage
+#        value: openebs/m-exporter:{{ cstor_image }}
+provisioner: openebs.io/provisioner-iscsi

--- a/experiments/functional/schedule-target-pod/storage_class.yml
+++ b/experiments/functional/schedule-target-pod/storage_class.yml
@@ -12,10 +12,4 @@ metadata:
       - name: TargetNodeSelector
         value: |-
             lkey: lvalue
-#      - name: VolumeControllerImage
-#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
-#      - name: VolumeTargetImage
-#        value: openebs/cstor-istgt:{{ cstor_image }}
-#      - name: VolumeMonitorImage
-#        value: openebs/m-exporter:{{ cstor_image }}
 provisioner: openebs.io/provisioner-iscsi

--- a/experiments/functional/schedule-target-pod/test.yml
+++ b/experiments/functional/schedule-target-pod/test.yml
@@ -1,0 +1,130 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Replacing the storage class name in storage class yaml file
+          replace:
+            path: ./storage_class.yml
+            regexp: "sc-name"
+            replace: "{{ sc_name }}"
+
+        - name: Replacing the pool type in storage class yaml file
+          replace:
+            path: ./storage_class.yml
+            regexp: "pool-type"
+            replace: "{{ pool_type }}"
+            
+        - name: Replacing the pool name in storage class yaml file
+          replace:
+            path: ./storage_class.yml
+            regexp: "pool-name"
+            replace: "{{ pool_name }}"
+            
+        - name: Get the node label values from env
+          set_fact:
+             node_lkey: "{{ node_label.split('=')[0] }}"
+             node_lvalue: "{{ node_label.split('=')[1] }}"
+
+        - name: Replace the node label placeholder in storage class yaml 
+          replace:
+            path: ./storage_class.yml
+            regexp: "lkey: lvalue"
+            replace: "{{ node_lkey }}: {{ node_lvalue }}"
+
+        - name: Give label to the node where target pod has to be scheduled
+          command: kubectl label nodes {{ target_node }} {{ node_lkey }}={{ node_lvalue }}
+                
+        - name: Create the storage class 
+          command: kubectl apply -f storage_class.yml 
+
+        - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+      
+        - name: Replace the volume capcity placeholder with provider
+          replace:
+            path: "{{ application_deployment }}"
+            regexp: "teststorage"
+            replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+        - include_tasks: /utils/k8s/deploy_single_app.yml
+          vars:
+            check_app_pod: 'yes'
+            delay: 10
+            retries: 20    
+
+        - name: Checking {{ application_name }} pod is in running state
+          shell: kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.{{app_lkey}}=="{{app_lvalue}}")].status.phase}'
+          register: result
+          until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+          delay: 10
+          retries: 20
+                   
+        - name: Get the pvc of the {{ application_name }} application 
+          shell: kubectl get pvc -n {{ app_ns }} 
+          register: pvc_name_info
+
+        - name: Get the name of pvc of the application
+          set_fact:
+             pvc_name: "{{ pvc_name_info.stdout_lines[1].split()[2] }}"
+
+        - name: Get the target pod of the {{ application_name }} application
+          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name }}
+          register: target_pod_info
+
+        - name: Obtain the name of target pod of {{ application_name }} application
+          set_fact:
+             target_pod: "{{ target_pod_info.stdout_lines[0].split()[0] }}"
+              
+        - name: Get the node name in which target pod is scheduled
+          shell: kubectl get pods {{ target_pod }} -n openebs -o jsonpath='{.spec.nodeName}'
+          register: node_name
+
+        - name: Display the message if target pod is scheduled in the node specified
+          debug:
+            msg:
+            - 'The target pod is scheduled in the same node specified'
+          when: "'{{ target_node }}' in node_name.stdout_lines"
+        
+        - name: Fail the play if target pod is not scheduled in specified node
+          fail: 
+            msg: "Target pod is scheduled in different node"
+          when: "'{{ target_node }}' not in node_name.stdout_lines"
+
+        - name: Check whether target pod is in running state or not 
+          shell: kubectl get pods {{ target_pod }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+          register: result
+          until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+          delay: 10
+          retries: 20
+
+        - name: Delete the label from node 
+          command: kubectl label nodes {{ target_node }} {{ node_lkey }}-   
+
+        - name: Delete the storage class 
+          command: kubectl delete -f storage_class.yml                   
+        
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/schedule-target-pod/test.yml
+++ b/experiments/functional/schedule-target-pod/test.yml
@@ -16,26 +16,21 @@
           vars:
             status: 'SOT'
 
-        - name: Replacing the storage class name in storage class yaml file
-          replace:
-            path: ./storage_class.yml
-            regexp: "sc-name"
-            replace: "{{ sc_name }}"
-                 
-        - name: Replacing the pool name in storage class yaml file
-          replace:
-            path: ./storage_class.yml
-            regexp: "pool-name"
-            replace: "{{ pool_name }}"
+        - name: Get the name of nodes in cluster
+          shell: kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
+          register: node_names
 
-        - name: Get the node name where target pod should be scheduled from the cluster
-          shell: kubectl get nodes | grep {{ target_node }}
-          register: node_name
-
-        - name: Get the name of the node from variable
+        - name: Select random node from the list of nodes
           set_fact:
-             target_node_name: "{{ node_name.stdout_lines[0].split()[0] }}"
-            
+            target_node: "{{ item }}"
+          with_random_choice: "{{ node_names.stdout_lines }}"  
+          when: lookup('env','TARGET_NODE') | length == 0
+          
+        - name: Set the node as target node if it is taken as input
+          set_fact:
+            target_node: "{{ target_node_name }}"  
+          when: lookup('env','TARGET_NODE') | length > 0        
+                 
         - name: Get the node label values from env
           set_fact:
              node_lkey: "{{ node_label.split('=')[0] }}"
@@ -43,15 +38,20 @@
 
         - name: Replace the node label placeholder in storage class yaml 
           replace:
-            path: ./storage_class.yml
+            path: ./storage_class.j2
             regexp: "lkey: lvalue"
             replace: "{{ node_lkey }}: {{ node_lvalue }}"
 
+        - name: Generate yaml file to create storage class from jinja template
+          template:
+            src: storage_class.j2
+            dest: "{{ storage_class }}"
+
         - name: Give label to the node where target pod has to be scheduled
-          command: kubectl label nodes {{ target_node_name }} {{ node_lkey }}={{ node_lvalue }}
+          command: kubectl label nodes {{ target_node }} {{ node_lkey }}={{ node_lvalue }}
                 
         - name: Create the storage class 
-          command: kubectl apply -f storage_class.yml 
+          command: kubectl apply -f {{ storage_class }}
 
         - include_tasks: /utils/k8s/pre_create_app_deploy.yml
       
@@ -79,71 +79,57 @@
           register: pvc_name
 
         - name: Get the target pod of the {{ application_name }} application
-          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name.stdout }}
-          register: target_pod_info
-
-        - name: Obtain the name of target pod of {{ application_name }} application
-          set_fact:
-             target_pod: "{{ target_pod_info.stdout_lines[0].split()[0] }}"
-
+          shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvc_name.stdout }} -o jsonpath='{.items[0].metadata.name}'
+          register: target_pod
+       
         - name: Check whether target pod is in running state or not 
-          shell: kubectl get pods {{ target_pod }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+          shell: kubectl get pods {{ target_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
           register: result
           until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
           delay: 10
           retries: 20
               
         - name: Get the node name in which target pod is scheduled
-          shell: kubectl get pods {{ target_pod }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
+          shell: kubectl get pods {{ target_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
           register: node_name
            
         - name: Fail the play if target pod is not scheduled in specified node
           fail: 
             msg: "Target pod is scheduled in different node"
-          when: "'{{ target_node_name }}' not in node_name.stdout_lines"   
+          when: "'{{ target_node }}' not in node_name.stdout_lines"   
 
         - name: Delete the target pod of {{ application_name }} application
-          shell: kubectl delete pods {{ target_pod }} -n {{ operator_ns }} 
+          shell: kubectl delete pods {{ target_pod.stdout }} -n {{ operator_ns }} 
 
         - name: Wait for 20 seconds to make sure that new target pod has come up
           wait_for:
             timeout: 20
 
         - name: Get the name of new target pod created
-          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name.stdout }}
-          register: new_target_pod_info
-
-        - name: Obtain the name of new target pod from variable
-          set_fact:
-             new_target_pod: "{{ new_target_pod_info.stdout_lines[0].split()[0] }}"
+          shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvc_name.stdout }} -o jsonpath='{.items[0].metadata.name}'
+          register: new_target_pod     
 
         - name: Check whether new target pod is in running state or not 
-          shell: kubectl get pods {{ new_target_pod }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+          shell: kubectl get pods {{ new_target_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.phase}' 
           register: result
           until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
           delay: 10
           retries: 20
 
         - name: Get the node name in which new target pod is scheduled
-          shell: kubectl get pods {{ new_target_pod }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
+          shell: kubectl get pods {{ new_target_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
           register: name_of_node
 
         - name: Display the message if target pod is scheduled in the node specified
           debug:
             msg:
             - 'The target pod is scheduled in the same node specified'
-          when: "'{{ target_node_name }}' in name_of_node.stdout_lines" 
+          when: "'{{ target_node }}' in name_of_node.stdout_lines" 
 
         - name: Fail the play if target pod is not scheduled in specified node
           fail: 
             msg: "Target pod is scheduled in different node"
-          when: "'{{ target_node_name }}' not in node_name.stdout_lines"   
-
-        - name: Delete the label from node 
-          command: kubectl label nodes {{ target_node_name }} {{ node_lkey }}-   
-
-        - name: Delete the storage class 
-          command: kubectl delete -f storage_class.yml                   
+          when: "'{{ target_node }}' not in node_name.stdout_lines"                  
         
         - set_fact:
             flag: "Pass"
@@ -153,6 +139,12 @@
             flag: "Fail"
 
       always:
+        - name: Delete the label from node 
+          command: kubectl label nodes {{ target_node }} {{ node_lkey }}-   
+
+        - name: Delete the storage class 
+          command: kubectl delete -f {{ storage_class }}        
+    
            ## RECORD END-OF-TEST IN LITMUS RESULT CR
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:

--- a/experiments/functional/schedule-target-pod/test.yml
+++ b/experiments/functional/schedule-target-pod/test.yml
@@ -36,7 +36,7 @@
              node_lkey: "{{ node_label.split('=')[0] }}"
              node_lvalue: "{{ node_label.split('=')[1] }}"
 
-        - name: Replace the node label placeholder in storage class yaml 
+        - name: Replace the node label placeholder in jinja template 
           replace:
             path: ./storage_class.j2
             regexp: "lkey: lvalue"

--- a/experiments/functional/schedule-target-pod/test.yml
+++ b/experiments/functional/schedule-target-pod/test.yml
@@ -20,7 +20,7 @@
           shell: kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
           register: node_names
 
-        - name: Select random node from the list of nodes
+        - name: Select random node from the list of nodes as target node
           set_fact:
             target_node: "{{ item }}"
           with_random_choice: "{{ node_names.stdout_lines }}"  
@@ -36,6 +36,9 @@
              node_lkey: "{{ node_label.split('=')[0] }}"
              node_lvalue: "{{ node_label.split('=')[1] }}"
 
+        - name: Give label to the node where target pod has to be scheduled
+          command: kubectl label nodes {{ target_node }} {{ node_lkey }}={{ node_lvalue }}
+
         - name: Replace the node label placeholder in jinja template 
           replace:
             path: ./storage_class.j2
@@ -45,10 +48,7 @@
         - name: Generate yaml file to create storage class from jinja template
           template:
             src: storage_class.j2
-            dest: "{{ storage_class }}"
-
-        - name: Give label to the node where target pod has to be scheduled
-          command: kubectl label nodes {{ target_node }} {{ node_lkey }}={{ node_lvalue }}
+            dest: "{{ storage_class }}"      
                 
         - name: Create the storage class 
           command: kubectl apply -f {{ storage_class }}
@@ -96,14 +96,21 @@
         - name: Fail the play if target pod is not scheduled in specified node
           fail: 
             msg: "Target pod is scheduled in different node"
-          when: "'{{ target_node }}' not in node_name.stdout_lines"   
+          when: "target_node not in node_name.stdout_lines"   
 
         - name: Delete the target pod of {{ application_name }} application
           shell: kubectl delete pods {{ target_pod.stdout }} -n {{ operator_ns }} 
 
-        - name: Wait for 20 seconds to make sure that new target pod has come up
+        - name: Get the name of all pods in {{ operator_ns }} namespace
+          shell: kubectl get pods -n {{ operator_ns }} -o jsonpath='{.items[*].metadata.name}'
+          register: pod_names
+
+        - name: Make sure that target pod is deleted and new pod has come up
           wait_for:
-            timeout: 20
+            timeout: 3
+          until: "target_pod.stdout not in pod_names.stdout"
+          delay: 5
+          retries: 10
 
         - name: Get the name of new target pod created
           shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvc_name.stdout }} -o jsonpath='{.items[0].metadata.name}'
@@ -124,12 +131,12 @@
           debug:
             msg:
             - 'The target pod is scheduled in the same node specified'
-          when: "'{{ target_node }}' in name_of_node.stdout_lines" 
+          when: "target_node in name_of_node.stdout_lines" 
 
         - name: Fail the play if target pod is not scheduled in specified node
           fail: 
             msg: "Target pod is scheduled in different node"
-          when: "'{{ target_node }}' not in node_name.stdout_lines"                  
+          when: "target_node not in node_name.stdout_lines"                  
         
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/schedule-target-pod/test.yml
+++ b/experiments/functional/schedule-target-pod/test.yml
@@ -21,18 +21,20 @@
             path: ./storage_class.yml
             regexp: "sc-name"
             replace: "{{ sc_name }}"
-
-        - name: Replacing the pool type in storage class yaml file
-          replace:
-            path: ./storage_class.yml
-            regexp: "pool-type"
-            replace: "{{ pool_type }}"
-            
+                 
         - name: Replacing the pool name in storage class yaml file
           replace:
             path: ./storage_class.yml
             regexp: "pool-name"
             replace: "{{ pool_name }}"
+
+        - name: Get the node name where target pod should be scheduled from the cluster
+          shell: kubectl get nodes | grep {{ target_node }}
+          register: node_name
+
+        - name: Get the name of the node from variable
+          set_fact:
+             target_node_name: "{{ node_name.stdout_lines[0].split()[0] }}"
             
         - name: Get the node label values from env
           set_fact:
@@ -46,14 +48,14 @@
             replace: "{{ node_lkey }}: {{ node_lvalue }}"
 
         - name: Give label to the node where target pod has to be scheduled
-          command: kubectl label nodes {{ target_node }} {{ node_lkey }}={{ node_lvalue }}
+          command: kubectl label nodes {{ target_node_name }} {{ node_lkey }}={{ node_lvalue }}
                 
         - name: Create the storage class 
           command: kubectl apply -f storage_class.yml 
 
         - include_tasks: /utils/k8s/pre_create_app_deploy.yml
       
-        - name: Replace the volume capcity placeholder with provider
+        - name: Replace the volume capacity placeholder with provider
           replace:
             path: "{{ application_deployment }}"
             regexp: "teststorage"
@@ -73,35 +75,16 @@
           retries: 20
                    
         - name: Get the pvc of the {{ application_name }} application 
-          shell: kubectl get pvc -n {{ app_ns }} 
-          register: pvc_name_info
-
-        - name: Get the name of pvc of the application
-          set_fact:
-             pvc_name: "{{ pvc_name_info.stdout_lines[1].split()[2] }}"
+          shell: kubectl get pvc -n {{ app_ns }} -o jsonpath='{.items[0].spec.volumeName}'
+          register: pvc_name
 
         - name: Get the target pod of the {{ application_name }} application
-          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name }}
+          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name.stdout }}
           register: target_pod_info
 
         - name: Obtain the name of target pod of {{ application_name }} application
           set_fact:
              target_pod: "{{ target_pod_info.stdout_lines[0].split()[0] }}"
-              
-        - name: Get the node name in which target pod is scheduled
-          shell: kubectl get pods {{ target_pod }} -n openebs -o jsonpath='{.spec.nodeName}'
-          register: node_name
-
-        - name: Display the message if target pod is scheduled in the node specified
-          debug:
-            msg:
-            - 'The target pod is scheduled in the same node specified'
-          when: "'{{ target_node }}' in node_name.stdout_lines"
-        
-        - name: Fail the play if target pod is not scheduled in specified node
-          fail: 
-            msg: "Target pod is scheduled in different node"
-          when: "'{{ target_node }}' not in node_name.stdout_lines"
 
         - name: Check whether target pod is in running state or not 
           shell: kubectl get pods {{ target_pod }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
@@ -109,9 +92,55 @@
           until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
           delay: 10
           retries: 20
+              
+        - name: Get the node name in which target pod is scheduled
+          shell: kubectl get pods {{ target_pod }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
+          register: node_name
+           
+        - name: Fail the play if target pod is not scheduled in specified node
+          fail: 
+            msg: "Target pod is scheduled in different node"
+          when: "'{{ target_node_name }}' not in node_name.stdout_lines"   
+
+        - name: Delete the target pod of {{ application_name }} application
+          shell: kubectl delete pods {{ target_pod }} -n {{ operator_ns }} 
+
+        - name: Wait for 20 seconds to make sure that new target pod has come up
+          wait_for:
+            timeout: 20
+
+        - name: Get the name of new target pod created
+          shell: kubectl get pods -n {{ operator_ns }} -o wide| grep {{ pvc_name.stdout }}
+          register: new_target_pod_info
+
+        - name: Obtain the name of new target pod from variable
+          set_fact:
+             new_target_pod: "{{ new_target_pod_info.stdout_lines[0].split()[0] }}"
+
+        - name: Check whether new target pod is in running state or not 
+          shell: kubectl get pods {{ new_target_pod }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+          register: result
+          until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+          delay: 10
+          retries: 20
+
+        - name: Get the node name in which new target pod is scheduled
+          shell: kubectl get pods {{ new_target_pod }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
+          register: name_of_node
+
+        - name: Display the message if target pod is scheduled in the node specified
+          debug:
+            msg:
+            - 'The target pod is scheduled in the same node specified'
+          when: "'{{ target_node_name }}' in name_of_node.stdout_lines" 
+
+        - name: Fail the play if target pod is not scheduled in specified node
+          fail: 
+            msg: "Target pod is scheduled in different node"
+          when: "'{{ target_node_name }}' not in node_name.stdout_lines"   
 
         - name: Delete the label from node 
-          command: kubectl label nodes {{ target_node }} {{ node_lkey }}-   
+          command: kubectl label nodes {{ target_node_name }} {{ node_lkey }}-   
 
         - name: Delete the storage class 
           command: kubectl delete -f storage_class.yml                   

--- a/experiments/functional/schedule-target-pod/test_vars.yml
+++ b/experiments/functional/schedule-target-pod/test_vars.yml
@@ -1,0 +1,13 @@
+test_name: schedule-target-pod-on-node
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_label: "{{ lookup('env','APP_LABEL') }}"
+deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
+sc_name: "{{ lookup('env', 'PROVIDER_STORAGE_CLASS') }}"
+node_label: "{{ lookup('env','NODE_LABEL') }}"
+target_node: "{{ lookup('env','TARGET_NODE') }}"
+application_deployment: busybox_deployment.yml
+application_name: "busybox"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"

--- a/experiments/functional/schedule-target-pod/test_vars.yml
+++ b/experiments/functional/schedule-target-pod/test_vars.yml
@@ -1,9 +1,7 @@
 test_name: schedule-target-pod-on-node
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 app_label: "{{ lookup('env','APP_LABEL') }}"
-deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
 pool_name: "{{ lookup('env','POOL_NAME') }}"
-pool_type: "{{ lookup('env','POOL_TYPE') }}"
 sc_name: "{{ lookup('env', 'PROVIDER_STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
 target_node: "{{ lookup('env','TARGET_NODE') }}"

--- a/experiments/functional/schedule-target-pod/test_vars.yml
+++ b/experiments/functional/schedule-target-pod/test_vars.yml
@@ -4,8 +4,10 @@ app_label: "{{ lookup('env','APP_LABEL') }}"
 pool_name: "{{ lookup('env','POOL_NAME') }}"
 sc_name: "{{ lookup('env', 'PROVIDER_STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
-target_node: "{{ lookup('env','TARGET_NODE') }}"
+target_node_name: "{{ lookup('env','TARGET_NODE') }}"
 application_deployment: busybox_deployment.yml
 application_name: "busybox"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
+storage_class: storage_class.yml


### PR DESCRIPTION
**What this PR does / why we need it**:
* The target pod is scheduled on the node specified in run_litmus_test.yml
* In storage class , we use TargetNodeSelector to schedule target pod in particular node which has the label.
* Below steps are followed to do the scheduling of target pod on node.
    1. Node where target pod has to be scheduled is given a label.
    2. Jinja template is converted into storage class yaml file.
    3. Storage class yaml file which contains TargetNodeSelector is applied and hence a storage class is 
        created.
    4. Deployment of busybox is done.
    5. Whether target pod is scheduled in the specified node or not is verified.
    6. The label given to node is erased.
    7. Storage class is deleted.

**Special notes for your reviewer**:
Here are the logs :
1. When target pod is scheduled in specified node:
```
[root@master-1558702621 sushma]# kubectl logs litmus-target-pod-schedule5nm94-xns6q -n litmus -f
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/schedule-target-pod/test.yml

PLAY [localhost] ***************************************************************
2019-07-18T08:35:20.017401 (delta: 0.063255)         elapsed: 0.063255 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:2
2019-07-18T08:35:20.034442 (delta: 0.016982)         elapsed: 0.080296 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:12
2019-07-18T08:35:29.827510 (delta: 9.793033)         elapsed: 9.873364 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-07-18T08:35:29.947907 (delta: 0.120346)         elapsed: 9.993761 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-07-18T08:35:30.021430 (delta: 0.073456)         elapsed: 10.067284 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:15
2019-07-18T08:35:30.122576 (delta: 0.101081)         elapsed: 10.16843 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-07-18T08:35:30.304443 (delta: 0.181754)         elapsed: 10.350297 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "1b64e250cd64fd86cd289ab71744f85340eaa953", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a5ff36075f6ad57ef8708a9ca2625d0a", "mode": "0644", "owner": "root", "size": 428, "src": "/root/.ansible/tmp/ansible-tmp-1563438930.38-118189347790874/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-07-18T08:35:31.196252 (delta: 0.891722)         elapsed: 11.242106 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.299338", "end": "2019-07-18 08:35:32.933260", "rc": 0, "start": "2019-07-18 08:35:31.633922", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: schedule-target-pod-on-node \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: schedule-target-pod-on-node ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-07-18T08:35:33.000721 (delta: 1.804399)         elapsed: 13.046575 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.736629", "end": "2019-07-18 08:35:34.995539", "failed_when_result": false, "rc": 0, "start": "2019-07-18 08:35:33.258910", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/schedule-target-pod-on-node configured", "stdout_lines": ["litmusresult.litmus.io/schedule-target-pod-on-node configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-07-18T08:35:35.077536 (delta: 2.07675)         elapsed: 15.12339 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-07-18T08:35:35.174616 (delta: 0.097018)         elapsed: 15.22047 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-07-18T08:35:35.249090 (delta: 0.074351)         elapsed: 15.294944 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the name of nodes in cluster] ****************************************
task path: /experiments/functional/schedule-target-pod/test.yml:19
2019-07-18T08:35:35.330764 (delta: 0.081582)         elapsed: 15.376618 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.351615", "end": "2019-07-18 08:35:36.960976", "rc": 0, "start": "2019-07-18 08:35:35.609361", "stderr": "", "stderr_lines": [], "stdout": "node1-1558702621.mayalabs.io\nnode2-1558702621.mayalabs.io\nnode3-1558702621.mayalabs.io", "stdout_lines": ["node1-1558702621.mayalabs.io", "node2-1558702621.mayalabs.io", "node3-1558702621.mayalabs.io"]}

TASK [Select random node from the list of nodes as target node] ****************
task path: /experiments/functional/schedule-target-pod/test.yml:23
2019-07-18T08:35:37.059023 (delta: 1.72819)         elapsed: 17.104877 ******** 
ok: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"ansible_facts": {"target_node": "node3-1558702621.mayalabs.io"}, "changed": false, "item": "node3-1558702621.mayalabs.io"}

TASK [Set the node as target node if it is taken as input] *********************
task path: /experiments/functional/schedule-target-pod/test.yml:29
2019-07-18T08:35:37.182523 (delta: 0.123411)         elapsed: 17.228377 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the node label values from env] **************************************
task path: /experiments/functional/schedule-target-pod/test.yml:34
2019-07-18T08:35:37.264220 (delta: 0.081636)         elapsed: 17.310074 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"node_lkey": "node", "node_lvalue": "appnode"}, "changed": false}

TASK [Give label to the node where target pod has to be scheduled] *************
task path: /experiments/functional/schedule-target-pod/test.yml:39
2019-07-18T08:35:37.408454 (delta: 0.144167)         elapsed: 17.454308 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "label", "nodes", "node3-1558702621.mayalabs.io", "node=appnode"], "delta": "0:00:01.419479", "end": "2019-07-18 08:35:39.114973", "rc": 0, "start": "2019-07-18 08:35:37.695494", "stderr": "", "stderr_lines": [], "stdout": "node/node3-1558702621.mayalabs.io labeled", "stdout_lines": ["node/node3-1558702621.mayalabs.io labeled"]}

TASK [Replace the node label placeholder in jinja template] ********************
task path: /experiments/functional/schedule-target-pod/test.yml:42
2019-07-18T08:35:39.209372 (delta: 1.800848)         elapsed: 19.255226 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Generate yaml file to create storage class from jinja template] **********
task path: /experiments/functional/schedule-target-pod/test.yml:48
2019-07-18T08:35:39.842943 (delta: 0.633478)         elapsed: 19.888797 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7607d5718454fdc0da6a84823576fe350ac03b20", "dest": "./storage_class.yml", "gid": 0, "group": "root", "md5sum": "17478063283da48be48278607c8d2918", "mode": "0644", "owner": "root", "size": 403, "src": "/root/.ansible/tmp/ansible-tmp-1563438939.92-111634668925541/source", "state": "file", "uid": 0}

TASK [Create the storage class] ************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:53
2019-07-18T08:35:40.352978 (delta: 0.509944)         elapsed: 20.398832 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "storage_class.yml"], "delta": "0:00:01.524950", "end": "2019-07-18 08:35:42.185724", "rc": 0, "start": "2019-07-18 08:35:40.660774", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-storage-2 created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-storage-2 created"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:56
2019-07-18T08:35:42.261776 (delta: 1.908731)         elapsed: 22.30763 ******** 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:3
2019-07-18T08:35:42.415200 (delta: 0.153357)         elapsed: 22.461054 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-storage-2", "delta": "0:00:02.336809", "end": "2019-07-18 08:35:44.976882", "rc": 0, "start": "2019-07-18 08:35:42.640073", "stderr": "", "stderr_lines": [], "stdout": "NAME                      PROVISIONER                    AGE\nopenebs-cstor-storage-2   openebs.io/provisioner-iscsi   1s", "stdout_lines": ["NAME                      PROVISIONER                    AGE", "openebs-cstor-storage-2   openebs.io/provisioner-iscsi   1s"]}

TASK [Replace the pvc placeholder with provider] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:9
2019-07-18T08:35:45.051299 (delta: 2.636029)         elapsed: 25.097153 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:15
2019-07-18T08:35:45.329075 (delta: 0.277716)         elapsed: 25.374929 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:21
2019-07-18T08:35:45.625649 (delta: 0.296508)         elapsed: 25.671503 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:24
2019-07-18T08:35:45.758119 (delta: 0.132339)         elapsed: 25.803973 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-deploy"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
task path: /utils/k8s/pre_create_app_deploy.yml:29
2019-07-18T08:35:45.943799 (delta: 0.185595)         elapsed: 25.989653 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
task path: /utils/k8s/pre_create_app_deploy.yml:35
2019-07-18T08:35:46.347510 (delta: 0.403626)         elapsed: 26.393364 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:44
2019-07-18T08:35:46.427734 (delta: 0.080157)         elapsed: 26.473588 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
task path: /utils/k8s/create_ns.yml:2
2019-07-18T08:35:46.588699 (delta: 0.160877)         elapsed: 26.634553 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.298558", "end": "2019-07-18 08:35:48.098461", "rc": 0, "start": "2019-07-18 08:35:46.799903", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\napp-busybox-ns-1\napp-busybox-ns-2\napp-busybox-ns-3\napp-busybox-ns-4\ndefault\nfio\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["app-busybox-ns", "app-busybox-ns-1", "app-busybox-ns-2", "app-busybox-ns-3", "app-busybox-ns-4", "default", "fio", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
task path: /utils/k8s/create_ns.yml:11
2019-07-18T08:35:48.174195 (delta: 1.58544)         elapsed: 28.220049 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-busybox-ns-6", "delta": "0:00:01.416376", "end": "2019-07-18 08:35:49.885158", "rc": 0, "start": "2019-07-18 08:35:48.468782", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-busybox-ns-6 created", "stdout_lines": ["namespace/app-busybox-ns-6 created"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/create_ns.yml:17
2019-07-18T08:35:49.988925 (delta: 1.814646)         elapsed: 30.034779 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
task path: /utils/k8s/status_testns.yml:2
2019-07-18T08:35:50.128223 (delta: 0.13921)         elapsed: 30.174077 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-busybox-ns-6 -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.300236", "end": "2019-07-18 08:35:51.660754", "rc": 0, "start": "2019-07-18 08:35:50.360518", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the volume capacity placeholder with provider] *******************
task path: /experiments/functional/schedule-target-pod/test.yml:58
2019-07-18T08:35:51.756915 (delta: 1.6286)         elapsed: 31.802769 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:64
2019-07-18T08:35:52.125445 (delta: 0.368458)         elapsed: 32.171299 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying busybox] *******************************************************
task path: /utils/k8s/deploy_single_app.yml:4
2019-07-18T08:35:52.313342 (delta: 0.187831)         elapsed: 32.359196 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox_deployment.yml -n app-busybox-ns-6", "delta": "0:00:01.529431", "end": "2019-07-18 08:35:54.077185", "rc": 0, "start": "2019-07-18 08:35:52.547754", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/app-busybox created\npersistentvolumeclaim/openebs-busybox created", "stdout_lines": ["deployment.apps/app-busybox created", "persistentvolumeclaim/openebs-busybox created"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:7
2019-07-18T08:35:54.150711 (delta: 1.837296)         elapsed: 34.196565 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-07-18T08:35:54.285340 (delta: 0.134561)         elapsed: 34.331194 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns-6 -l app=\"busybox-deploy\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.516581", "end": "2019-07-18 08:36:17.750796", "rc": 0, "start": "2019-07-18 08:36:16.234215", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-07-18T08:36:14Z]]", "stdout_lines": ["map[running:map[startedAt:2019-07-18T08:36:14Z]]"]}

TASK [Checking busybox pod is in running state] ********************************
task path: /utils/k8s/status_app_pod.yml:13
2019-07-18T08:36:17.860115 (delta: 23.574707)         elapsed: 57.905969 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns-6 -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-deploy\")].status.phase}'", "delta": "0:00:01.287726", "end": "2019-07-18 08:36:19.428339", "rc": 0, "start": "2019-07-18 08:36:18.140613", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:10
2019-07-18T08:36:19.518705 (delta: 1.658513)         elapsed: 59.564559 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking busybox pod is in running state] ********************************
task path: /experiments/functional/schedule-target-pod/test.yml:70
2019-07-18T08:36:19.625725 (delta: 0.106955)         elapsed: 59.671579 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns-6 -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-deploy\")].status.phase}'", "delta": "0:00:01.246869", "end": "2019-07-18 08:36:21.136474", "rc": 0, "start": "2019-07-18 08:36:19.889605", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the pvc of the busybox application] **********************************
task path: /experiments/functional/schedule-target-pod/test.yml:77
2019-07-18T08:36:21.226122 (delta: 1.600318)         elapsed: 61.271976 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-ns-6 -o jsonpath='{.items[0].spec.volumeName}'", "delta": "0:00:01.260109", "end": "2019-07-18 08:36:22.707815", "rc": 0, "start": "2019-07-18 08:36:21.447706", "stderr": "", "stderr_lines": [], "stdout": "pvc-0e5b0aba-a937-11e9-9595-0050569846e3", "stdout_lines": ["pvc-0e5b0aba-a937-11e9-9595-0050569846e3"]}

TASK [Get the target pod of the busybox application] ***************************
task path: /experiments/functional/schedule-target-pod/test.yml:81
2019-07-18T08:36:22.804943 (delta: 1.578757)         elapsed: 62.850797 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-0e5b0aba-a937-11e9-9595-0050569846e3 -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.276852", "end": "2019-07-18 08:36:24.363539", "rc": 0, "start": "2019-07-18 08:36:23.086687", "stderr": "", "stderr_lines": [], "stdout": "pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj", "stdout_lines": ["pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj"]}

TASK [Check whether target pod is in running state or not] *********************
task path: /experiments/functional/schedule-target-pod/test.yml:85
2019-07-18T08:36:24.433859 (delta: 1.628842)         elapsed: 64.479713 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj -n openebs -o jsonpath='{.status.phase}'", "delta": "0:00:01.362085", "end": "2019-07-18 08:36:26.055053", "rc": 0, "start": "2019-07-18 08:36:24.692968", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the node name in which target pod is scheduled] **********************
task path: /experiments/functional/schedule-target-pod/test.yml:92
2019-07-18T08:36:26.160586 (delta: 1.72666)         elapsed: 66.20644 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj -n openebs -o jsonpath='{.spec.nodeName}'", "delta": "0:00:01.544925", "end": "2019-07-18 08:36:27.952459", "rc": 0, "start": "2019-07-18 08:36:26.407534", "stderr": "", "stderr_lines": [], "stdout": "node3-1558702621.mayalabs.io", "stdout_lines": ["node3-1558702621.mayalabs.io"]}

TASK [Fail the play if target pod is not scheduled in specified node] **********
task path: /experiments/functional/schedule-target-pod/test.yml:96
2019-07-18T08:36:28.047081 (delta: 1.886407)         elapsed: 68.092935 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the target pod of busybox application] ****************************
task path: /experiments/functional/schedule-target-pod/test.yml:101
2019-07-18T08:36:28.118772 (delta: 0.071614)         elapsed: 68.164626 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj -n openebs", "delta": "0:00:33.957702", "end": "2019-07-18 08:37:02.328971", "rc": 0, "start": "2019-07-18 08:36:28.371269", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj\" deleted", "stdout_lines": ["pod \"pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-pw7lj\" deleted"]}

TASK [Get the name of all pods in openebs namespace] ***************************
task path: /experiments/functional/schedule-target-pod/test.yml:104
2019-07-18T08:37:02.407187 (delta: 34.288353)         elapsed: 102.453041 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[*].metadata.name}'", "delta": "0:00:01.452580", "end": "2019-07-18 08:37:04.085604", "rc": 0, "start": "2019-07-18 08:37:02.633024", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-6aex-84bd75fd6f-8mhf7 cstor-block-disk-pool-nw9t-6dbdfcdc58-xrnmp cstor-block-disk-pool-uu41-848bfdcf75-6h9fs maya-apiserver-79ffbdb8b4-djrl8 openebs-admission-server-6cbcdb747d-nk94v openebs-localpv-provisioner-68fccfb9f5-hwv7f openebs-ndm-h2lzt openebs-ndm-l9z6m openebs-ndm-lg8m6 openebs-ndm-operator-cb77d795f-mhvsf openebs-provisioner-776b5f5874-7lb46 openebs-snapshot-operator-788f66444d-v8kkv pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj pvc-1818cce3-a920-11e9-9595-0050569846e3-target-69447b777-hw7r5 pvc-842a7d47-a922-11e9-9595-0050569846e3-target-74b98c674-xbz4x pvc-ad88e176-a871-11e9-9595-0050569846e3-target-589db7b746cnw7c pvc-ad8c4413-a86b-11e9-9595-0050569846e3-target-698c7d9f552ck2h pvc-b32ed4c3-a921-11e9-9595-0050569846e3-target-5576c6dbf-7zfsp pvc-ee2899b1-a86e-11e9-9595-0050569846e3-target-797f85b9946hmlc pvc-f0105e86-a924-11e9-9595-0050569846e3-target-668f76f5887lftn pvc-f07ef2cf-a91e-11e9-9595-0050569846e3-target-5b877797c88bxqm", "stdout_lines": ["cstor-block-disk-pool-6aex-84bd75fd6f-8mhf7 cstor-block-disk-pool-nw9t-6dbdfcdc58-xrnmp cstor-block-disk-pool-uu41-848bfdcf75-6h9fs maya-apiserver-79ffbdb8b4-djrl8 openebs-admission-server-6cbcdb747d-nk94v openebs-localpv-provisioner-68fccfb9f5-hwv7f openebs-ndm-h2lzt openebs-ndm-l9z6m openebs-ndm-lg8m6 openebs-ndm-operator-cb77d795f-mhvsf openebs-provisioner-776b5f5874-7lb46 openebs-snapshot-operator-788f66444d-v8kkv pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj pvc-1818cce3-a920-11e9-9595-0050569846e3-target-69447b777-hw7r5 pvc-842a7d47-a922-11e9-9595-0050569846e3-target-74b98c674-xbz4x pvc-ad88e176-a871-11e9-9595-0050569846e3-target-589db7b746cnw7c pvc-ad8c4413-a86b-11e9-9595-0050569846e3-target-698c7d9f552ck2h pvc-b32ed4c3-a921-11e9-9595-0050569846e3-target-5576c6dbf-7zfsp pvc-ee2899b1-a86e-11e9-9595-0050569846e3-target-797f85b9946hmlc pvc-f0105e86-a924-11e9-9595-0050569846e3-target-668f76f5887lftn pvc-f07ef2cf-a91e-11e9-9595-0050569846e3-target-5b877797c88bxqm"]}

TASK [Make sure that target pod is deleted and new pod has come up] ************
task path: /experiments/functional/schedule-target-pod/test.yml:108
2019-07-18T08:37:04.161539 (delta: 1.754301)         elapsed: 104.207393 ****** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "elapsed": 3, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Get the name of new target pod created] **********************************
task path: /experiments/functional/schedule-target-pod/test.yml:115
2019-07-18T08:37:07.808591 (delta: 3.646992)         elapsed: 107.854445 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-0e5b0aba-a937-11e9-9595-0050569846e3 -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.401582", "end": "2019-07-18 08:37:09.471128", "rc": 0, "start": "2019-07-18 08:37:08.069546", "stderr": "", "stderr_lines": [], "stdout": "pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj", "stdout_lines": ["pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj"]}

TASK [Check whether new target pod is in running state or not] *****************
task path: /experiments/functional/schedule-target-pod/test.yml:119
2019-07-18T08:37:09.563613 (delta: 1.754903)         elapsed: 109.609467 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj -n openebs -o jsonpath='{.status.phase}'", "delta": "0:00:01.152462", "end": "2019-07-18 08:37:11.011516", "rc": 0, "start": "2019-07-18 08:37:09.859054", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the node name in which new target pod is scheduled] ******************
task path: /experiments/functional/schedule-target-pod/test.yml:126
2019-07-18T08:37:11.093471 (delta: 1.529747)         elapsed: 111.139325 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods pvc-0e5b0aba-a937-11e9-9595-0050569846e3-target-76b98577-sd2hj -n openebs -o jsonpath='{.spec.nodeName}'", "delta": "0:00:01.261413", "end": "2019-07-18 08:37:12.582481", "rc": 0, "start": "2019-07-18 08:37:11.321068", "stderr": "", "stderr_lines": [], "stdout": "node3-1558702621.mayalabs.io", "stdout_lines": ["node3-1558702621.mayalabs.io"]}

TASK [Display the message if target pod is scheduled in the node specified] ****
task path: /experiments/functional/schedule-target-pod/test.yml:130
2019-07-18T08:37:12.671759 (delta: 1.578224)         elapsed: 112.717613 ****** 
ok: [127.0.0.1] => {
    "msg": [
        "The target pod is scheduled in the same node specified"
    ]
}

TASK [Fail the play if target pod is not scheduled in specified node] **********
task path: /experiments/functional/schedule-target-pod/test.yml:136
2019-07-18T08:37:12.780195 (delta: 0.108355)         elapsed: 112.826049 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:141
2019-07-18T08:37:12.864786 (delta: 0.084528)         elapsed: 112.91064 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Delete the label from node] **********************************************
task path: /experiments/functional/schedule-target-pod/test.yml:149
2019-07-18T08:37:12.974078 (delta: 0.109211)         elapsed: 113.019932 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "label", "nodes", "node3-1558702621.mayalabs.io", "node-"], "delta": "0:00:01.453367", "end": "2019-07-18 08:37:14.644551", "rc": 0, "start": "2019-07-18 08:37:13.191184", "stderr": "", "stderr_lines": [], "stdout": "node/node3-1558702621.mayalabs.io labeled", "stdout_lines": ["node/node3-1558702621.mayalabs.io labeled"]}

TASK [Delete the storage class] ************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:152
2019-07-18T08:37:14.740523 (delta: 1.766374)         elapsed: 114.786377 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "delete", "-f", "storage_class.yml"], "delta": "0:00:01.320464", "end": "2019-07-18 08:37:16.377481", "rc": 0, "start": "2019-07-18 08:37:15.057017", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-cstor-storage-2\" deleted", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-cstor-storage-2\" deleted"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:156
2019-07-18T08:37:16.468515 (delta: 1.727881)         elapsed: 116.514369 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-07-18T08:37:16.658304 (delta: 0.189722)         elapsed: 116.704158 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-07-18T08:37:16.741276 (delta: 0.082892)         elapsed: 116.78713 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-07-18T08:37:16.836341 (delta: 0.094998)         elapsed: 116.882195 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-07-18T08:37:16.917045 (delta: 0.080634)         elapsed: 116.962899 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "a6b702b8af8f9beef7c8f7936fd3740c1334d82a", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9393a7d7192997e9ba7a0e94ecd74dd8", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1563439037.01-4309687722557/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-07-18T08:37:19.862186 (delta: 2.945055)         elapsed: 119.90804 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.138669", "end": "2019-07-18 08:37:21.208905", "rc": 0, "start": "2019-07-18 08:37:20.070236", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: schedule-target-pod-on-node \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: schedule-target-pod-on-node ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-07-18T08:37:21.297508 (delta: 1.435242)         elapsed: 121.343362 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.547030", "end": "2019-07-18 08:37:24.080881", "failed_when_result": false, "rc": 0, "start": "2019-07-18 08:37:21.533851", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/schedule-target-pod-on-node configured", "stdout_lines": ["litmusresult.litmus.io/schedule-target-pod-on-node configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=49   changed=34   unreachable=0    failed=0   

2019-07-18T08:37:24.132193 (delta: 2.83462)         elapsed: 124.178047 ******* 
=============================================================================== 
 
 
```

2. When target pod is not scheduled on the node specified( This is done by removing TargetNodeSelector in storage class yaml file)
```
[root@master-1558702621 sushma]# kubectl logs litmus-target-pod-schedulel4jwk-zp68j -n litmus -f
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/schedule-target-pod/test.yml

PLAY [localhost] ***************************************************************
2019-07-18T08:52:03.255319 (delta: 0.067343)         elapsed: 0.067343 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:2
2019-07-18T08:52:03.273702 (delta: 0.018279)         elapsed: 0.085726 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:12
2019-07-18T08:52:13.674170 (delta: 10.400431)         elapsed: 10.486194 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-07-18T08:52:13.796927 (delta: 0.122701)         elapsed: 10.608951 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-07-18T08:52:13.876174 (delta: 0.079178)         elapsed: 10.688198 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:15
2019-07-18T08:52:13.959015 (delta: 0.082774)         elapsed: 10.771039 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-07-18T08:52:14.117271 (delta: 0.158191)         elapsed: 10.929295 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "1b64e250cd64fd86cd289ab71744f85340eaa953", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a5ff36075f6ad57ef8708a9ca2625d0a", "mode": "0644", "owner": "root", "size": 428, "src": "/root/.ansible/tmp/ansible-tmp-1563439934.18-186696762776277/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-07-18T08:52:15.046572 (delta: 0.929216)         elapsed: 11.858596 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.099419", "end": "2019-07-18 08:52:16.720769", "rc": 0, "start": "2019-07-18 08:52:15.621350", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: schedule-target-pod-on-node \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: schedule-target-pod-on-node ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-07-18T08:52:16.795874 (delta: 1.749226)         elapsed: 13.607898 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.712546", "end": "2019-07-18 08:52:18.812809", "failed_when_result": false, "rc": 0, "start": "2019-07-18 08:52:17.100263", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/schedule-target-pod-on-node configured", "stdout_lines": ["litmusresult.litmus.io/schedule-target-pod-on-node configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-07-18T08:52:18.930679 (delta: 2.134739)         elapsed: 15.742703 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-07-18T08:52:19.020604 (delta: 0.089851)         elapsed: 15.832628 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-07-18T08:52:19.122853 (delta: 0.102181)         elapsed: 15.934877 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the name of nodes in cluster] ****************************************
task path: /experiments/functional/schedule-target-pod/test.yml:19
2019-07-18T08:52:19.199179 (delta: 0.076225)         elapsed: 16.011203 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:01.382087", "end": "2019-07-18 08:52:20.805516", "rc": 0, "start": "2019-07-18 08:52:19.423429", "stderr": "", "stderr_lines": [], "stdout": "node1-1558702621.mayalabs.io\nnode2-1558702621.mayalabs.io\nnode3-1558702621.mayalabs.io", "stdout_lines": ["node1-1558702621.mayalabs.io", "node2-1558702621.mayalabs.io", "node3-1558702621.mayalabs.io"]}

TASK [Select random node from the list of nodes as target node] ****************
task path: /experiments/functional/schedule-target-pod/test.yml:23
2019-07-18T08:52:20.891689 (delta: 1.692442)         elapsed: 17.703713 ******* 
ok: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"ansible_facts": {"target_node": "node3-1558702621.mayalabs.io"}, "changed": false, "item": "node3-1558702621.mayalabs.io"}

TASK [Set the node as target node if it is taken as input] *********************
task path: /experiments/functional/schedule-target-pod/test.yml:29
2019-07-18T08:52:21.079214 (delta: 0.187455)         elapsed: 17.891238 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the node label values from env] **************************************
task path: /experiments/functional/schedule-target-pod/test.yml:34
2019-07-18T08:52:21.186367 (delta: 0.107044)         elapsed: 17.998391 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"node_lkey": "node", "node_lvalue": "appnode"}, "changed": false}

TASK [Give label to the node where target pod has to be scheduled] *************
task path: /experiments/functional/schedule-target-pod/test.yml:39
2019-07-18T08:52:21.311653 (delta: 0.125175)         elapsed: 18.123677 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "label", "nodes", "node3-1558702621.mayalabs.io", "node=appnode"], "delta": "0:00:01.298102", "end": "2019-07-18 08:52:22.820443", "rc": 0, "start": "2019-07-18 08:52:21.522341", "stderr": "", "stderr_lines": [], "stdout": "node/node3-1558702621.mayalabs.io labeled", "stdout_lines": ["node/node3-1558702621.mayalabs.io labeled"]}

TASK [Replace the node label placeholder in jinja template] ********************
task path: /experiments/functional/schedule-target-pod/test.yml:42
2019-07-18T08:52:22.917824 (delta: 1.606095)         elapsed: 19.729848 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Generate yaml file to create storage class from jinja template] **********
task path: /experiments/functional/schedule-target-pod/test.yml:48
2019-07-18T08:52:23.530244 (delta: 0.612333)         elapsed: 20.342268 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "188b7a8e448b06a66431eb0c6fc58dd020bca5f0", "dest": "./storage_class.yml", "gid": 0, "group": "root", "md5sum": "08b15a2ea43da5b6c043d05600e045ed", "mode": "0644", "owner": "root", "size": 331, "src": "/root/.ansible/tmp/ansible-tmp-1563439943.59-230767055275539/source", "state": "file", "uid": 0}

TASK [Create the storage class] ************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:53
2019-07-18T08:52:24.039911 (delta: 0.509589)         elapsed: 20.851935 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "storage_class.yml"], "delta": "0:00:01.597633", "end": "2019-07-18 08:52:25.878698", "rc": 0, "start": "2019-07-18 08:52:24.281065", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-storage-2 created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-storage-2 created"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:56
2019-07-18T08:52:25.974962 (delta: 1.934984)         elapsed: 22.786986 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:3
2019-07-18T08:52:26.135496 (delta: 0.160446)         elapsed: 22.94752 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-storage-2", "delta": "0:00:01.162917", "end": "2019-07-18 08:52:27.538089", "rc": 0, "start": "2019-07-18 08:52:26.375172", "stderr": "", "stderr_lines": [], "stdout": "NAME                      PROVISIONER                    AGE\nopenebs-cstor-storage-2   openebs.io/provisioner-iscsi   2s", "stdout_lines": ["NAME                      PROVISIONER                    AGE", "openebs-cstor-storage-2   openebs.io/provisioner-iscsi   2s"]}

TASK [Replace the pvc placeholder with provider] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:9
2019-07-18T08:52:27.614794 (delta: 1.479232)         elapsed: 24.426818 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:15
2019-07-18T08:52:27.943933 (delta: 0.329074)         elapsed: 24.755957 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:21
2019-07-18T08:52:28.370099 (delta: 0.4261)         elapsed: 25.182123 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:24
2019-07-18T08:52:28.510309 (delta: 0.140126)         elapsed: 25.322333 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-deploy"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
task path: /utils/k8s/pre_create_app_deploy.yml:29
2019-07-18T08:52:28.645073 (delta: 0.134654)         elapsed: 25.457097 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
task path: /utils/k8s/pre_create_app_deploy.yml:35
2019-07-18T08:52:28.965977 (delta: 0.320838)         elapsed: 25.778001 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:44
2019-07-18T08:52:29.065046 (delta: 0.099003)         elapsed: 25.87707 ******** 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
task path: /utils/k8s/create_ns.yml:2
2019-07-18T08:52:29.219238 (delta: 0.154113)         elapsed: 26.031262 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.403674", "end": "2019-07-18 08:52:30.949346", "rc": 0, "start": "2019-07-18 08:52:29.545672", "stderr": "", "stderr_lines": [], "stdout": "default\nfio\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["default", "fio", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
task path: /utils/k8s/create_ns.yml:11
2019-07-18T08:52:31.058118 (delta: 1.838791)         elapsed: 27.870142 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-busybox-ns", "delta": "0:00:01.421175", "end": "2019-07-18 08:52:32.738877", "rc": 0, "start": "2019-07-18 08:52:31.317702", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-busybox-ns created", "stdout_lines": ["namespace/app-busybox-ns created"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/create_ns.yml:17
2019-07-18T08:52:32.836586 (delta: 1.778363)         elapsed: 29.64861 ******** 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
task path: /utils/k8s/status_testns.yml:2
2019-07-18T08:52:32.956048 (delta: 0.119363)         elapsed: 29.768072 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-busybox-ns -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.361991", "end": "2019-07-18 08:52:34.587958", "rc": 0, "start": "2019-07-18 08:52:33.225967", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the volume capacity placeholder with provider] *******************
task path: /experiments/functional/schedule-target-pod/test.yml:58
2019-07-18T08:52:34.692144 (delta: 1.735989)         elapsed: 31.504168 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:64
2019-07-18T08:52:35.029755 (delta: 0.337503)         elapsed: 31.841779 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying busybox] *******************************************************
task path: /utils/k8s/deploy_single_app.yml:4
2019-07-18T08:52:35.156459 (delta: 0.126616)         elapsed: 31.968483 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox_deployment.yml -n app-busybox-ns", "delta": "0:00:01.496278", "end": "2019-07-18 08:52:36.921588", "rc": 0, "start": "2019-07-18 08:52:35.425310", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/app-busybox created\npersistentvolumeclaim/openebs-busybox created", "stdout_lines": ["deployment.apps/app-busybox created", "persistentvolumeclaim/openebs-busybox created"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:7
2019-07-18T08:52:37.006955 (delta: 1.850431)         elapsed: 33.818979 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-07-18T08:52:37.130047 (delta: 0.123018)         elapsed: 33.942071 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-deploy\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.376304", "end": "2019-07-18 08:53:04.309858", "rc": 0, "start": "2019-07-18 08:53:02.933554", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-07-18T08:53:01Z]]", "stdout_lines": ["map[running:map[startedAt:2019-07-18T08:53:01Z]]"]}

TASK [Checking busybox pod is in running state] ********************************
task path: /utils/k8s/status_app_pod.yml:13
2019-07-18T08:53:04.387172 (delta: 27.257054)         elapsed: 61.199196 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-deploy\")].status.phase}'", "delta": "0:00:01.417373", "end": "2019-07-18 08:53:06.043835", "rc": 0, "start": "2019-07-18 08:53:04.626462", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:10
2019-07-18T08:53:06.130484 (delta: 1.743251)         elapsed: 62.942508 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking busybox pod is in running state] ********************************
task path: /experiments/functional/schedule-target-pod/test.yml:70
2019-07-18T08:53:06.213013 (delta: 0.082459)         elapsed: 63.025037 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-deploy\")].status.phase}'", "delta": "0:00:01.199405", "end": "2019-07-18 08:53:07.649316", "rc": 0, "start": "2019-07-18 08:53:06.449911", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the pvc of the busybox application] **********************************
task path: /experiments/functional/schedule-target-pod/test.yml:77
2019-07-18T08:53:07.748897 (delta: 1.535826)         elapsed: 64.560921 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-busybox-ns -o jsonpath='{.items[0].spec.volumeName}'", "delta": "0:00:01.333726", "end": "2019-07-18 08:53:09.373754", "rc": 0, "start": "2019-07-18 08:53:08.040028", "stderr": "", "stderr_lines": [], "stdout": "pvc-6418e681-a939-11e9-9595-0050569846e3", "stdout_lines": ["pvc-6418e681-a939-11e9-9595-0050569846e3"]}

TASK [Get the target pod of the busybox application] ***************************
task path: /experiments/functional/schedule-target-pod/test.yml:81
2019-07-18T08:53:09.451976 (delta: 1.703001)         elapsed: 66.264 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-6418e681-a939-11e9-9595-0050569846e3 -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.430516", "end": "2019-07-18 08:53:11.118934", "rc": 0, "start": "2019-07-18 08:53:09.688418", "stderr": "", "stderr_lines": [], "stdout": "pvc-6418e681-a939-11e9-9595-0050569846e3-target-5f4f94f885gkjll", "stdout_lines": ["pvc-6418e681-a939-11e9-9595-0050569846e3-target-5f4f94f885gkjll"]}

TASK [Check whether target pod is in running state or not] *********************
task path: /experiments/functional/schedule-target-pod/test.yml:85
2019-07-18T08:53:11.198754 (delta: 1.746716)         elapsed: 68.010778 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods pvc-6418e681-a939-11e9-9595-0050569846e3-target-5f4f94f885gkjll -n openebs -o jsonpath='{.status.phase}'", "delta": "0:00:01.385421", "end": "2019-07-18 08:53:12.854868", "rc": 0, "start": "2019-07-18 08:53:11.469447", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the node name in which target pod is scheduled] **********************
task path: /experiments/functional/schedule-target-pod/test.yml:92
2019-07-18T08:53:12.986551 (delta: 1.787728)         elapsed: 69.798575 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods pvc-6418e681-a939-11e9-9595-0050569846e3-target-5f4f94f885gkjll -n openebs -o jsonpath='{.spec.nodeName}'", "delta": "0:00:01.432097", "end": "2019-07-18 08:53:14.675301", "rc": 0, "start": "2019-07-18 08:53:13.243204", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Fail the play if target pod is not scheduled in specified node] **********
task path: /experiments/functional/schedule-target-pod/test.yml:96
2019-07-18T08:53:14.769715 (delta: 1.783091)         elapsed: 71.581739 ******* 
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Target pod is scheduled in different node"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:145
2019-07-18T08:53:14.894578 (delta: 0.124789)         elapsed: 71.706602 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [Delete the label from node] **********************************************
task path: /experiments/functional/schedule-target-pod/test.yml:149
2019-07-18T08:53:15.028293 (delta: 0.133643)         elapsed: 71.840317 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "label", "nodes", "node3-1558702621.mayalabs.io", "node-"], "delta": "0:00:01.472929", "end": "2019-07-18 08:53:16.734932", "rc": 0, "start": "2019-07-18 08:53:15.262003", "stderr": "", "stderr_lines": [], "stdout": "node/node3-1558702621.mayalabs.io labeled", "stdout_lines": ["node/node3-1558702621.mayalabs.io labeled"]}

TASK [Delete the storage class] ************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:152
2019-07-18T08:53:16.814008 (delta: 1.785637)         elapsed: 73.626032 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "delete", "-f", "storage_class.yml"], "delta": "0:00:01.425589", "end": "2019-07-18 08:53:18.532219", "rc": 0, "start": "2019-07-18 08:53:17.106630", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-cstor-storage-2\" deleted", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-cstor-storage-2\" deleted"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/schedule-target-pod/test.yml:156
2019-07-18T08:53:18.621452 (delta: 1.807371)         elapsed: 75.433476 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-07-18T08:53:18.827042 (delta: 0.205504)         elapsed: 75.639066 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-07-18T08:53:18.910459 (delta: 0.083351)         elapsed: 75.722483 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-07-18T08:53:18.991065 (delta: 0.080523)         elapsed: 75.803089 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-07-18T08:53:19.092970 (delta: 0.101836)         elapsed: 75.904994 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cdc331893e66cb8099f9a2a3e2f7664cbecf0caf", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6324c6b696e5f681cb2d8d9cc307f97a", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1563439999.17-110741073154849/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-07-18T08:53:22.090057 (delta: 2.99701)         elapsed: 78.902081 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.194971", "end": "2019-07-18 08:53:23.547831", "rc": 0, "start": "2019-07-18 08:53:22.352860", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: schedule-target-pod-on-node \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: schedule-target-pod-on-node ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-07-18T08:53:23.627411 (delta: 1.537256)         elapsed: 80.439435 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.561443", "end": "2019-07-18 08:53:25.490888", "failed_when_result": false, "rc": 0, "start": "2019-07-18 08:53:23.929445", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/schedule-target-pod-on-node configured", "stdout_lines": ["litmusresult.litmus.io/schedule-target-pod-on-node configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=42   changed=28   unreachable=0    failed=1   

2019-07-18T08:53:25.546409 (delta: 1.918921)         elapsed: 82.358433 ******* 
===============================================================================  

```

