### PR TITLE
Increased timeout for ssh into instances task in packet cluster creation playbook

### DIFF
--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -73,7 +73,7 @@
             host: "{{ item.public_ipv4 }}"
             port: 22
             state: started
-            timeout: 500
+            timeout: 1500
           with_items:
             - "{{ master.devices }}"
             - "{{ workers.devices }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Increased timeout for waiting for ssh into each instance