### PR TITLE
refactor[litmusbook]: Modified and removed the tasks in litmusbook

### DIFF
--- a/apps/percona/functional/k8s_snapshot/test.yml
+++ b/apps/percona/functional/k8s_snapshot/test.yml
@@ -225,19 +225,19 @@
        
         ### Attempting to delete parent PVC which has clone.
 
-        - name: Attempt deleting volume which has clones.
-          shell: kubectl delete pvc {{ pvc_name }} -n {{ app_ns }}
-          args:
-            executable: /bin/bash
-          register: delete_pvc
-          failed_when: delete_pvc.rc == 0
+          #        - name: Attempt deleting volume which has clones.
+          #          shell: kubectl delete pvc {{ pvc_name }} -n {{ app_ns }}
+          #          args:
+          #            executable: /bin/bash
+          #          register: delete_pvc
+          #          failed_when: delete_pvc.rc == 0
 
-        - name: Check if the PVC is not deleted.
-          shell: kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: pvc_state
-          failed_when: "'Bound' not in pvc_state.stdout"
+          #        - name: Check if the PVC is not deleted.
+          #          shell: kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers -o custom-columns=:status.phase
+          #          args:
+          #            executable: /bin/bash
+          #          register: pvc_state
+          #          failed_when: "'Bound' not in pvc_state.stdout"
 
         - set_fact:
             flag: "Pass"

--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -51,8 +51,8 @@
 
 - name: Get controller svc
   shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
-    -n {{ app_ns }} --no-headers -o custom-columns=:spec.clusterIP
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc 
+    -n {{ app_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
   args:
     executable: /bin/bash
   register: controller_svc

--- a/chaoslib/openebs/jiva_replica_network_delay.yaml
+++ b/chaoslib/openebs/jiva_replica_network_delay.yaml
@@ -66,7 +66,7 @@
 - name: Get controller svc
   shell: >
     kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
-    -n {{ app_ns }} --no-headers -o custom-columns=:spec.clusterIP
+    -n {{ app_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
   args:
     executable: /bin/bash
   register: controller_svc

--- a/experiments/functional/fio/data-integrity/fio-read.yml
+++ b/experiments/functional/fio/data-integrity/fio-read.yml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: basic-read
 data:
-
  basic-rw : |-
 
      [global]
@@ -35,7 +34,7 @@ spec:
         image: openebs/tests-fio:latest
         imagePullPolicy: Always
         command: ["/bin/bash"]
-        args: ["-c", "./fio_runner.sh --read-only /datadir/basic-fio; ./fio_runner.sh --available_space /datadir --miscellaneous /datadir; exit 0"]
+        args: ["-c", "./fio_runner.sh --read-only /datadir/basic-fio; exit 0"]
         volumeMounts:
            - mountPath: /datadir
              name: demo-vol1

--- a/experiments/functional/fio/data-integrity/run_litmus_test.yml
+++ b/experiments/functional/fio/data-integrity/run_litmus_test.yml
@@ -32,11 +32,5 @@ spec:
           - name: FIO_TESTRUN_PERIOD
             value: "60"
 
-          - name: DATA_CHECK #data_integrity for jiva  #data_accesibility for cstor
-            value: "data_integrity"
-
-          - name: POOL_LABEL
-            value: "app=cstor-pool"
-
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/fio/data-integrity/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/fio/data-integrity/test.yml
+++ b/experiments/functional/fio/data-integrity/test.yml
@@ -11,24 +11,15 @@
   tasks:
    - block:
 
-       - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-         when: lookup('env','RUN_ID')
+        ## Generating the testname.
+       - include_tasks: /utils/fcm/create_testname.yml
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
          vars:
            status: 'SOT'
 
-       ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS
+        ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS
 
        - name: Check whether the provider storageclass is applied
          shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
@@ -66,59 +57,11 @@
            pvc_label: demo-vol1-claim
            execute: 1          
 
-       - include_tasks: /utils/scm/openebs/disable_compression_on_pools.yml
-         when: data_check == 'data_accessibility'
-
        - name: Replace the data sample size with user-defined size
          replace:
            path: "{{ fio_write_yml }}"
            regexp: "256m"
            replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
-         when: data_check == 'data_integrity'
-
-       - block:
-
-           - name: Fetch the Storage from PVC using namespace(need to modify)
-             shell: kubectl get pvc -n {{ app_ns }} -o jsonpath={.items[0].spec.resources.requests.storage}
-             args:
-               executable: /bin/bash
-             register: storage_capacity
-
-           - name: Fetch the alphabet(G,M,m,g) from storage capacity
-             shell: echo "{{ storage_capacity.stdout }}" | grep -o -E '[A-Za-z]+'
-             args:
-               executable: /bin/bash
-             register: symbol
-
-           - name: Fetch the alphabet(G,M,m,g) from storage capacity
-             shell: echo "{{ storage_capacity.stdout }}" | grep -o -E '[0-9]+'
-             args:
-               executable: /bin/bash
-             register: value_str
-
-           - set_fact:
-               value_num: '{{ ( (value_str.stdout | int - 0.2) * 0.93 * 1024) |  int }}'
-             when: "'G' in symbol.stdout"
-
-           - set_fact:
-               value_num: '{{ ((value_str.stdout | int - 0.2) * 0.93 * 1024 * 1024) | int }}'
-             when: "'T' in symbol.stdout"
-
-           - name: Replace the data sample size with 90% of pvc size in {{ fio_write_yml }}
-             replace:
-               path: "{{ fio_write_yml }}"
-               regexp: "256m"
-               replace: "{{ value_num }}m"
-             when: "'G' in symbol.stdout or 'T' in symbol.stdout"
-
-           - name: Replace the data sample size with 90% of pvc size in {{ fio_write_yml }}
-             replace:
-               path: "{{ fio_write_yml }}"
-               regexp: "256m"
-               replace: "{{ storage_capacity.stdout }}"
-             when: "'M' in symbol.stdout"
-
-         when: data_check == 'data_accessibility'
 
        ## RUN FIO WORKLOAD TEST
 
@@ -141,17 +84,18 @@
          register: status_fio_pod
          until: "'Running' in status_fio_pod.stdout"
          delay: 5
-         retries: 100
+         retries: 30
 
        - name: Check if fio write job is completed
          shell: >
-           kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="fio-write")].status.containerStatuses[*].state.terminated.reason}'
+           kubectl get pods -n {{ app_ns }} 
+           -o jsonpath='{.items[?(@.metadata.labels.name=="fio-write")].status.containerStatuses[*].state.terminated.reason}'
          args:
            executable: /bin/bash
          register: result_fio_pod
          until: "'Completed' in result_fio_pod.stdout"
-         delay: 60
-         retries: 900
+         delay: 15
+         retries: 30
 
        - name: Verify the fio logs to check if run is complete w/o errors
          shell: >
@@ -177,13 +121,14 @@
 
        - name: Check if fio read job is completed
          shell: >
-           kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="fio-read")].status.containerStatuses[*].state.terminated.reason}'
+           kubectl get pods -n {{ app_ns }} 
+           -o jsonpath='{.items[?(@.metadata.labels.name=="fio-read")].status.containerStatuses[*].state.terminated.reason}'
          args:
            executable: /bin/bash
          register: result_read_job
          until: "'Completed' in result_read_job.stdout"
-         delay: 60
-         retries: 20
+         delay: 5
+         retries: 30
 
        - name: Verify the data integrity check
          shell: >

--- a/experiments/functional/fio/data-integrity/test_vars.yml
+++ b/experiments/functional/fio/data-integrity/test_vars.yml
@@ -4,8 +4,6 @@ test_name: fio-data-integrity
 fio_write_yml: fio-write.yml
 fio_read_yml: fio-read.yml
 app_ns: "{{ lookup('env','FIO_NAMESPACE') }}"
-data_check: "{{ lookup('env','DATA_CHECK') }}"
 pvc_yml: pvc.yml
 operator_ns: "openebs"
-pool_label: "{{ lookup('env','POOL_LABEL') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- This PR is modifying the below LitmusBook/Utils
    - k8s-snapshot clone litmusbook
    - FIO data integrity check LitmusBook
    - Jiva Controller network delay Util
    - Jiva replica network delay Util
- The Changes in LitmusBook is needed because they are already covered as part of different LitmuBook for ex: Delete parent volume has separate LitmusBook and the Volume capacity fill using FIO also covered by different LitmusBook.
- The Changes in the Utils is needed as part of accommodating for Statefulset and deployment. 

data integrity LitmusBook log:-
```
'No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-08-07T11:33:26.986209 (delta: 0.06884)         elapsed: 0.06884 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-08-07T11:33:27.001867 (delta: 0.015608)         elapsed: 0.084498 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-08-07T11:33:36.260181 (delta: 9.258293)         elapsed: 9.342812 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-08-07T11:33:36.469160 (delta: 0.208904)         elapsed: 9.551791 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-08-07T11:33:36.615463 (delta: 0.14621)         elapsed: 9.698094 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-08-07T11:33:36.766703 (delta: 0.151157)         elapsed: 9.849334 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-07T11:33:36.991929 (delta: 0.225134)         elapsed: 10.07456 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "146d56191547cf1ef37fc24f1c32123c685a3ba2", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1858ec125d0913cc89507969a9190901", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1565177617.05-171710664536742/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-07T11:33:37.912263 (delta: 0.920284)         elapsed: 10.994894 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.071133", "end": "2019-08-07 11:33:39.539004", "rc": 0, "start": "2019-08-07 11:33:38.467871", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-07T11:33:39.612645 (delta: 1.700262)         elapsed: 12.695276 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.622038", "end": "2019-08-07 11:33:41.473553", "failed_when_result": false, "rc": 0, "start": "2019-08-07 11:33:39.851515", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-07T11:33:41.616040 (delta: 2.003346)         elapsed: 14.698671 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-07T11:33:41.745238 (delta: 0.129083)         elapsed: 14.827869 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-07T11:33:41.888828 (delta: 0.143505)         elapsed: 14.971459 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-08-07T11:33:42.015903 (delta: 0.12698)         elapsed: 15.098534 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default", "delta": "0:00:01.207655", "end": "2019-08-07 11:33:43.585162", "rc": 0, "start": "2019-08-07 11:33:42.377507", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-jiva-default   openebs.io/provisioner-iscsi   18m", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-jiva-default   openebs.io/provisioner-iscsi   18m"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-08-07T11:33:43.727643 (delta: 1.711654)         elapsed: 16.810274 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create test specific namespace.] *****************************************
2019-08-07T11:33:44.384683 (delta: 0.656935)         elapsed: 17.467314 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:01.306990", "end": "2019-08-07 11:33:46.072917", "rc": 0, "start": "2019-08-07 11:33:44.765927", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [Checking the status  of test specific namespace.] ************************
2019-08-07T11:33:46.198327 (delta: 1.813555)         elapsed: 19.280958 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o jsonpath='{.status.phase}'", "delta": "0:00:01.263444", "end": "2019-08-07 11:33:47.748820", "rc": 0, "start": "2019-08-07 11:33:46.485376", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2019-08-07T11:33:47.893734 (delta: 1.695322)         elapsed: 20.976365 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:02.435922", "end": "2019-08-07 11:33:50.705401", "rc": 0, "start": "2019-08-07 11:33:48.269479", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [set_fact] ****************************************************************
2019-08-07T11:33:50.858163 (delta: 2.964337)         elapsed: 23.940794 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"execute": 1, "pvc_label": "demo-vol1-claim"}, "changed": false}

TASK [Replace the data sample size with user-defined size] *********************
2019-08-07T11:33:51.049763 (delta: 0.191472)         elapsed: 24.132394 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy fio write test job] ***********************************************
2019-08-07T11:33:51.543387 (delta: 0.493519)         elapsed: 24.626018 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:02.406481", "end": "2019-08-07 11:33:54.195166", "rc": 0, "start": "2019-08-07 11:33:51.788685", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2019-08-07T11:33:54.356741 (delta: 2.8133)         elapsed: 27.439372 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.068480", "end": "2019-08-07 11:33:55.682185", "rc": 0, "start": "2019-08-07 11:33:54.613705", "stderr": "", "stderr_lines": [], "stdout": "fio-tlt84", "stdout_lines": ["fio-tlt84"]}

TASK [Check the status of pod] *************************************************
2019-08-07T11:33:55.849445 (delta: 1.492616)         elapsed: 28.932076 ******* 
FAILED - RETRYING: Check the status of pod (30 retries left).
FAILED - RETRYING: Check the status of pod (29 retries left).
FAILED - RETRYING: Check the status of pod (28 retries left).
FAILED - RETRYING: Check the status of pod (27 retries left).
FAILED - RETRYING: Check the status of pod (26 retries left).
FAILED - RETRYING: Check the status of pod (25 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl get po fio-tlt84 -n fio -o jsonpath={.status.phase}", "delta": "0:00:01.298477", "end": "2019-08-07 11:34:37.682348", "rc": 0, "start": "2019-08-07 11:34:36.383871", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check if fio write job is completed] *************************************
2019-08-07T11:34:37.763783 (delta: 41.914261)         elapsed: 70.846414 ****** 
FAILED - RETRYING: Check if fio write job is completed (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-write\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:02.128720", "end": "2019-08-07 11:34:56.865074", "rc": 0, "start": "2019-08-07 11:34:54.736354", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the fio logs to check if run is complete w/o errors] **************
2019-08-07T11:34:57.020181 (delta: 19.25634)         elapsed: 90.102812 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-tlt84 -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.399627", "end": "2019-08-07 11:34:58.800302", "failed_when_result": false, "rc": 0, "start": "2019-08-07 11:34:57.400675", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Deploy fio read test job] ************************************************
2019-08-07T11:34:58.954992 (delta: 1.934693)         elapsed: 92.037623 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-read.yml -n fio", "delta": "0:00:01.420342", "end": "2019-08-07 11:35:00.778861", "rc": 0, "start": "2019-08-07 11:34:59.358519", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic-read created\njob.batch/fio-read created", "stdout_lines": ["configmap/basic-read created", "job.batch/fio-read created"]}

TASK [Obtaining the fio read job pod name] *************************************
2019-08-07T11:35:00.870160 (delta: 1.915039)         elapsed: 93.952791 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-read -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.244334", "end": "2019-08-07 11:35:02.429669", "rc": 0, "start": "2019-08-07 11:35:01.185335", "stderr": "", "stderr_lines": [], "stdout": "fio-read-4dmtp", "stdout_lines": ["fio-read-4dmtp"]}

TASK [Check if fio read job is completed] **************************************
2019-08-07T11:35:02.560946 (delta: 1.690699)         elapsed: 95.643577 ******* 
FAILED - RETRYING: Check if fio read job is completed (30 retries left).
FAILED - RETRYING: Check if fio read job is completed (29 retries left).
FAILED - RETRYING: Check if fio read job is completed (28 retries left).
FAILED - RETRYING: Check if fio read job is completed (27 retries left).
FAILED - RETRYING: Check if fio read job is completed (26 retries left).
FAILED - RETRYING: Check if fio read job is completed (25 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-read\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:01.292574", "end": "2019-08-07 11:35:43.269393", "rc": 0, "start": "2019-08-07 11:35:41.976819", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the data integrity check] *****************************************
2019-08-07T11:35:43.375284 (delta: 40.814229)         elapsed: 136.457915 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-read-4dmtp -n fio | grep -i '\"error\"' | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.362868", "end": "2019-08-07 11:35:45.092714", "failed_when_result": false, "rc": 0, "start": "2019-08-07 11:35:43.729846", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [set_fact] ****************************************************************
2019-08-07T11:35:45.241269 (delta: 1.865879)         elapsed: 138.3239 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-08-07T11:35:45.397158 (delta: 0.155785)         elapsed: 138.479789 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-07T11:35:45.530840 (delta: 0.133581)         elapsed: 138.613471 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-07T11:35:45.591413 (delta: 0.060519)         elapsed: 138.674044 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-07T11:35:45.662032 (delta: 0.070566)         elapsed: 138.744663 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-07T11:35:45.741843 (delta: 0.079733)         elapsed: 138.824474 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "36164a81fa9671efa51def99079c8bc40712183b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "916231ca29633a704d25e2c2ac858ab5", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1565177745.82-19691877427850/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-07T11:35:48.411968 (delta: 2.670053)         elapsed: 141.494599 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.890372", "end": "2019-08-07 11:35:49.644414", "rc": 0, "start": "2019-08-07 11:35:48.754042", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-07T11:35:49.718652 (delta: 1.306594)         elapsed: 142.801283 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.557757", "end": "2019-08-07 11:35:51.548193", "failed_when_result": false, "rc": 0, "start": "2019-08-07 11:35:49.990436", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=21   unreachable=0    failed=0   

2019-08-07T11:35:51.592007 (delta: 1.873301)         elapsed: 144.674638 ****** 
=============================================================================== 
```