### PR TITLE
fix(packet cluster setup): Refactor script to setup cluster for version k8s-1.14 & above

### DIFF
--- a/k8s/packet/k8s-installer/README.md
+++ b/k8s/packet/k8s-installer/README.md
@@ -67,5 +67,5 @@ ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=1.11.3-
 - Run `delete_packet_cluster`, this will delete the cluster as well as ssh key.
 
 ```bash
-ansible-playbook delete_packet_cluster.yml -vv
+ansible-playbook delete_packet_cluster.yml --extra-vars "packet_api=<token>" -vv
 ```

--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -100,15 +100,22 @@
             - "{{ workers.devices }}"
 
         - name: install kubeadm inside master
-          shell: bash pre_requisite.sh "{{ k8s_version }}" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
+          shell: bash pre_requisite.sh "{{ k8s_version }}" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master
           args:
             executable: /bin/bash
           delegate_to: "root@{{ item.public_ipv4 }}"
-          register: storage
           with_items: "{{ master.devices }}"
 
         - name: set kubeconfig to local
           shell: scp root@{{ item.public_ipv4 }}:/etc/kubernetes/admin.conf ~/.kube/config
+          with_items: "{{ master.devices }}"
+
+        - name: Generate Kubeadm Join command
+          shell: kubeadm token create --print-join-command
+          register: storage
+          args:
+            executable: /bin/bash
+          delegate_to: "root@{{ item.public_ipv4 }}"
           with_items: "{{ master.devices }}"
 
         - name: joining workers node with master


### PR DESCRIPTION
**What this PR does / why we need it**:
- Create packet cluster for kubernetes version 1.14 and above.
- Update `README.md` for packet cluster deletion command

**Following is the log of ansible test container**
```
PLAY [localhost] *****************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:19
ok: [localhost]
META: ran handlers

TASK [Generate ssh key for packet] ***********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:30
changed: [localhost] => {"changed": true, "sshkeys": [{"fingerprint": "6a:b8:a5:d9:1d:30:1b:36:4b:f8:7e:47:ac:30:c3:69", "id": "d0f21a66-aebc-4abb-85f8-a9e13e227313", "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIG9gQUGtSs7Vk0Gd10L3xqM0/2WwXixstBXuufbzmGkBsDRwIjIpuLOCB2mgut9LPp4Iy2DJ0UU6ZEkWZrfOLrtPsY4q3giifukKgkOGzKZlCbTdzPvSWlQbVH736EenouTcgKe6z0zTNYi48jXvKvprdKJt15rCs+ocEcuFiKeH+j1SjjoJTtjaNO8+ok4TYKJDSU40w0C/6y8bfFEmtr+o6pqAqDt2Hoao1MPkgvsidEx7yhKj87Y0kJ8tPBI9/7w20u1y59nyZJVFy5eFrh1tCd5NPg3jEox7T3I4F8PF2cjssXH/7S1UNCd8pWZ7iEdeuZ2nHF3oEBqBGnDbR shashank@shashank", "label": "shashank@shashank"}]}

TASK [Generate random Cluster name] **********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:35
changed: [localhost] => {"changed": true, "cmd": ["python", "../../utils/name_generator/namesgenerator.py"], "delta": "0:00:00.023982", "end": "2019-08-02 14:58:20.642587", "rc": 0, "start": "2019-08-02 14:58:20.618605", "stderr": "", "stderr_lines": [], "stdout": "frosty-pare", "stdout_lines": ["frosty-pare"]}

TASK [set_fact] ******************************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:40
ok: [localhost] => {"ansible_facts": {"cluster_name": "frosty-pare"}, "changed": false}

TASK [set_fact] ******************************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:44
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating master instance in packet] ****************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:48
changed: [localhost] => {"changed": true, "devices": [{"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}]}

TASK [Creating workers instance in packet] ***************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:59
changed: [localhost] => {"changed": true, "devices": [{"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}]}

TASK [wait for ssh inside instances] *********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:70
ok: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"changed": false, "elapsed": 1, "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "path": null, "port": 22, "search_regex": null, "state": "started"}
ok: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::3', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.3', u'public': False, u'address_family': 4}]}) => {"changed": false, "elapsed": 1, "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "path": null, "port": 22, "search_regex": null, "state": "started"}
ok: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::5', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.5', u'public': False, u'address_family': 4}]}) => {"changed": false, "elapsed": 1, "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "path": null, "port": 22, "search_regex": null, "state": "started"}
ok: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::7', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.7', u'public': False, u'address_family': 4}]}) => {"changed": false, "elapsed": 1, "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "path": null, "port": 22, "search_regex": null, "state": "started"}

TASK [Create a file for store device Ids] ****************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:81
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::3', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.3', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::5', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.5', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "msg": "line added"}
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::7', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.7', u'public': False, u'address_family': 4}]}) => {"backup": "", "changed": true, "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "msg": "line added"}

TASK [Removing any known hosts] **************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:92
changed: [localhost] => {"changed": true, "cmd": "cat ~/.ssh/known_hosts > ~/.ssh/known_hosts", "delta": "0:00:00.001952", "end": "2019-08-02 15:01:23.027021", "rc": 0, "start": "2019-08-02 15:01:23.025069", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [copy file to instances] ****************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:96
The authenticity of host '147.75.88.231 (147.75.88.231)' can't be established.
ECDSA key fingerprint is SHA256:xOq6s7mO2F/j23JRUsulnIG+kGqtRSRU3/VV98rpJ8M.
Are you sure you want to continue connecting (yes/no)? yes
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.88.231:.", "delta": "0:00:07.002356", "end": "2019-08-02 15:01:30.206949", "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 15:01:23.204593", "stderr": "Warning: Permanently added '147.75.88.231' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.88.231' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
The authenticity of host '147.75.88.241 (147.75.88.241)' can't be established.
ECDSA key fingerprint is SHA256:M8AxOOas/650osMidgX3QAD0FgRPfwQLj9cSah5/7M0.
Are you sure you want to continue connecting (yes/no)? yes
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::3', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.3', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.88.241:.", "delta": "0:00:05.646241", "end": "2019-08-02 15:01:35.985330", "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 15:01:30.339089", "stderr": "Warning: Permanently added '147.75.88.241' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.88.241' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
yes
The authenticity of host '147.75.89.137 (147.75.89.137)' can't be established.
ECDSA key fingerprint is SHA256:qS0QvK0wf3V0je76QsbrGQFYyulVFm1tGQOCTixHp9Q.
Are you sure you want to continue connecting (yes/no)? yes
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::5', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.5', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.89.137:.", "delta": "0:00:08.775811", "end": "2019-08-02 15:01:44.885490", "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 15:01:36.109679", "stderr": "Warning: Permanently added '147.75.89.137' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.89.137' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}
The authenticity of host '147.75.68.85 (147.75.68.85)' can't be established.
ECDSA key fingerprint is SHA256:bNqg8A7zri+i7UCPwleuJa696E45qRmm99f/zOsZO7E.
Are you sure you want to continue connecting (yes/no)? yes
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::7', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.7', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp pre_requisite.sh root@147.75.68.85:.", "delta": "0:00:08.122643", "end": "2019-08-02 15:01:53.141470", "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 15:01:45.018827", "stderr": "Warning: Permanently added '147.75.68.85' (ECDSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '147.75.68.85' (ECDSA) to the list of known hosts."], "stdout": "", "stdout_lines": []}

TASK [install kubeadm inside master] *********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:102
changed: [localhost -> root@147.75.88.231] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh \"1.15.1-00\" \"147.75.88.231\" \"10.1.0.0/16\" master", "delta": "0:02:25.047834", "end": "2019-08-02 09:34:28.804683", "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:32:03.756849", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)\ndebconf: falling back to frontend: Readline\n\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)", "debconf: falling back to frontend: Readline", "\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\nca-certificates is already the newest version (20170717~16.04.1).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nsoftware-properties-common is already the newest version (0.96.20.7).\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\nOK\nGet:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]\nGet:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]\nHit:3 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]\nFetched 4,389 kB in 3s (1,284 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl\n  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22\n  pigz\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\n  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl\nThe following NEW packages will be installed:\n  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl\n  liberror-perl libltdl7 patch pigz\nThe following packages will be upgraded:\n  libperl5.22 perl perl-base perl-modules-5.22\n4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.\nNeed to get 52.3 MB of archives.\nAfter this operation, 226 MB of additional disk space will be used.\nGet:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]\nPreconfiguring packages ...\nFetched 52.3 MB in 3s (14.9 MB/s)\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up perl-base (5.22.1-9ubuntu0.6) ...\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...\r\nUnpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nSelecting previously unselected package pigz.\r\nPreparing to unpack .../pigz_2.3.1-2_amd64.deb ...\r\nUnpacking pigz (2.3.1-2) ...\r\nSelecting previously unselected package libapparmor-perl.\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package aufs-tools.\r\nPreparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...\r\nUnpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package libltdl7:amd64.\r\nPreparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...\r\nUnpacking libltdl7:amd64 (2.4.6-0.1) ...\r\nSelecting previously unselected package docker-ce.\r\nPreparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...\r\nUnpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...\r\nSetting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...\r\nSetting up perl (5.22.1-9ubuntu0.6) ...\r\nSetting up pigz (2.3.1-2) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.11) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up libltdl7:amd64 (2.4.6-0.1) ...\r\nSetting up docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.6) ...\r\nSetting up git (1:2.7.4-0ubuntu1.6) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nOK\nHit:1 https://download.docker.com/linux/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:4 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:5 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]\nFetched 36.7 kB in 0s (36.8 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3\nThe following NEW packages will be installed:\n  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n  libnetfilter-conntrack3\n0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 52.7 MB of archives.\nAfter this operation, 280 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]\nGet:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]\nGet:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]\nFetched 52.7 MB in 4s (11.1 MB/s)\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30977 files and directories currently installed.)\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package conntrack.\r\nPreparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...\r\nUnpacking conntrack (1:1.4.3-3) ...\r\nSelecting previously unselected package cri-tools.\r\nPreparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.13.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.7.5-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.15.1-00_amd64.deb ...\r\nUnpacking kubelet (1.15.1-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.15.1-00_amd64.deb ...\r\nUnpacking kubectl (1.15.1-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...\r\nUnpacking kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up conntrack (1:1.4.3-3) ...\r\nSetting up cri-tools (1.13.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.7.5-00) ...\r\nSetting up kubelet (1.15.1-00) ...\r\nSetting up kubectl (1.15.1-00) ...\r\nSetting up kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[init] Using Kubernetes version: v1.15.1\n[preflight] Running pre-flight checks\n[preflight] Pulling images required for setting up a Kubernetes cluster\n[preflight] This might take a minute or two, depending on the speed of your internet connection\n[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'\n[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet-start] Activating the kubelet service\n[certs] Using certificateDir folder \"/etc/kubernetes/pki\"\n[certs] Generating \"ca\" certificate and key\n[certs] Generating \"apiserver-kubelet-client\" certificate and key\n[certs] Generating \"apiserver\" certificate and key\n[certs] apiserver serving cert is signed for DNS names [master-frosty-pare kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local] and IPs [10.96.0.1 147.75.88.231 10.0.2.15]\n[certs] Generating \"front-proxy-ca\" certificate and key\n[certs] Generating \"front-proxy-client\" certificate and key\n[certs] Generating \"etcd/ca\" certificate and key\n[certs] Generating \"etcd/server\" certificate and key\n[certs] etcd/server serving cert is signed for DNS names [master-frosty-pare localhost] and IPs [147.75.88.231 127.0.0.1 ::1]\n[certs] Generating \"etcd/healthcheck-client\" certificate and key\n[certs] Generating \"etcd/peer\" certificate and key\n[certs] etcd/peer serving cert is signed for DNS names [master-frosty-pare localhost] and IPs [147.75.88.231 127.0.0.1 ::1]\n[certs] Generating \"apiserver-etcd-client\" certificate and key\n[certs] Generating \"sa\" key and public key\n[kubeconfig] Using kubeconfig folder \"/etc/kubernetes\"\n[kubeconfig] Writing \"admin.conf\" kubeconfig file\n[kubeconfig] Writing \"kubelet.conf\" kubeconfig file\n[kubeconfig] Writing \"controller-manager.conf\" kubeconfig file\n[kubeconfig] Writing \"scheduler.conf\" kubeconfig file\n[control-plane] Using manifest folder \"/etc/kubernetes/manifests\"\n[control-plane] Creating static Pod manifest for \"kube-apiserver\"\n[control-plane] Creating static Pod manifest for \"kube-controller-manager\"\n[control-plane] Creating static Pod manifest for \"kube-scheduler\"\n[etcd] Creating static Pod manifest for local etcd in \"/etc/kubernetes/manifests\"\n[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory \"/etc/kubernetes/manifests\". This can take up to 4m0s\n[apiclient] All control plane components are healthy after 35.004884 seconds\n[upload-config] Storing the configuration used in ConfigMap \"kubeadm-config\" in the \"kube-system\" Namespace\n[kubelet] Creating a ConfigMap \"kubelet-config-1.15\" in namespace kube-system with the configuration for the kubelets in the cluster\n[upload-certs] Skipping phase. Please see --upload-certs\n[mark-control-plane] Marking the node master-frosty-pare as control-plane by adding the label \"node-role.kubernetes.io/master=''\"\n[mark-control-plane] Marking the node master-frosty-pare as control-plane by adding the taints [node-role.kubernetes.io/master:NoSchedule]\n[bootstrap-token] Using token: od29oc.jwk3vryyckdjwa95\n[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles\n[bootstrap-token] configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials\n[bootstrap-token] configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token\n[bootstrap-token] configured RBAC rules to allow certificate rotation for all node client certificates in the cluster\n[bootstrap-token] Creating the \"cluster-info\" ConfigMap in the \"kube-public\" namespace\n[addons] Applied essential addon: CoreDNS\n[addons] Applied essential addon: kube-proxy\n\nYour Kubernetes control-plane has initialized successfully!\n\nTo start using your cluster, you need to run the following as a regular user:\n\n  mkdir -p $HOME/.kube\n  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config\n  sudo chown $(id -u):$(id -g) $HOME/.kube/config\n\nYou should now deploy a pod network to the cluster.\nRun \"kubectl apply -f [podnetwork].yaml\" with one of the options listed at:\n  https://kubernetes.io/docs/concepts/cluster-administration/addons/\n\nThen you can join any number of worker nodes by running the following on each as root:\n\nkubeadm join 147.75.88.231:6443 --token od29oc.jwk3vryyckdjwa95 \\\n    --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 \nnet.bridge.bridge-nf-call-iptables = 1\nconfigmap/kube-router-cfg created\ndaemonset.apps/kube-router created\nserviceaccount/kube-router created\nclusterrole.rbac.authorization.k8s.io/kube-router created\nclusterrolebinding.rbac.authorization.k8s.io/kube-router created", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "ca-certificates is already the newest version (20170717~16.04.1).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "software-properties-common is already the newest version (0.96.20.7).", "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.", "OK", "Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]", "Get:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]", "Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]", "Fetched 4,389 kB in 3s (1,284 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl", "  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22", "  pigz", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl", "The following NEW packages will be installed:", "  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl", "  liberror-perl libltdl7 patch pigz", "The following packages will be upgraded:", "  libperl5.22 perl perl-base perl-modules-5.22", "4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.", "Need to get 52.3 MB of archives.", "After this operation, 226 MB of additional disk space will be used.", "Get:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]", "Preconfiguring packages ...", "Fetched 52.3 MB in 3s (14.9 MB/s)", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up perl-base (5.22.1-9ubuntu0.6) ...", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...", "Unpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Selecting previously unselected package pigz.", "Preparing to unpack .../pigz_2.3.1-2_amd64.deb ...", "Unpacking pigz (2.3.1-2) ...", "Selecting previously unselected package libapparmor-perl.", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package aufs-tools.", "Preparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...", "Unpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package libltdl7:amd64.", "Preparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...", "Unpacking libltdl7:amd64 (2.4.6-0.1) ...", "Selecting previously unselected package docker-ce.", "Preparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...", "Unpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...", "Setting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...", "Setting up perl (5.22.1-9ubuntu0.6) ...", "Setting up pigz (2.3.1-2) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Setting up apparmor (2.10.95-0ubuntu2.11) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Setting up cgroupfs-mount (1.2) ...", "Setting up libltdl7:amd64 (2.4.6-0.1) ...", "Setting up docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.6) ...", "Setting up git (1:2.7.4-0ubuntu1.6) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "OK", "Hit:1 https://download.docker.com/linux/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:4 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:5 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]", "Fetched 36.7 kB in 0s (36.8 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3", "The following NEW packages will be installed:", "  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "  libnetfilter-conntrack3", "0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.", "Need to get 52.7 MB of archives.", "After this operation, 280 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]", "Get:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]", "Get:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]", "Fetched 52.7 MB in 4s (11.1 MB/s)", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30977 files and directories currently installed.)", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package conntrack.", "Preparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...", "Unpacking conntrack (1:1.4.3-3) ...", "Selecting previously unselected package cri-tools.", "Preparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...", "Unpacking cri-tools (1.13.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...", "Unpacking kubernetes-cni (0.7.5-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.15.1-00_amd64.deb ...", "Unpacking kubelet (1.15.1-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.15.1-00_amd64.deb ...", "Unpacking kubectl (1.15.1-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...", "Unpacking kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up conntrack (1:1.4.3-3) ...", "Setting up cri-tools (1.13.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.7.5-00) ...", "Setting up kubelet (1.15.1-00) ...", "Setting up kubectl (1.15.1-00) ...", "Setting up kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[init] Using Kubernetes version: v1.15.1", "[preflight] Running pre-flight checks", "[preflight] Pulling images required for setting up a Kubernetes cluster", "[preflight] This might take a minute or two, depending on the speed of your internet connection", "[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'", "[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet-start] Activating the kubelet service", "[certs] Using certificateDir folder \"/etc/kubernetes/pki\"", "[certs] Generating \"ca\" certificate and key", "[certs] Generating \"apiserver-kubelet-client\" certificate and key", "[certs] Generating \"apiserver\" certificate and key", "[certs] apiserver serving cert is signed for DNS names [master-frosty-pare kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local] and IPs [10.96.0.1 147.75.88.231 10.0.2.15]", "[certs] Generating \"front-proxy-ca\" certificate and key", "[certs] Generating \"front-proxy-client\" certificate and key", "[certs] Generating \"etcd/ca\" certificate and key", "[certs] Generating \"etcd/server\" certificate and key", "[certs] etcd/server serving cert is signed for DNS names [master-frosty-pare localhost] and IPs [147.75.88.231 127.0.0.1 ::1]", "[certs] Generating \"etcd/healthcheck-client\" certificate and key", "[certs] Generating \"etcd/peer\" certificate and key", "[certs] etcd/peer serving cert is signed for DNS names [master-frosty-pare localhost] and IPs [147.75.88.231 127.0.0.1 ::1]", "[certs] Generating \"apiserver-etcd-client\" certificate and key", "[certs] Generating \"sa\" key and public key", "[kubeconfig] Using kubeconfig folder \"/etc/kubernetes\"", "[kubeconfig] Writing \"admin.conf\" kubeconfig file", "[kubeconfig] Writing \"kubelet.conf\" kubeconfig file", "[kubeconfig] Writing \"controller-manager.conf\" kubeconfig file", "[kubeconfig] Writing \"scheduler.conf\" kubeconfig file", "[control-plane] Using manifest folder \"/etc/kubernetes/manifests\"", "[control-plane] Creating static Pod manifest for \"kube-apiserver\"", "[control-plane] Creating static Pod manifest for \"kube-controller-manager\"", "[control-plane] Creating static Pod manifest for \"kube-scheduler\"", "[etcd] Creating static Pod manifest for local etcd in \"/etc/kubernetes/manifests\"", "[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory \"/etc/kubernetes/manifests\". This can take up to 4m0s", "[apiclient] All control plane components are healthy after 35.004884 seconds", "[upload-config] Storing the configuration used in ConfigMap \"kubeadm-config\" in the \"kube-system\" Namespace", "[kubelet] Creating a ConfigMap \"kubelet-config-1.15\" in namespace kube-system with the configuration for the kubelets in the cluster", "[upload-certs] Skipping phase. Please see --upload-certs", "[mark-control-plane] Marking the node master-frosty-pare as control-plane by adding the label \"node-role.kubernetes.io/master=''\"", "[mark-control-plane] Marking the node master-frosty-pare as control-plane by adding the taints [node-role.kubernetes.io/master:NoSchedule]", "[bootstrap-token] Using token: od29oc.jwk3vryyckdjwa95", "[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles", "[bootstrap-token] configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials", "[bootstrap-token] configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token", "[bootstrap-token] configured RBAC rules to allow certificate rotation for all node client certificates in the cluster", "[bootstrap-token] Creating the \"cluster-info\" ConfigMap in the \"kube-public\" namespace", "[addons] Applied essential addon: CoreDNS", "[addons] Applied essential addon: kube-proxy", "", "Your Kubernetes control-plane has initialized successfully!", "", "To start using your cluster, you need to run the following as a regular user:", "", "  mkdir -p $HOME/.kube", "  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config", "  sudo chown $(id -u):$(id -g) $HOME/.kube/config", "", "You should now deploy a pod network to the cluster.", "Run \"kubectl apply -f [podnetwork].yaml\" with one of the options listed at:", "  https://kubernetes.io/docs/concepts/cluster-administration/addons/", "", "Then you can join any number of worker nodes by running the following on each as root:", "", "kubeadm join 147.75.88.231:6443 --token od29oc.jwk3vryyckdjwa95 \\", "    --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 ", "net.bridge.bridge-nf-call-iptables = 1", "configmap/kube-router-cfg created", "daemonset.apps/kube-router created", "serviceaccount/kube-router created", "clusterrole.rbac.authorization.k8s.io/kube-router created", "clusterrolebinding.rbac.authorization.k8s.io/kube-router created"]}

TASK [set kubeconfig to local] ***************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:109
changed: [localhost] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "scp root@147.75.88.231:/etc/kubernetes/admin.conf ~/.kube/config", "delta": "0:00:04.429029", "end": "2019-08-02 15:04:34.094466", "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 15:04:29.665437", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Generate Kubeadm Join command] *********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:113
changed: [localhost -> root@147.75.88.231] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::1', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.1', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "kubeadm token create --print-join-command", "delta": "0:00:00.109066", "end": "2019-08-02 09:34:40.505428", "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:34:40.396362", "stderr": "", "stderr_lines": [], "stdout": "kubeadm join 147.75.88.231:6443 --token ez6z6f.jk591ivf006blvy7     --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 ", "stdout_lines": ["kubeadm join 147.75.88.231:6443 --token ez6z6f.jk591ivf006blvy7     --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 "]}

TASK [joining workers node with master] ******************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:122
changed: [localhost -> root@147.75.88.241] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::3', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.3', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh \"1.15.1-00\" && kubeadm join 147.75.88.231:6443 --token ez6z6f.jk591ivf006blvy7     --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 ", "delta": "0:01:14.880069", "end": "2019-08-02 09:36:07.056260", "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:34:52.176191", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)\ndebconf: falling back to frontend: Readline\n\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)", "debconf: falling back to frontend: Readline", "\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\nca-certificates is already the newest version (20170717~16.04.1).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nsoftware-properties-common is already the newest version (0.96.20.7).\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\nOK\nGet:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:3 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]\nFetched 4,389 kB in 3s (1,262 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl\n  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22\n  pigz\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\n  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl\nThe following NEW packages will be installed:\n  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl\n  liberror-perl libltdl7 patch pigz\nThe following packages will be upgraded:\n  libperl5.22 perl perl-base perl-modules-5.22\n4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.\nNeed to get 52.3 MB of archives.\nAfter this operation, 226 MB of additional disk space will be used.\nGet:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]\nPreconfiguring packages ...\nFetched 52.3 MB in 3s (14.4 MB/s)\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up perl-base (5.22.1-9ubuntu0.6) ...\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...\r\nUnpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nSelecting previously unselected package pigz.\r\nPreparing to unpack .../pigz_2.3.1-2_amd64.deb ...\r\nUnpacking pigz (2.3.1-2) ...\r\nSelecting previously unselected package libapparmor-perl.\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package aufs-tools.\r\nPreparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...\r\nUnpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package libltdl7:amd64.\r\nPreparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...\r\nUnpacking libltdl7:amd64 (2.4.6-0.1) ...\r\nSelecting previously unselected package docker-ce.\r\nPreparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...\r\nUnpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...\r\nSetting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...\r\nSetting up perl (5.22.1-9ubuntu0.6) ...\r\nSetting up pigz (2.3.1-2) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.11) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up libltdl7:amd64 (2.4.6-0.1) ...\r\nSetting up docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.6) ...\r\nSetting up git (1:2.7.4-0ubuntu1.6) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nOK\nHit:1 https://download.docker.com/linux/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nHit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]\nFetched 36.7 kB in 0s (41.3 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3\nThe following NEW packages will be installed:\n  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n  libnetfilter-conntrack3\n0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 52.7 MB of archives.\nAfter this operation, 280 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]\nGet:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]\nGet:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]\nFetched 52.7 MB in 2s (22.1 MB/s)\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30977 files and directories currently installed.)\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package conntrack.\r\nPreparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...\r\nUnpacking conntrack (1:1.4.3-3) ...\r\nSelecting previously unselected package cri-tools.\r\nPreparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.13.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.7.5-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.15.1-00_amd64.deb ...\r\nUnpacking kubelet (1.15.1-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.15.1-00_amd64.deb ...\r\nUnpacking kubectl (1.15.1-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...\r\nUnpacking kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up conntrack (1:1.4.3-3) ...\r\nSetting up cri-tools (1.13.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.7.5-00) ...\r\nSetting up kubelet (1.15.1-00) ...\r\nSetting up kubectl (1.15.1-00) ...\r\nSetting up kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] Running pre-flight checks\n[preflight] Reading configuration from the cluster...\n[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'\n[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace\n[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[kubelet-start] Activating the kubelet service\n[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...\n\nThis node has joined the cluster:\n* Certificate signing request was sent to apiserver and a response was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the control-plane to see this node join the cluster.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "ca-certificates is already the newest version (20170717~16.04.1).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "software-properties-common is already the newest version (0.96.20.7).", "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.", "OK", "Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:3 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]", "Fetched 4,389 kB in 3s (1,262 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl", "  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22", "  pigz", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl", "The following NEW packages will be installed:", "  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl", "  liberror-perl libltdl7 patch pigz", "The following packages will be upgraded:", "  libperl5.22 perl perl-base perl-modules-5.22", "4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.", "Need to get 52.3 MB of archives.", "After this operation, 226 MB of additional disk space will be used.", "Get:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]", "Preconfiguring packages ...", "Fetched 52.3 MB in 3s (14.4 MB/s)", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up perl-base (5.22.1-9ubuntu0.6) ...", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...", "Unpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Selecting previously unselected package pigz.", "Preparing to unpack .../pigz_2.3.1-2_amd64.deb ...", "Unpacking pigz (2.3.1-2) ...", "Selecting previously unselected package libapparmor-perl.", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package aufs-tools.", "Preparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...", "Unpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package libltdl7:amd64.", "Preparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...", "Unpacking libltdl7:amd64 (2.4.6-0.1) ...", "Selecting previously unselected package docker-ce.", "Preparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...", "Unpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...", "Setting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...", "Setting up perl (5.22.1-9ubuntu0.6) ...", "Setting up pigz (2.3.1-2) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Setting up apparmor (2.10.95-0ubuntu2.11) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Setting up cgroupfs-mount (1.2) ...", "Setting up libltdl7:amd64 (2.4.6-0.1) ...", "Setting up docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.6) ...", "Setting up git (1:2.7.4-0ubuntu1.6) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "OK", "Hit:1 https://download.docker.com/linux/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Hit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]", "Fetched 36.7 kB in 0s (41.3 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3", "The following NEW packages will be installed:", "  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "  libnetfilter-conntrack3", "0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.", "Need to get 52.7 MB of archives.", "After this operation, 280 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]", "Get:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]", "Get:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]", "Fetched 52.7 MB in 2s (22.1 MB/s)", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30977 files and directories currently installed.)", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package conntrack.", "Preparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...", "Unpacking conntrack (1:1.4.3-3) ...", "Selecting previously unselected package cri-tools.", "Preparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...", "Unpacking cri-tools (1.13.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...", "Unpacking kubernetes-cni (0.7.5-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.15.1-00_amd64.deb ...", "Unpacking kubelet (1.15.1-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.15.1-00_amd64.deb ...", "Unpacking kubectl (1.15.1-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...", "Unpacking kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up conntrack (1:1.4.3-3) ...", "Setting up cri-tools (1.13.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.7.5-00) ...", "Setting up kubelet (1.15.1-00) ...", "Setting up kubectl (1.15.1-00) ...", "Setting up kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] Running pre-flight checks", "[preflight] Reading configuration from the cluster...", "[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'", "[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace", "[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[kubelet-start] Activating the kubelet service", "[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...", "", "This node has joined the cluster:", "* Certificate signing request was sent to apiserver and a response was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the control-plane to see this node join the cluster."]}
changed: [localhost -> root@147.75.89.137] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::5', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.5', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh \"1.15.1-00\" && kubeadm join 147.75.88.231:6443 --token ez6z6f.jk591ivf006blvy7     --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 ", "delta": "0:01:15.413508", "end": "2019-08-02 09:37:52.635450", "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:36:37.221942", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)\ndebconf: falling back to frontend: Readline\n\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)", "debconf: falling back to frontend: Readline", "\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\nca-certificates is already the newest version (20170717~16.04.1).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nsoftware-properties-common is already the newest version (0.96.20.7).\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\nOK\nGet:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]\nGet:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]\nHit:3 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]\nFetched 4,389 kB in 3s (1,309 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl\n  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22\n  pigz\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\n  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl\nThe following NEW packages will be installed:\n  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl\n  liberror-perl libltdl7 patch pigz\nThe following packages will be upgraded:\n  libperl5.22 perl perl-base perl-modules-5.22\n4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.\nNeed to get 52.3 MB of archives.\nAfter this operation, 226 MB of additional disk space will be used.\nGet:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]\nPreconfiguring packages ...\nFetched 52.3 MB in 3s (14.3 MB/s)\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up perl-base (5.22.1-9ubuntu0.6) ...\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...\r\nUnpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nSelecting previously unselected package pigz.\r\nPreparing to unpack .../pigz_2.3.1-2_amd64.deb ...\r\nUnpacking pigz (2.3.1-2) ...\r\nSelecting previously unselected package libapparmor-perl.\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package aufs-tools.\r\nPreparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...\r\nUnpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package libltdl7:amd64.\r\nPreparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...\r\nUnpacking libltdl7:amd64 (2.4.6-0.1) ...\r\nSelecting previously unselected package docker-ce.\r\nPreparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...\r\nUnpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...\r\nSetting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...\r\nSetting up perl (5.22.1-9ubuntu0.6) ...\r\nSetting up pigz (2.3.1-2) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.11) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up libltdl7:amd64 (2.4.6-0.1) ...\r\nSetting up docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.6) ...\r\nSetting up git (1:2.7.4-0ubuntu1.6) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nOK\nHit:1 https://download.docker.com/linux/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nHit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]\nFetched 36.7 kB in 0s (42.2 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3\nThe following NEW packages will be installed:\n  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n  libnetfilter-conntrack3\n0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 52.7 MB of archives.\nAfter this operation, 280 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]\nGet:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]\nFetched 52.7 MB in 2s (21.2 MB/s)\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30977 files and directories currently installed.)\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package conntrack.\r\nPreparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...\r\nUnpacking conntrack (1:1.4.3-3) ...\r\nSelecting previously unselected package cri-tools.\r\nPreparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.13.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.7.5-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.15.1-00_amd64.deb ...\r\nUnpacking kubelet (1.15.1-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.15.1-00_amd64.deb ...\r\nUnpacking kubectl (1.15.1-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...\r\nUnpacking kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up conntrack (1:1.4.3-3) ...\r\nSetting up cri-tools (1.13.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.7.5-00) ...\r\nSetting up kubelet (1.15.1-00) ...\r\nSetting up kubectl (1.15.1-00) ...\r\nSetting up kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] Running pre-flight checks\n[preflight] Reading configuration from the cluster...\n[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'\n[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace\n[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[kubelet-start] Activating the kubelet service\n[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...\n\nThis node has joined the cluster:\n* Certificate signing request was sent to apiserver and a response was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the control-plane to see this node join the cluster.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "ca-certificates is already the newest version (20170717~16.04.1).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "software-properties-common is already the newest version (0.96.20.7).", "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.", "OK", "Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]", "Get:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]", "Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]", "Fetched 4,389 kB in 3s (1,309 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl", "  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22", "  pigz", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl", "The following NEW packages will be installed:", "  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl", "  liberror-perl libltdl7 patch pigz", "The following packages will be upgraded:", "  libperl5.22 perl perl-base perl-modules-5.22", "4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.", "Need to get 52.3 MB of archives.", "After this operation, 226 MB of additional disk space will be used.", "Get:1 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]", "Preconfiguring packages ...", "Fetched 52.3 MB in 3s (14.3 MB/s)", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up perl-base (5.22.1-9ubuntu0.6) ...", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...", "Unpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Selecting previously unselected package pigz.", "Preparing to unpack .../pigz_2.3.1-2_amd64.deb ...", "Unpacking pigz (2.3.1-2) ...", "Selecting previously unselected package libapparmor-perl.", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package aufs-tools.", "Preparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...", "Unpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package libltdl7:amd64.", "Preparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...", "Unpacking libltdl7:amd64 (2.4.6-0.1) ...", "Selecting previously unselected package docker-ce.", "Preparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...", "Unpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...", "Setting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...", "Setting up perl (5.22.1-9ubuntu0.6) ...", "Setting up pigz (2.3.1-2) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Setting up apparmor (2.10.95-0ubuntu2.11) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Setting up cgroupfs-mount (1.2) ...", "Setting up libltdl7:amd64 (2.4.6-0.1) ...", "Setting up docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.6) ...", "Setting up git (1:2.7.4-0ubuntu1.6) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "OK", "Hit:1 https://download.docker.com/linux/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Hit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]", "Fetched 36.7 kB in 0s (42.2 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3", "The following NEW packages will be installed:", "  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "  libnetfilter-conntrack3", "0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.", "Need to get 52.7 MB of archives.", "After this operation, 280 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]", "Get:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]", "Fetched 52.7 MB in 2s (21.2 MB/s)", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30977 files and directories currently installed.)", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package conntrack.", "Preparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...", "Unpacking conntrack (1:1.4.3-3) ...", "Selecting previously unselected package cri-tools.", "Preparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...", "Unpacking cri-tools (1.13.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...", "Unpacking kubernetes-cni (0.7.5-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.15.1-00_amd64.deb ...", "Unpacking kubelet (1.15.1-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.15.1-00_amd64.deb ...", "Unpacking kubectl (1.15.1-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...", "Unpacking kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up conntrack (1:1.4.3-3) ...", "Setting up cri-tools (1.13.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.7.5-00) ...", "Setting up kubelet (1.15.1-00) ...", "Setting up kubectl (1.15.1-00) ...", "Setting up kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] Running pre-flight checks", "[preflight] Reading configuration from the cluster...", "[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'", "[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace", "[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[kubelet-start] Activating the kubelet service", "[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...", "", "This node has joined the cluster:", "* Certificate signing request was sent to apiserver and a response was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the control-plane to see this node join the cluster."]}
changed: [localhost -> root@147.75.68.85] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::7', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.7', u'public': False, u'address_family': 4}]}) => {"changed": true, "cmd": "bash pre_requisite.sh \"1.15.1-00\" && kubeadm join 147.75.88.231:6443 --token ez6z6f.jk591ivf006blvy7     --discovery-token-ca-cert-hash sha256:557b0bcbbee52901f31fb9fc4b598e638485b55184c091f51dddc4d80663bcf5 ", "delta": "0:01:13.680084", "end": "2019-08-02 09:39:32.338681", "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:38:18.658597", "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Dialog\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)\ndebconf: falling back to frontend: Readline\n\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/", "stderr_lines": ["debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 15.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 9.)", "debconf: falling back to frontend: Readline", "\t[WARNING IsDockerSystemdCheck]: detected \"cgroupfs\" as the Docker cgroup driver. The recommended driver is \"systemd\". Please follow the guide at https://kubernetes.io/docs/setup/cri/"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\napt-transport-https is already the newest version (1.2.27).\nca-certificates is already the newest version (20170717~16.04.1).\ncurl is already the newest version (7.47.0-1ubuntu2.8).\nsoftware-properties-common is already the newest version (0.96.20.7).\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\nOK\nGet:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:3 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]\nFetched 4,389 kB in 3s (1,372 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl\n  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22\n  pigz\nSuggested packages:\n  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils\n  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email\n  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc\n  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl\nThe following NEW packages will be installed:\n  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl\n  liberror-perl libltdl7 patch pigz\nThe following packages will be upgraded:\n  libperl5.22 perl perl-base perl-modules-5.22\n4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.\nNeed to get 52.3 MB of archives.\nAfter this operation, 226 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]\nGet:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]\nPreconfiguring packages ...\nFetched 52.3 MB in 3s (15.6 MB/s)\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nPreparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...\r\nUnpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up perl-base (5.22.1-9ubuntu0.6) ...\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 29709 files and directories currently installed.)\r\nPreparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...\r\nUnpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...\r\nSelecting previously unselected package pigz.\r\nPreparing to unpack .../pigz_2.3.1-2_amd64.deb ...\r\nUnpacking pigz (2.3.1-2) ...\r\nSelecting previously unselected package libapparmor-perl.\r\nPreparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package apparmor.\r\nPreparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...\r\nUnpacking apparmor (2.10.95-0ubuntu2.11) ...\r\nSelecting previously unselected package aufs-tools.\r\nPreparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...\r\nUnpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSelecting previously unselected package cgroupfs-mount.\r\nPreparing to unpack .../cgroupfs-mount_1.2_all.deb ...\r\nUnpacking cgroupfs-mount (1.2) ...\r\nSelecting previously unselected package libltdl7:amd64.\r\nPreparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...\r\nUnpacking libltdl7:amd64 (2.4.6-0.1) ...\r\nSelecting previously unselected package docker-ce.\r\nPreparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...\r\nUnpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSelecting previously unselected package liberror-perl.\r\nPreparing to unpack .../liberror-perl_0.17-1.2_all.deb ...\r\nUnpacking liberror-perl (0.17-1.2) ...\r\nSelecting previously unselected package git-man.\r\nPreparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...\r\nUnpacking git-man (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package git.\r\nPreparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...\r\nUnpacking git (1:2.7.4-0ubuntu1.6) ...\r\nSelecting previously unselected package patch.\r\nPreparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...\r\nUnpacking patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...\r\nSetting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...\r\nSetting up perl (5.22.1-9ubuntu0.6) ...\r\nSetting up pigz (2.3.1-2) ...\r\nSetting up libapparmor-perl (2.10.95-0ubuntu2.11) ...\r\nSetting up apparmor (2.10.95-0ubuntu2.11) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)\r\ndebconf: falling back to frontend: Readline\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists\r\ninsserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists\r\ninsserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists\r\ninsserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists\r\ninsserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists\r\ninsserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists\r\ninsserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists\r\ninsserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists\r\ninsserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists\r\ninsserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists\r\ninsserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists\r\ninsserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists\r\ninsserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists\r\ninsserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists\r\ndiff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory\r\nSetting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...\r\nSetting up cgroupfs-mount (1.2) ...\r\nSetting up libltdl7:amd64 (2.4.6-0.1) ...\r\nSetting up docker-ce (18.06.3~ce~3-0~ubuntu) ...\r\nSetting up liberror-perl (0.17-1.2) ...\r\nSetting up git-man (1:2.7.4-0ubuntu1.6) ...\r\nSetting up git (1:2.7.4-0ubuntu1.6) ...\r\nSetting up patch (2.7.5-1ubuntu0.16.04.2) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nOK\nHit:1 https://download.docker.com/linux/ubuntu xenial InRelease\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nGet:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]\nHit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease\nGet:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]\nFetched 36.7 kB in 0s (41.0 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3\nThe following NEW packages will be installed:\n  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni\n  libnetfilter-conntrack3\n0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 52.7 MB of archives.\nAfter this operation, 280 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]\nGet:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]\nGet:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]\nGet:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]\nGet:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]\nGet:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]\nFetched 52.7 MB in 3s (16.9 MB/s)\nSelecting previously unselected package libnetfilter-conntrack3:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 30977 files and directories currently installed.)\r\nPreparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...\r\nUnpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSelecting previously unselected package conntrack.\r\nPreparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...\r\nUnpacking conntrack (1:1.4.3-3) ...\r\nSelecting previously unselected package cri-tools.\r\nPreparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...\r\nUnpacking cri-tools (1.13.0-00) ...\r\nSelecting previously unselected package ebtables.\r\nPreparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...\r\nUnpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nSelecting previously unselected package ethtool.\r\nPreparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...\r\nUnpacking ethtool (1:4.5-1) ...\r\nSelecting previously unselected package kubernetes-cni.\r\nPreparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...\r\nUnpacking kubernetes-cni (0.7.5-00) ...\r\nSelecting previously unselected package kubelet.\r\nPreparing to unpack .../kubelet_1.15.1-00_amd64.deb ...\r\nUnpacking kubelet (1.15.1-00) ...\r\nSelecting previously unselected package kubectl.\r\nPreparing to unpack .../kubectl_1.15.1-00_amd64.deb ...\r\nUnpacking kubectl (1.15.1-00) ...\r\nSelecting previously unselected package kubeadm.\r\nPreparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...\r\nUnpacking kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\nSetting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...\r\nSetting up conntrack (1:1.4.3-3) ...\r\nSetting up cri-tools (1.13.0-00) ...\r\nSetting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...\r\nupdate-rc.d: warning: start and stop actions are no longer supported; falling back to defaults\r\nSetting up ethtool (1:4.5-1) ...\r\nSetting up kubernetes-cni (0.7.5-00) ...\r\nSetting up kubelet (1.15.1-00) ...\r\nSetting up kubectl (1.15.1-00) ...\r\nSetting up kubeadm (1.15.1-00) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for systemd (229-4ubuntu21.4) ...\r\n[preflight] Running pre-flight checks\n[preflight] Reading configuration from the cluster...\n[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'\n[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace\n[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"\n[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"\n[kubelet-start] Activating the kubelet service\n[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...\n\nThis node has joined the cluster:\n* Certificate signing request was sent to apiserver and a response was received.\n* The Kubelet was informed of the new secure connection details.\n\nRun 'kubectl get nodes' on the control-plane to see this node join the cluster.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "apt-transport-https is already the newest version (1.2.27).", "ca-certificates is already the newest version (20170717~16.04.1).", "curl is already the newest version (7.47.0-1ubuntu2.8).", "software-properties-common is already the newest version (0.96.20.7).", "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.", "OK", "Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:3 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [10.0 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,000 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [393 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [759 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [317 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [710 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-security/main Translation-en [281 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [450 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-security/universe Translation-en [183 kB]", "Fetched 4,389 kB in 3s (1,372 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  apparmor aufs-tools cgroupfs-mount git git-man libapparmor-perl", "  liberror-perl libltdl7 libperl5.22 patch perl perl-base perl-modules-5.22", "  pigz", "Suggested packages:", "  apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils", "  mountall git-daemon-run | git-daemon-sysvinit git-doc git-el git-email", "  git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn ed diffutils-doc", "  perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl", "The following NEW packages will be installed:", "  apparmor aufs-tools cgroupfs-mount docker-ce git git-man libapparmor-perl", "  liberror-perl libltdl7 patch pigz", "The following packages will be upgraded:", "  libperl5.22 perl perl-base perl-modules-5.22", "4 upgraded, 11 newly installed, 0 to remove and 125 not upgraded.", "Need to get 52.3 MB of archives.", "After this operation, 226 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3,405 kB]", "Get:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 18.06.3~ce~3-0~ubuntu [40.0 MB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1,283 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2,629 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git-man all 1:2.7.4-0ubuntu1.6 [736 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 git amd64 1:2.7.4-0ubuntu1.6 [3,176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 patch amd64 2.7.5-1ubuntu0.16.04.2 [90.8 kB]", "Preconfiguring packages ...", "Fetched 52.3 MB in 3s (15.6 MB/s)", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Preparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...", "Unpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up perl-base (5.22.1-9ubuntu0.6) ...", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 29709 files and directories currently installed.)", "Preparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...", "Unpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) over (5.22.1-9ubuntu0.5) ...", "Selecting previously unselected package pigz.", "Preparing to unpack .../pigz_2.3.1-2_amd64.deb ...", "Unpacking pigz (2.3.1-2) ...", "Selecting previously unselected package libapparmor-perl.", "Preparing to unpack .../libapparmor-perl_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package apparmor.", "Preparing to unpack .../apparmor_2.10.95-0ubuntu2.11_amd64.deb ...", "Unpacking apparmor (2.10.95-0ubuntu2.11) ...", "Selecting previously unselected package aufs-tools.", "Preparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...", "Unpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Selecting previously unselected package cgroupfs-mount.", "Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...", "Unpacking cgroupfs-mount (1.2) ...", "Selecting previously unselected package libltdl7:amd64.", "Preparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...", "Unpacking libltdl7:amd64 (2.4.6-0.1) ...", "Selecting previously unselected package docker-ce.", "Preparing to unpack .../docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb ...", "Unpacking docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Selecting previously unselected package liberror-perl.", "Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...", "Unpacking liberror-perl (0.17-1.2) ...", "Selecting previously unselected package git-man.", "Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1.6_all.deb ...", "Unpacking git-man (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package git.", "Preparing to unpack .../git_1%3a2.7.4-0ubuntu1.6_amd64.deb ...", "Unpacking git (1:2.7.4-0ubuntu1.6) ...", "Selecting previously unselected package patch.", "Preparing to unpack .../patch_2.7.5-1ubuntu0.16.04.2_amd64.deb ...", "Unpacking patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...", "Setting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...", "Setting up perl (5.22.1-9ubuntu0.6) ...", "Setting up pigz (2.3.1-2) ...", "Setting up libapparmor-perl (2.10.95-0ubuntu2.11) ...", "Setting up apparmor (2.10.95-0ubuntu2.11) ...", "debconf: unable to initialize frontend: Dialog", "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)", "debconf: falling back to frontend: Readline", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc0.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/halt, ../rc0.d/K11halt): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc0.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc0.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc0.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc0.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/networking, ../rc0.d/K07networking): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc0.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc0.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc0.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc0.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc1.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc1.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc1.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc2.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc2.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc3.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc3.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc4.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc4.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/ondemand, ../rc5.d/S03ondemand): File exists", "insserv: can not symlink(../init.d/rc.local, ../rc5.d/S03rc.local): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/umountroot, ../rc6.d/K09umountroot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/reboot, ../rc6.d/K11reboot): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/sendsigs, ../rc6.d/K04sendsigs): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/umountnfs.sh, ../rc6.d/K06umountnfs.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rc6.d/K06hwclock.sh): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/umountfs, ../rc6.d/K08umountfs): File exists", "insserv: can not symlink(../init.d/networking, ../rc6.d/K07networking): File exists", "insserv: can not symlink(../init.d/iscsid, ../rc6.d/K03iscsid): File exists", "insserv: can not symlink(../init.d/rsyslog, ../rc6.d/K05rsyslog): File exists", "insserv: can not symlink(../init.d/open-iscsi, ../rc6.d/K02open-iscsi): File exists", "insserv: can not symlink(../init.d/mdadm-waitidle, ../rc6.d/K10mdadm-waitidle): File exists", "insserv: can not symlink(../init.d/hwclock.sh, ../rcS.d/S04hwclock.sh): File exists", "insserv: can not symlink(../init.d/mountdevsubfs.sh, ../rcS.d/S03mountdevsubfs.sh): File exists", "insserv: can not symlink(../init.d/checkroot.sh, ../rcS.d/S05checkroot.sh): File exists", "insserv: can not symlink(../init.d/mountnfs-bootclean.sh, ../rcS.d/S10mountnfs-bootclean.sh): File exists", "insserv: can not symlink(../init.d/mountnfs.sh, ../rcS.d/S09mountnfs.sh): File exists", "insserv: can not symlink(../init.d/bootmisc.sh, ../rcS.d/S11bootmisc.sh): File exists", "insserv: can not symlink(../init.d/mountall.sh, ../rcS.d/S08mountall.sh): File exists", "insserv: can not symlink(../init.d/checkfs.sh, ../rcS.d/S07checkfs.sh): File exists", "insserv: can not symlink(../init.d/mountall-bootclean.sh, ../rcS.d/S09mountall-bootclean.sh): File exists", "insserv: can not symlink(../init.d/procps, ../rcS.d/S03procps): File exists", "diff: /var/lib/apparmor/profiles/.apparmor.md5sums: No such file or directory", "Setting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...", "Setting up cgroupfs-mount (1.2) ...", "Setting up libltdl7:amd64 (2.4.6-0.1) ...", "Setting up docker-ce (18.06.3~ce~3-0~ubuntu) ...", "Setting up liberror-perl (0.17-1.2) ...", "Setting up git-man (1:2.7.4-0ubuntu1.6) ...", "Setting up git (1:2.7.4-0ubuntu1.6) ...", "Setting up patch (2.7.5-1ubuntu0.16.04.2) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "OK", "Hit:1 https://download.docker.com/linux/ubuntu xenial InRelease", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Get:4 https://apt.kubernetes.io kubernetes-xenial InRelease [161 B]", "Hit:5 http://archive.ubuntu.com/ubuntu xenial-security InRelease", "Get:6 https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages [27.7 kB]", "Fetched 36.7 kB in 0s (41.0 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  conntrack cri-tools ebtables ethtool kubernetes-cni libnetfilter-conntrack3", "The following NEW packages will be installed:", "  conntrack cri-tools ebtables ethtool kubeadm kubectl kubelet kubernetes-cni", "  libnetfilter-conntrack3", "0 upgraded, 9 newly installed, 0 to remove and 126 not upgraded.", "Need to get 52.7 MB of archives.", "After this operation, 280 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]", "Get:2 https://apt.kubernetes.io kubernetes-xenial/main amd64 cri-tools amd64 1.13.0-00 [8,776 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial/main amd64 conntrack amd64 1:1.4.3-3 [27.3 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ebtables amd64 2.0.10.4-3.4ubuntu2.16.04.2 [79.9 kB]", "Get:5 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubernetes-cni amd64 0.7.5-00 [6,473 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 ethtool amd64 1:4.5-1 [97.5 kB]", "Get:7 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubelet amd64 1.15.1-00 [20.2 MB]", "Get:8 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubectl amd64 1.15.1-00 [8,763 kB]", "Get:9 https://apt.kubernetes.io kubernetes-xenial/main amd64 kubeadm amd64 1.15.1-00 [8,247 kB]", "Fetched 52.7 MB in 3s (16.9 MB/s)", "Selecting previously unselected package libnetfilter-conntrack3:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 30977 files and directories currently installed.)", "Preparing to unpack .../libnetfilter-conntrack3_1.0.5-1_amd64.deb ...", "Unpacking libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Selecting previously unselected package conntrack.", "Preparing to unpack .../conntrack_1%3a1.4.3-3_amd64.deb ...", "Unpacking conntrack (1:1.4.3-3) ...", "Selecting previously unselected package cri-tools.", "Preparing to unpack .../cri-tools_1.13.0-00_amd64.deb ...", "Unpacking cri-tools (1.13.0-00) ...", "Selecting previously unselected package ebtables.", "Preparing to unpack .../ebtables_2.0.10.4-3.4ubuntu2.16.04.2_amd64.deb ...", "Unpacking ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "Selecting previously unselected package ethtool.", "Preparing to unpack .../ethtool_1%3a4.5-1_amd64.deb ...", "Unpacking ethtool (1:4.5-1) ...", "Selecting previously unselected package kubernetes-cni.", "Preparing to unpack .../kubernetes-cni_0.7.5-00_amd64.deb ...", "Unpacking kubernetes-cni (0.7.5-00) ...", "Selecting previously unselected package kubelet.", "Preparing to unpack .../kubelet_1.15.1-00_amd64.deb ...", "Unpacking kubelet (1.15.1-00) ...", "Selecting previously unselected package kubectl.", "Preparing to unpack .../kubectl_1.15.1-00_amd64.deb ...", "Unpacking kubectl (1.15.1-00) ...", "Selecting previously unselected package kubeadm.", "Preparing to unpack .../kubeadm_1.15.1-00_amd64.deb ...", "Unpacking kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "Setting up libnetfilter-conntrack3:amd64 (1.0.5-1) ...", "Setting up conntrack (1:1.4.3-3) ...", "Setting up cri-tools (1.13.0-00) ...", "Setting up ebtables (2.0.10.4-3.4ubuntu2.16.04.2) ...", "update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults", "Setting up ethtool (1:4.5-1) ...", "Setting up kubernetes-cni (0.7.5-00) ...", "Setting up kubelet (1.15.1-00) ...", "Setting up kubectl (1.15.1-00) ...", "Setting up kubeadm (1.15.1-00) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for systemd (229-4ubuntu21.4) ...", "[preflight] Running pre-flight checks", "[preflight] Reading configuration from the cluster...", "[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'", "[kubelet-start] Downloading configuration for the kubelet from the \"kubelet-config-1.15\" ConfigMap in the kube-system namespace", "[kubelet-start] Writing kubelet configuration to file \"/var/lib/kubelet/config.yaml\"", "[kubelet-start] Writing kubelet environment file with flags to file \"/var/lib/kubelet/kubeadm-flags.env\"", "[kubelet-start] Activating the kubelet service", "[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...", "", "This node has joined the cluster:", "* Certificate signing request was sent to apiserver and a response was received.", "* The Kubelet was informed of the new secure connection details.", "", "Run 'kubectl get nodes' on the control-plane to see this node join the cluster."]}

TASK [Installing xfs binaries to worker nodes] ***********************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:129
changed: [localhost -> root@147.75.88.241] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::3', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.3', u'public': False, u'address_family': 4}]}) => {"cache_update_time": 1564738525, "cache_updated": false, "changed": true, "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libreadline5\nSuggested packages:\n  xfsdump acl attr quota\nThe following NEW packages will be installed:\n  libreadline5 xfsprogs\n0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 696 kB of archives.\nAfter this operation, 3744 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]\nFetched 696 kB in 1s (526 kB/s)\nSelecting previously unselected package libreadline5:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 31058 files and directories currently installed.)\r\nPreparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...\r\nUnpacking libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSelecting previously unselected package xfsprogs.\r\nPreparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...\r\nUnpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSetting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nupdate-initramfs: deferring update (trigger activated)\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for initramfs-tools (0.122ubuntu8.11) ...\r\nupdate-initramfs: Generating /boot/initrd.img-4.4.0-134-generic\r\nW: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast\r\nW: mdadm: /etc/mdadm/mdadm.conf defines no arrays.\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libreadline5", "Suggested packages:", "  xfsdump acl attr quota", "The following NEW packages will be installed:", "  libreadline5 xfsprogs", "0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.", "Need to get 696 kB of archives.", "After this operation, 3744 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]", "Fetched 696 kB in 1s (526 kB/s)", "Selecting previously unselected package libreadline5:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 31058 files and directories currently installed.)", "Preparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...", "Unpacking libreadline5:amd64 (5.2+dfsg-3build1) ...", "Selecting previously unselected package xfsprogs.", "Preparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...", "Unpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up libreadline5:amd64 (5.2+dfsg-3build1) ...", "Setting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "update-initramfs: deferring update (trigger activated)", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for initramfs-tools (0.122ubuntu8.11) ...", "update-initramfs: Generating /boot/initrd.img-4.4.0-134-generic", "W: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast", "W: mdadm: /etc/mdadm/mdadm.conf defines no arrays."]}
changed: [localhost -> root@147.75.89.137] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::5', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.5', u'public': False, u'address_family': 4}]}) => {"cache_update_time": 1564738630, "cache_updated": false, "changed": true, "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libreadline5\nSuggested packages:\n  xfsdump acl attr quota\nThe following NEW packages will be installed:\n  libreadline5 xfsprogs\n0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 696 kB of archives.\nAfter this operation, 3744 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]\nFetched 696 kB in 1s (545 kB/s)\nSelecting previously unselected package libreadline5:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 31058 files and directories currently installed.)\r\nPreparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...\r\nUnpacking libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSelecting previously unselected package xfsprogs.\r\nPreparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...\r\nUnpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSetting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nupdate-initramfs: deferring update (trigger activated)\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for initramfs-tools (0.122ubuntu8.11) ...\r\nupdate-initramfs: Generating /boot/initrd.img-4.4.0-134-generic\r\nW: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast\r\nW: mdadm: /etc/mdadm/mdadm.conf defines no arrays.\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libreadline5", "Suggested packages:", "  xfsdump acl attr quota", "The following NEW packages will be installed:", "  libreadline5 xfsprogs", "0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.", "Need to get 696 kB of archives.", "After this operation, 3744 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]", "Fetched 696 kB in 1s (545 kB/s)", "Selecting previously unselected package libreadline5:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 31058 files and directories currently installed.)", "Preparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...", "Unpacking libreadline5:amd64 (5.2+dfsg-3build1) ...", "Selecting previously unselected package xfsprogs.", "Preparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...", "Unpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up libreadline5:amd64 (5.2+dfsg-3build1) ...", "Setting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "update-initramfs: deferring update (trigger activated)", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for initramfs-tools (0.122ubuntu8.11) ...", "update-initramfs: Generating /boot/initrd.img-4.4.0-134-generic", "W: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast", "W: mdadm: /etc/mdadm/mdadm.conf defines no arrays."]}
changed: [localhost -> root@147.75.68.85] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'public': True, u'address_family': 4}, {u'address': u'2604:1380:1000:6c00::7', u'public': True, u'address_family': 6}, {u'address': u'10.88.82.7', u'public': False, u'address_family': 4}]}) => {"cache_update_time": 1564738731, "cache_updated": false, "changed": true, "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libreadline5\nSuggested packages:\n  xfsdump acl attr quota\nThe following NEW packages will be installed:\n  libreadline5 xfsprogs\n0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.\nNeed to get 696 kB of archives.\nAfter this operation, 3744 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]\nFetched 696 kB in 1s (485 kB/s)\nSelecting previously unselected package libreadline5:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 31058 files and directories currently installed.)\r\nPreparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...\r\nUnpacking libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSelecting previously unselected package xfsprogs.\r\nPreparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...\r\nUnpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nSetting up libreadline5:amd64 (5.2+dfsg-3build1) ...\r\nSetting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...\r\nupdate-initramfs: deferring update (trigger activated)\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nProcessing triggers for initramfs-tools (0.122ubuntu8.11) ...\r\nupdate-initramfs: Generating /boot/initrd.img-4.4.0-134-generic\r\nW: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast\r\nW: mdadm: /etc/mdadm/mdadm.conf defines no arrays.\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libreadline5", "Suggested packages:", "  xfsdump acl attr quota", "The following NEW packages will be installed:", "  libreadline5 xfsprogs", "0 upgraded, 2 newly installed, 0 to remove and 126 not upgraded.", "Need to get 696 kB of archives.", "After this operation, 3744 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]", "Fetched 696 kB in 1s (485 kB/s)", "Selecting previously unselected package libreadline5:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 31058 files and directories currently installed.)", "Preparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...", "Unpacking libreadline5:amd64 (5.2+dfsg-3build1) ...", "Selecting previously unselected package xfsprogs.", "Preparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...", "Unpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for man-db (2.7.5-1) ...", "Setting up libreadline5:amd64 (5.2+dfsg-3build1) ...", "Setting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...", "update-initramfs: deferring update (trigger activated)", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Processing triggers for initramfs-tools (0.122ubuntu8.11) ...", "update-initramfs: Generating /boot/initrd.img-4.4.0-134-generic", "W: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast", "W: mdadm: /etc/mdadm/mdadm.conf defines no arrays."]}

TASK [Disable swap on the nodes] *************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:135
included: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml for localhost
included: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml for localhost

TASK [Obtain node list from playbook] ********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:4
ok: [localhost] => {"ansible_facts": {"nodes": [{"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}]}, "changed": false}

TASK [Remove swapfile from /etc/fstab] *******************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:8
changed: [localhost -> root@147.75.88.231] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::1', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.1', u'address_family': 4, u'public': False}]}) => {"backup": "", "changed": true, "found": 1, "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "msg": "1 line(s) removed"}

TASK [Disabling swap on nodes] ***************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:16
changed: [localhost -> root@147.75.88.231] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.231', u'public_ipv6': u'2604:1380:1000:6c00::1', u'hostname': u'master-frosty-pare', u'id': u'9cb7804e-be2d-41a0-b378-70ea6e23baa0', u'state': u'provisioning', u'private_ipv4': u'10.88.82.1', u'ip_addresses': [{u'address': u'147.75.88.231', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::1', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.1', u'address_family': 4, u'public': False}]}) => {"changed": true, "cmd": ["swapoff", "-a"], "delta": "0:00:00.005055", "end": "2019-08-02 09:42:42.507909", "item": {"hostname": "master-frosty-pare", "id": "9cb7804e-be2d-41a0-b378-70ea6e23baa0", "ip_addresses": [{"address": "147.75.88.231", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::1", "address_family": 6, "public": true}, {"address": "10.88.82.1", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.1", "public_ipv4": "147.75.88.231", "public_ipv6": "2604:1380:1000:6c00::1", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:42:42.502854", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain node list from playbook] ********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:4
ok: [localhost] => {"ansible_facts": {"nodes": [{"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}]}, "changed": false}

TASK [Remove swapfile from /etc/fstab] *******************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:8
changed: [localhost -> root@147.75.88.241] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::3', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.3', u'address_family': 4, u'public': False}]}) => {"backup": "", "changed": true, "found": 1, "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "msg": "1 line(s) removed"}
changed: [localhost -> root@147.75.89.137] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::5', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.5', u'address_family': 4, u'public': False}]}) => {"backup": "", "changed": true, "found": 1, "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "msg": "1 line(s) removed"}
changed: [localhost -> root@147.75.68.85] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::7', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.7', u'address_family': 4, u'public': False}]}) => {"backup": "", "changed": true, "found": 1, "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "msg": "1 line(s) removed"}

TASK [Disabling swap on nodes] ***************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/utils/swap_disable/swap_disable.yml:16
changed: [localhost -> root@147.75.88.241] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.88.241', u'public_ipv6': u'2604:1380:1000:6c00::3', u'hostname': u'node-frosty-pare01', u'id': u'87f69977-eb11-4169-bdc6-e7cc59d3022b', u'state': u'provisioning', u'private_ipv4': u'10.88.82.3', u'ip_addresses': [{u'address': u'147.75.88.241', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::3', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.3', u'address_family': 4, u'public': False}]}) => {"changed": true, "cmd": ["swapoff", "-a"], "delta": "0:00:00.005283", "end": "2019-08-02 09:43:29.196478", "item": {"hostname": "node-frosty-pare01", "id": "87f69977-eb11-4169-bdc6-e7cc59d3022b", "ip_addresses": [{"address": "147.75.88.241", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::3", "address_family": 6, "public": true}, {"address": "10.88.82.3", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.3", "public_ipv4": "147.75.88.241", "public_ipv6": "2604:1380:1000:6c00::3", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:43:29.191195", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> root@147.75.89.137] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.89.137', u'public_ipv6': u'2604:1380:1000:6c00::5', u'hostname': u'node-frosty-pare02', u'id': u'5008e89c-dda2-418d-9b95-6062c625e3a8', u'state': u'provisioning', u'private_ipv4': u'10.88.82.5', u'ip_addresses': [{u'address': u'147.75.89.137', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::5', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.5', u'address_family': 4, u'public': False}]}) => {"changed": true, "cmd": ["swapoff", "-a"], "delta": "0:00:00.005234", "end": "2019-08-02 09:43:39.026717", "item": {"hostname": "node-frosty-pare02", "id": "5008e89c-dda2-418d-9b95-6062c625e3a8", "ip_addresses": [{"address": "147.75.89.137", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::5", "address_family": 6, "public": true}, {"address": "10.88.82.5", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.5", "public_ipv4": "147.75.89.137", "public_ipv6": "2604:1380:1000:6c00::5", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:43:39.021483", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> root@147.75.68.85] => (item={u'locked': False, u'tags': [], u'public_ipv4': u'147.75.68.85', u'public_ipv6': u'2604:1380:1000:6c00::7', u'hostname': u'node-frosty-pare03', u'id': u'75bd5876-0e87-452d-9d4a-c667fa35a9fd', u'state': u'provisioning', u'private_ipv4': u'10.88.82.7', u'ip_addresses': [{u'address': u'147.75.68.85', u'address_family': 4, u'public': True}, {u'address': u'2604:1380:1000:6c00::7', u'address_family': 6, u'public': True}, {u'address': u'10.88.82.7', u'address_family': 4, u'public': False}]}) => {"changed": true, "cmd": ["swapoff", "-a"], "delta": "0:00:00.005187", "end": "2019-08-02 09:43:50.116886", "item": {"hostname": "node-frosty-pare03", "id": "75bd5876-0e87-452d-9d4a-c667fa35a9fd", "ip_addresses": [{"address": "147.75.68.85", "address_family": 4, "public": true}, {"address": "2604:1380:1000:6c00::7", "address_family": 6, "public": true}, {"address": "10.88.82.7", "address_family": 4, "public": false}], "locked": false, "private_ipv4": "10.88.82.7", "public_ipv4": "147.75.68.85", "public_ipv6": "2604:1380:1000:6c00::7", "state": "provisioning", "tags": []}, "rc": 0, "start": "2019-08-02 09:43:50.111699", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Getting nodes name] ********************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:144
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Taint node using key and value] ********************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:148
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Create a file for store taint node property] *******************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:151
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Set Test Status] ***********************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/k8s/packet/k8s-installer/create_packet_cluster.yml:160
ok: [localhost] => {"ansible_facts": {"flag": "Test Passed"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************************************
localhost                  : ok=24   changed=16   unreachable=0    failed=0
```
