### PR TITLE
fix[yaml]: Correct the typo in file 

### DIFF
--- a/experiments/functional/schedule-target-pod/run_litmus_test.yml
+++ b/experiments/functional/schedule-target-pod/run_litmus_test.yml
@@ -64,4 +64,4 @@ spec:
             value: 5G
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/task.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/functional/schedule-target-pod/test.yml -i /etc/ansible/hosts -vv; exit 0"]


### PR DESCRIPTION
* In run_litmus_test.yml by mistake it was written as task.yml. It is corrected to test.yml