### PR TITLE
refactor[LitmusBook]: Changed the default cluster region for Packet cluster

### DIFF
--- a/k8s/packet/k8s-installer/vars.yml
+++ b/k8s/packet/k8s-installer/vars.yml
@@ -1,7 +1,7 @@
 ---
 workers_count: 3
 master_count: 1 # kubeadm support single master only
-location: ams1
+location: sjc1
 os: ubuntu_16_04
 network_cidr: 10.1.0.0/16
 master_config: t1.small.x86


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the default cluster region for Packet cluster creation has to support t1.small.x86 VM's