### PR TITLE
test(litmus): implement csi driver deployment litmus experiment

### DIFF
--- a/providers/csi-provisioner/README.md
+++ b/providers/csi-provisioner/README.md
@@ -1,0 +1,22 @@
+# LitmusBook to deploy the OpenEBS CSI Driver.
+
+## Description
+   - This LitmusBook is capable of setting up OpenEBS CSI Driver and create a storageclass.
+
+   - This test constitutes the below files. 
+
+### run_litmus_test.yml
+   - This includes the litmus job which triggers the test execution. The pod includes several environmental variables such as 
+        - PROVIDER_STORAGE_CLASS : The name of storageclass using csi provisioner
+        - REPLICA_COUNT : The number of volume replicas to be created.
+        - NODE_OS : The operating system of worker nodes.
+        - SPC : The SPC to be used by storage class.
+
+### csi-cstor-sc.j2
+   - The storage class template which has to be populated with the given variables
+
+### test_vars.yml
+   - This test_vars file has the list of test specific variables used in LitmusBook
+
+### test.yml
+   - test.yml is the playbook where the test logic is built to deploy OpenEBS CSI Driver and create stoarge class.

--- a/providers/csi-provisioner/csi-cstor-sc.j2
+++ b/providers/csi-provisioner/csi-cstor-sc.j2
@@ -1,0 +1,10 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ storage_class }}
+provisioner: openebs-csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  storagePoolClaim: {{ spc }}
+  replicaCount: "{{ replica_count }}"

--- a/providers/csi-provisioner/run_litmus_test.yml
+++ b/providers/csi-provisioner/run_litmus_test.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-csi-provisioner-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: csi-provisioner
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-csi-cstor-sparse
+
+          - name: NODE_OS
+            value: ubuntu-16.04
+
+          - name: SPC
+            value: cstor-sparse-pool
+
+          - name: REPLICA_COUNT
+            value: 3
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/csi-provisioner/run_litmus_test.yml
+++ b/providers/csi-provisioner/run_litmus_test.yml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
@@ -32,7 +32,7 @@ spec:
             value: cstor-sparse-pool
 
           - name: REPLICA_COUNT
-            value: 3
+            value: "3"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -1,0 +1,89 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Deploy CSI Driver 
+          shell: >
+            kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml
+          args:
+            executable: /bin/bash
+          register: result
+          failed_when: "result.rc != 0"
+          when: node_os == "ubuntu-16.06" or "centos"
+
+        - name: Deploy CSI Driver if os is ubuntu 18.04
+          shell: >
+            kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator-ubuntu-18.04.yaml
+          args:
+            executable: /bin/bash
+          when: node_os == "ubuntu-18.04"
+
+        - name: check if csi-controller pod is running
+          shell: >
+            kubectl get pods -n kube-system -l app=openebs-csi-controller 
+            --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: csi_controller
+          until: "'running' in csi_controller.stdout"
+          delay: 10
+          retries: 30
+
+        - name: Obtain the desired number of openebs-csi-node pods
+          shell: >
+            kubectl get ds -n kube-system openebs-csi-node --no-headers 
+            -o custom-columns=:status.desiredNumberScheduled
+          args:
+            executable: /bin/bash
+          register: desired_count
+
+        - name: Check if the desired count matches the ready pods
+          command: >
+            kubectl get ds -n kube-system openebs-csi-node --no-headers 
+            -o custom-columns=:status.numberReady
+          args:
+            executable: /bin/bash
+          register: ready_pods
+          until: "desired_count.stdout == ready_pods.stdout"
+          delay: 5
+          retries: 50
+
+        - name: Update the storage class template with the variables.
+          template:
+            src: csi-cstor-sc.j2
+            dest: csi-cstor-sc.yml
+
+        - name: Create Storageclass
+          shell: kubectl apply -f csi-cstor-sc.yml
+          args:
+            executable: /bin/bash
+          register: sc_result
+          failed_when: "sc_result != 0"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -39,7 +39,7 @@
           args:
             executable: /bin/bash
           register: csi_controller
-          until: "'running' in csi_controller.stdout"
+          until: "'Running' in csi_controller.stdout"
           delay: 10
           retries: 30
 
@@ -72,7 +72,7 @@
           args:
             executable: /bin/bash
           register: sc_result
-          failed_when: "sc_result != 0"
+          failed_when: "sc_result.rc != 0"
 
         - set_fact:
             flag: "Pass"

--- a/providers/csi-provisioner/test_vars.yml
+++ b/providers/csi-provisioner/test_vars.yml
@@ -1,0 +1,13 @@
+---
+
+# Test specific parameters
+
+test_name: "csi-provision"
+
+spc: "{{ lookup('env','SPC') }}"
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
+
+node_os: "{{ lookup('env','NODE_OS') }}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Deploy csi driver based on host operating system in kubernetes cluster.
- Verify the existence of csi controller and csi-node components.
- Populate the storageclass template with the variables.
- Create storage class.
- check if the desired pods and storageclass are created.

Resources created are as follows;
```
openebs-csi-controller-0                      4/4       Running   0          3m51s
openebs-csi-node-kpx4l                        2/2       Running   0          3m51s
openebs-csi-node-nflqq                        2/2       Running   0          3m51s
openebs-csi-node-srx24                        2/2       Running   0          3m51s
```

Test-result:

```
PLAY [localhost] ***************************************************************
2019-08-05T07:11:47.589814 (delta: 0.102345)         elapsed: 0.102345 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-08-05T07:11:47.611573 (delta: 0.021714)         elapsed: 0.124104 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-08-05T07:11:54.660800 (delta: 7.049186)         elapsed: 7.173331 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-08-05T07:11:54.787608 (delta: 0.126763)         elapsed: 7.300139 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-08-05T07:11:54.883898 (delta: 0.09623)         elapsed: 7.396429 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-08-05T07:11:54.976624 (delta: 0.092671)         elapsed: 7.489155 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-05T07:11:55.135949 (delta: 0.15924)         elapsed: 7.64848 ********** 
changed: [127.0.0.1] => {"changed": true, "checksum": "af580fd43c60b8040cbac636c779b0cb4ebf449b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2d66fb549be9e3c9cae61b70ee95b9e0", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1564989115.22-242953850599672/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-05T07:11:56.273647 (delta: 1.137642)         elapsed: 8.786178 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.590669", "end": "2019-08-05 07:11:57.399026", "rc": 0, "start": "2019-08-05 07:11:56.808357", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-05T07:11:57.475304 (delta: 1.201602)         elapsed: 9.987835 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.447834", "end": "2019-08-05 07:11:59.185664", "failed_when_result": false, "rc": 0, "start": "2019-08-05 07:11:57.737830", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/csi-provision configured", "stdout_lines": ["litmusresult.litmus.io/csi-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-05T07:11:59.272943 (delta: 1.797583)         elapsed: 11.785474 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-05T07:11:59.351252 (delta: 0.078252)         elapsed: 11.863783 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-05T07:11:59.428503 (delta: 0.077194)         elapsed: 11.941034 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver] *******************************************************
2019-08-05T07:11:59.506704 (delta: 0.078146)         elapsed: 12.019235 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml", "delta": "0:00:01.492541", "end": "2019-08-05 07:12:01.280090", "failed_when_result": false, "rc": 0, "start": "2019-08-05 07:11:59.787549", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged\nserviceaccount/openebs-csi-controller-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-csi-provisioner-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-csi-provisioner-binding unchanged\nstatefulset.apps/openebs-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-csi-attacher-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-csi-attacher-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-csi-snapshotter-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-csi-snapshotter-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-csi-cluster-driver-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-csi-cluster-driver-registrar-binding unchanged\nserviceaccount/openebs-csi-node-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-csi-driver-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-csi-driver-registrar-binding unchanged\ndaemonset.apps/openebs-csi-node created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged", "serviceaccount/openebs-csi-controller-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-csi-provisioner-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-csi-provisioner-binding unchanged", "statefulset.apps/openebs-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-csi-attacher-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-csi-attacher-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-csi-snapshotter-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-csi-snapshotter-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-csi-cluster-driver-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-csi-cluster-driver-registrar-binding unchanged", "serviceaccount/openebs-csi-node-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-csi-driver-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-csi-driver-registrar-binding unchanged", "daemonset.apps/openebs-csi-node created"]}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2019-08-05T07:12:01.382459 (delta: 1.875672)         elapsed: 13.89499 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if csi-controller pod is running] **********************************
2019-08-05T07:12:01.486927 (delta: 0.104409)         elapsed: 13.999458 ******* 
FAILED - RETRYING: check if csi-controller pod is running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.795221", "end": "2019-08-05 07:12:13.663257", "rc": 0, "start": "2019-08-05 07:12:12.868036", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2019-08-05T07:12:13.748700 (delta: 12.261717)         elapsed: 26.261231 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.771317", "end": "2019-08-05 07:12:14.776382", "rc": 0, "start": "2019-08-05 07:12:14.005065", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the desired count matches the ready pods] ***********************
2019-08-05T07:12:14.859340 (delta: 1.110585)         elapsed: 27.371871 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:00.772272", "end": "2019-08-05 07:12:15.883772", "rc": 0, "start": "2019-08-05 07:12:15.111500", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Update the storage class template with the variables.] *******************
2019-08-05T07:12:15.976563 (delta: 1.117169)         elapsed: 28.489094 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7070c5cb74ab86f59b92b7f71e23c96fbe7c28a9", "dest": "./csi-cstor-sc.yml", "gid": 0, "group": "root", "md5sum": "44cfe4b284a7d6549d3bae09eb89996a", "mode": "0644", "owner": "root", "size": 229, "src": "/root/.ansible/tmp/ansible-tmp-1564989136.05-27039871799968/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2019-08-05T07:12:16.536247 (delta: 0.55963)         elapsed: 29.048778 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-sc.yml", "delta": "0:00:01.033059", "end": "2019-08-05 07:12:17.822326", "failed_when_result": false, "rc": 0, "start": "2019-08-05 07:12:16.789267", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-csi-cstor-sparse created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-csi-cstor-sparse created"]}

TASK [set_fact] ****************************************************************
2019-08-05T07:12:17.913434 (delta: 1.377131)         elapsed: 30.425965 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-08-05T07:12:18.038363 (delta: 0.124874)         elapsed: 30.550894 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-05T07:12:18.185263 (delta: 0.146846)         elapsed: 30.697794 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-05T07:12:18.265515 (delta: 0.080162)         elapsed: 30.778046 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-05T07:12:18.345672 (delta: 0.080099)         elapsed: 30.858203 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-05T07:12:18.425577 (delta: 0.079817)         elapsed: 30.938108 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8465df021b7326c95c9856682eb50700e84d8dc7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "685bbc60e191086cf7d2cf0f55be2022", "mode": "0644", "owner": "root", "size": 412, "src": "/root/.ansible/tmp/ansible-tmp-1564989138.51-127289902077489/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-05T07:12:20.201895 (delta: 1.77626)         elapsed: 32.714426 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.581214", "end": "2019-08-05 07:12:21.045377", "rc": 0, "start": "2019-08-05 07:12:20.464163", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-05T07:12:21.122916 (delta: 0.920964)         elapsed: 33.635447 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.992253", "end": "2019-08-05 07:12:22.380139", "failed_when_result": false, "rc": 0, "start": "2019-08-05 07:12:21.387886", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/csi-provision configured", "stdout_lines": ["litmusresult.litmus.io/csi-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=12   unreachable=0    failed=0   

2019-08-05T07:12:22.426922 (delta: 1.303951)         elapsed: 34.939453 ******* 
=============================================================================== 
```