### PR TITLE
refactor[yaml]: Modified openebs target failure litmusbook for statefulset and deployment

### DIFF
--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -51,6 +51,10 @@ spec:
           - name: TARGET_CONTAINER
             value: "cstor-volume-mgmt"
 
+           # DEPLOY_TYPE values: deployment, statefulset
+          - name: DEPLOY_TYPE
+            value: deployment
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_target_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 

--- a/experiments/chaos/openebs_target_failure/test.yml
+++ b/experiments/chaos/openebs_target_failure/test.yml
@@ -125,6 +125,14 @@
             #operator_ns: works by var scope
             app_label: "{{ label }}"
             app_pvc: "{{ pvc }}"
+          when: deploy_type == 'deployment'
+
+          ## Check statefulset application-target pod affinity
+        - include_tasks: /utils/scm/openebs/sts_target_affinity_check.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            app_label: "{{ label }}"
+          when: deploy_type == 'statefulset'
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/openebs_target_failure/test_vars.yml
@@ -16,4 +16,5 @@ liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
 chaos_type: "{{ lookup('env','CHAOS_TYPE') }}"
 target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
-chaos_duration: 360 
+chaos_duration: 360
+deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"


### PR DESCRIPTION
- Included util of statefulset target affinity in openebs target failure litmusbook 
- This change is needed for this PR has to perform both deployment and statefulset applications based on the ENV parameters given in the run_litmus_test.yml

litmusbook log in caseof deployment
```
[root@master-1558702621 openebs_target_failure]# kubectl logs -f openebs-target-failure-89dnb-lnpp4 -n litmus
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_failure/test.yml

PLAY [localhost] ***************************************************************
2019-08-02T08:58:28.695594 (delta: 0.078049)         elapsed: 0.078049 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:2
2019-08-02T08:58:28.719523 (delta: 0.023867)         elapsed: 0.101978 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:12
2019-08-02T08:58:39.775028 (delta: 11.055457)         elapsed: 11.157483 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:2
2019-08-02T08:58:39.857906 (delta: 0.082774)         elapsed: 11.240361 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.503371", "end": "2019-08-02 08:58:41.877984", "rc": 0, "start": "2019-08-02 08:58:40.374613", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:10
2019-08-02T08:58:41.999583 (delta: 2.141623)         elapsed: 13.382038 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:02.446117", "end": "2019-08-02 08:58:44.706674", "rc": 0, "start": "2019-08-02 08:58:42.260557", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:18
2019-08-02T08:58:44.811897 (delta: 2.812243)         elapsed: 16.194352 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:22
2019-08-02T08:58:44.941853 (delta: 0.12988)         elapsed: 16.324308 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:27
2019-08-02T08:58:45.092083 (delta: 0.150163)         elapsed: 16.474538 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.592785", "end": "2019-08-02 08:58:46.941011", "rc": 0, "start": "2019-08-02 08:58:45.348226", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c0826d-b4f6-11e9-a240-0050569846e3", "stdout_lines": ["pvc-10c0826d-b4f6-11e9-a240-0050569846e3"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:35
2019-08-02T08:58:47.043080 (delta: 1.950902)         elapsed: 18.425535 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-10c0826d-b4f6-11e9-a240-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.649397", "end": "2019-08-02 08:58:48.975695", "rc": 0, "start": "2019-08-02 08:58:47.326298", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:43
2019-08-02T08:58:49.088636 (delta: 2.045438)         elapsed: 20.471091 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:48
2019-08-02T08:58:49.268464 (delta: 0.179753)         elapsed: 20.650919 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "75caae513fb8040b9a471456809a572f8f53fd14", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "04d579e9ac54a8a2eac3266cb21f5c9b", "mode": "0644", "owner": "root", "size": 70, "src": "/root/.ansible/tmp/ansible-tmp-1564736329.35-161123115896113/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:17
2019-08-02T08:58:50.292482 (delta: 1.023939)         elapsed: 21.674937 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_container_kill.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:20
2019-08-02T08:58:50.405019 (delta: 0.112458)         elapsed: 21.787474 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_container_kill.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:25
2019-08-02T08:58:50.521554 (delta: 0.116478)         elapsed: 21.904009 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-08-02T08:58:50.655091 (delta: 0.133471)         elapsed: 22.037546 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-08-02T08:58:50.746850 (delta: 0.091667)         elapsed: 22.129305 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:27
2019-08-02T08:58:50.839574 (delta: 0.09267)         elapsed: 22.222029 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-08-02T08:58:50.986054 (delta: 0.146412)         elapsed: 22.368509 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "fcf16f3a460fff9d12212bc22032c93546eff753", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "011dcf638c469f0cb145e5bca99d8413", "mode": "0644", "owner": "root", "size": 458, "src": "/root/.ansible/tmp/ansible-tmp-1564736331.05-70899623289511/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-08-02T08:58:51.561686 (delta: 0.575545)         elapsed: 22.944141 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.514788", "end": "2019-08-02 08:58:53.370335", "rc": 0, "start": "2019-08-02 08:58:51.855547", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_container_kill \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_container_kill ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-08-02T08:58:53.448597 (delta: 1.886824)         elapsed: 24.831052 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.816375", "end": "2019-08-02 08:58:56.519217", "failed_when_result": false, "rc": 0, "start": "2019-08-02 08:58:53.702842", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-08-02T08:58:56.657076 (delta: 3.208419)         elapsed: 28.039531 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-08-02T08:58:56.736455 (delta: 0.079267)         elapsed: 28.11891 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-08-02T08:58:56.829843 (delta: 0.093328)         elapsed: 28.212298 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_failure/test.yml:34
2019-08-02T08:58:56.938318 (delta: 0.108396)         elapsed: 28.320773 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace           : app-busybox-ns", 
        "Target Namespace    : openebs", 
        "Label               : app=busybox-sts", 
        "PVC                 : openebs-busybox", 
        "StorageClass        : openebs-cstor-disk"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_failure/test.yml:46
2019-08-02T08:58:57.113709 (delta: 0.175309)         elapsed: 28.496164 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-08-02T08:58:57.239909 (delta: 0.126137)         elapsed: 28.622364 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.548760", "end": "2019-08-02 08:58:59.087992", "rc": 0, "start": "2019-08-02 08:58:57.539232", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-08-02T07:21:58Z]]", "stdout_lines": ["map[running:map[startedAt:2019-08-02T07:21:58Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-08-02T08:58:59.253028 (delta: 2.013059)         elapsed: 30.635483 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.514363", "end": "2019-08-02 08:59:01.028873", "rc": 0, "start": "2019-08-02 08:58:59.514510", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:55
2019-08-02T08:59:01.155479 (delta: 1.902348)         elapsed: 32.537934 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.532161", "end": "2019-08-02 08:59:03.019589", "rc": 0, "start": "2019-08-02 08:59:01.487428", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-8w6dl", "stdout_lines": ["app-busybox-546d66979-8w6dl"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_target_failure/test.yml:63
2019-08-02T08:59:03.168974 (delta: 2.01343)         elapsed: 34.551429 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:77
2019-08-02T08:59:03.267486 (delta: 0.098452)         elapsed: 34.649941 ******* 
included: /chaoslib/openebs/cstor_target_container_kill.yml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:1
2019-08-02T08:59:03.445487 (delta: 0.177936)         elapsed: 34.827942 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.500508", "end": "2019-08-02 08:59:05.172473", "rc": 0, "start": "2019-08-02 08:59:03.671965", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c0826d-b4f6-11e9-a240-0050569846e3", "stdout_lines": ["pvc-10c0826d-b4f6-11e9-a240-0050569846e3"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:10
2019-08-02T08:59:05.313232 (delta: 1.867689)         elapsed: 36.695687 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-10c0826d-b4f6-11e9-a240-0050569846e3 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.746265", "end": "2019-08-02 08:59:07.323385", "rc": 0, "start": "2019-08-02 08:59:05.577120", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4", "stdout_lines": ["pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4"]}

TASK [Get the restartCount of cstor-istgt container] ***************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:19
2019-08-02T08:59:07.411451 (delta: 2.098145)         elapsed: 38.793906 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==''\"cstor-volume-mgmt\"'')].restartCount}'", "delta": "0:00:01.800029", "end": "2019-08-02 08:59:09.540070", "rc": 0, "start": "2019-08-02 08:59:07.740041", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [include_tasks] ***********************************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:27
2019-08-02T08:59:09.639343 (delta: 2.227829)         elapsed: 41.021798 ******* 
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:4
2019-08-02T08:59:09.862122 (delta: 0.222712)         elapsed: 41.244577 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:01.810337", "end": "2019-08-02 08:59:11.947975", "rc": 0, "start": "2019-08-02 08:59:10.137638", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:13
2019-08-02T08:59:12.050218 (delta: 2.188038)         elapsed: 43.432673 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (30 retries left).
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (29 retries left).
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:01.571811", "end": "2019-08-02 08:59:25.742732", "rc": 0, "start": "2019-08-02 08:59:24.170921", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Select the app pod] ******************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:27
2019-08-02T08:59:25.883752 (delta: 13.83346)         elapsed: 57.266207 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36
2019-08-02T08:59:26.042022 (delta: 0.158181)         elapsed: 57.424477 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43
2019-08-02T08:59:26.203376 (delta: 0.161196)         elapsed: 57.585831 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_pod_ut": "pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4"}, "changed": false}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49
2019-08-02T08:59:26.355362 (delta: 0.15188)         elapsed: 57.737817 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.406673", "end": "2019-08-02 08:59:28.032805", "rc": 0, "start": "2019-08-02 08:59:26.626132", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:57
2019-08-02T08:59:28.137073 (delta: 1.781651)         elapsed: 59.519528 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "node2-1558702621.mayalabs.io"}, "changed": false}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:63
2019-08-02T08:59:28.252827 (delta: 0.115673)         elapsed: 59.635282 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:70
2019-08-02T08:59:28.374555 (delta: 0.121663)         elapsed: 59.75701 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:76
2019-08-02T08:59:28.480792 (delta: 0.106153)         elapsed: 59.863247 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep node2-1558702621.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.662975", "end": "2019-08-02 08:59:30.423329", "rc": 0, "start": "2019-08-02 08:59:28.760354", "stderr": "", "stderr_lines": [], "stdout": "pumba-jvnzb", "stdout_lines": ["pumba-jvnzb"]}

TASK [Record restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:85
2019-08-02T08:59:30.560671 (delta: 2.079818)         elapsed: 61.943126 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-volume-mgmt\")].restartCount}'", "delta": "0:00:01.508522", "end": "2019-08-02 08:59:32.450962", "rc": 0, "start": "2019-08-02 08:59:30.942440", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:93
2019-08-02T08:59:32.557127 (delta: 1.996375)         elapsed: 63.939582 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-jvnzb -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-volume-mgmt_;", "delta": "0:00:03.961304", "end": "2019-08-02 08:59:36.871431", "rc": 0, "start": "2019-08-02 08:59:32.910127", "stderr": "time=\"2019-08-02T08:59:34Z\" level=info msg=\"Kill containers\" \ntime=\"2019-08-02T08:59:36Z\" level=info msg=\"Killing /k8s_cstor-volume-mgmt_pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4_openebs_1109b358-b4f6-11e9-a240-0050569846e3_0 (32626d112ce0787ca9fffb8baca7d639bd5a3dc5f57b8a0e742d240d7cf64e43) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-08-02T08:59:34Z\" level=info msg=\"Kill containers\" ", "time=\"2019-08-02T08:59:36Z\" level=info msg=\"Killing /k8s_cstor-volume-mgmt_pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4_openebs_1109b358-b4f6-11e9-a240-0050569846e3_0 (32626d112ce0787ca9fffb8baca7d639bd5a3dc5f57b8a0e742d240d7cf64e43) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}

TASK [Verify restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:102
2019-08-02T08:59:36.987264 (delta: 4.430043)         elapsed: 68.369719 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-volume-mgmt\")].restartCount}'", "delta": "0:00:01.528823", "end": "2019-08-02 08:59:38.892604", "rc": 0, "start": "2019-08-02 08:59:37.363781", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Check if pumba is indeed running] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:117
2019-08-02T08:59:38.981027 (delta: 1.993654)         elapsed: 70.363482 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:132
2019-08-02T08:59:39.058394 (delta: 0.077264)         elapsed: 70.440849 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:139
2019-08-02T08:59:39.155485 (delta: 0.097025)         elapsed: 70.53794 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for target pod in running state] ***********************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:34
2019-08-02T08:59:39.227057 (delta: 0.071506)         elapsed: 70.609512 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:01.449348", "end": "2019-08-02 08:59:40.919470", "rc": 0, "start": "2019-08-02 08:59:39.470122", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Get the runningStatus of target pod] *************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:45
2019-08-02T08:59:41.102007 (delta: 1.874875)         elapsed: 72.484462 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.482637", "end": "2019-08-02 08:59:42.851485", "rc": 0, "start": "2019-08-02 08:59:41.368848", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the restartCount of cstor-istgt container] ***************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:57
2019-08-02T08:59:42.974287 (delta: 1.872078)         elapsed: 74.356742 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-10c0826d-b4f6-11e9-a240-0050569846e3-target-755c7b4f6796gw4 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==''\"cstor-volume-mgmt\"'')].restartCount}'", "delta": "0:00:01.518861", "end": "2019-08-02 08:59:44.770066", "rc": 0, "start": "2019-08-02 08:59:43.251205", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Compare restartCounts] ***************************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:65
2019-08-02T08:59:44.868017 (delta: 1.893648)         elapsed: 76.250472 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "Verified pool pods were restarted by fault injection", 
        "Before: 0", 
        "After: 1"
    ]
}

TASK [Wait (soak) for I/O on pools] ********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:84
2019-08-02T08:59:44.983349 (delta: 0.115223)         elapsed: 76.365804 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 360, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_failure/test.yml:88
2019-08-02T09:05:45.631051 (delta: 360.647647)         elapsed: 437.013506 **** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-08-02T09:05:45.773684 (delta: 0.142437)         elapsed: 437.156139 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.463702", "end": "2019-08-02 09:05:47.482699", "rc": 0, "start": "2019-08-02 09:05:46.018997", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-08-02T07:21:58Z]]", "stdout_lines": ["map[running:map[startedAt:2019-08-02T07:21:58Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-08-02T09:05:47.564817 (delta: 1.791058)         elapsed: 438.947272 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.474069", "end": "2019-08-02 09:05:49.326441", "rc": 0, "start": "2019-08-02 09:05:47.852372", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:99
2019-08-02T09:05:49.412044 (delta: 1.847174)         elapsed: 440.794499 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:102
2019-08-02T09:05:49.498298 (delta: 0.086182)         elapsed: 440.880753 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.506018", "end": "2019-08-02 09:05:51.273284", "rc": 0, "start": "2019-08-02 09:05:49.767266", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-8w6dl", "stdout_lines": ["app-busybox-546d66979-8w6dl"]}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:110
2019-08-02T09:05:51.374151 (delta: 1.875777)         elapsed: 442.756606 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:122
2019-08-02T09:05:51.464353 (delta: 0.090132)         elapsed: 442.846808 ****** 
included: /utils/scm/openebs/target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
task path: /utils/scm/openebs/target_affinity_check.yml:1
2019-08-02T09:05:51.645748 (delta: 0.18134)         elapsed: 443.028203 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=busybox-sts -n app-busybox-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.472695", "end": "2019-08-02 09:05:53.347558", "rc": 0, "start": "2019-08-02 09:05:51.874863", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Derive PV from application PVC] ******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:9
2019-08-02T09:05:53.439630 (delta: 1.793808)         elapsed: 444.822085 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.525120", "end": "2019-08-02 09:05:55.321146", "rc": 0, "start": "2019-08-02 09:05:53.796026", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c0826d-b4f6-11e9-a240-0050569846e3", "stdout_lines": ["pvc-10c0826d-b4f6-11e9-a240-0050569846e3"]}

TASK [Derive storage engine from PV] *******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:18
2019-08-02T09:05:55.409646 (delta: 1.969958)         elapsed: 446.792101 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-10c0826d-b4f6-11e9-a240-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.617087", "end": "2019-08-02 09:05:57.280488", "rc": 0, "start": "2019-08-02 09:05:55.663401", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:26
2019-08-02T09:05:57.367382 (delta: 1.957675)         elapsed: 448.749837 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:35
2019-08-02T09:05:57.448147 (delta: 0.080706)         elapsed: 448.830602 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"target_label": "openebs.io/target=cstor-target", "target_ns": "openebs"}, "changed": false}

TASK [Obtain the node where PV target pod resides] *****************************
task path: /utils/scm/openebs/target_affinity_check.yml:40
2019-08-02T09:05:57.587819 (delta: 0.139609)         elapsed: 448.970274 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume==\"pvc-10c0826d-b4f6-11e9-a240-0050569846e3\")].spec.nodeName}'", "delta": "0:00:01.520612", "end": "2019-08-02 09:05:59.390607", "rc": 0, "start": "2019-08-02 09:05:57.869995", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Verify whether the app & target pod co-exist on same node] ***************
task path: /utils/scm/openebs/target_affinity_check.yml:49
2019-08-02T09:05:59.467200 (delta: 1.879326)         elapsed: 450.849655 ****** 
ok: [127.0.0.1] => {
    "msg": "App and Target affinity is maintained"
}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:131
2019-08-02T09:05:59.588767 (delta: 0.121513)         elapsed: 450.971222 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:137
2019-08-02T09:05:59.694648 (delta: 0.105821)         elapsed: 451.077103 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:148
2019-08-02T09:05:59.806929 (delta: 0.112214)         elapsed: 451.189384 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-08-02T09:05:59.940278 (delta: 0.133296)         elapsed: 451.322733 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-08-02T09:06:00.019855 (delta: 0.079521)         elapsed: 451.40231 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-08-02T09:06:00.118960 (delta: 0.099045)         elapsed: 451.501415 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-08-02T09:06:00.206807 (delta: 0.087767)         elapsed: 451.589262 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "45eaa4dbfb2d132afce3aa4f55e79457027e61ea", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "33e46b2d590adef0d53505850422ec3b", "mode": "0644", "owner": "root", "size": 456, "src": "/root/.ansible/tmp/ansible-tmp-1564736760.27-210669758055267/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-08-02T09:06:03.726362 (delta: 3.519496)         elapsed: 455.108817 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.369458", "end": "2019-08-02 09:06:05.334906", "rc": 0, "start": "2019-08-02 09:06:03.965448", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_container_kill \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_container_kill ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-08-02T09:06:05.450859 (delta: 1.724441)         elapsed: 456.833314 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.615827", "end": "2019-08-02 09:06:07.344800", "failed_when_result": false, "rc": 0, "start": "2019-08-02 09:06:05.728973", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=56   changed=34   unreachable=0    failed=0   

2019-08-02T09:06:07.396410 (delta: 1.945467)         elapsed: 458.778865 ****** 
=============================================================================== 
```
