### PR TITLE
refactor[yaml]: Modified a Pool creation LitmusBook to check the pool status

### DIFF
--- a/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-block-device-pool/run_litmus_test.yml
@@ -10,7 +10,6 @@ spec:
       name: litmus
       labels:
         app: cstor-block-device-pool-provision
-
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
@@ -46,6 +45,12 @@ spec:
           - name: DEVICE_CAPACITY
             value: "20Gi"
 
+          - name: SPC_MAXPOOL_COUNT
+            value: "3"
+
+          - name: DEPLOY_MODE
+            value: create
+        
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/cstor/cstor-block-device-pool/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -5,6 +5,7 @@ metadata:
 spec:
   name: pool-name
   type: disk
+  maxPools: maxpool-count
   poolSpec:
     poolType: pool-type
   blockDevices:

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -200,7 +200,7 @@
                 executable: /bin/bash
               register: runningStatusCount
               with_items: "{{ cstor_pool_pod.stdout_lines }}"
-              until: "runningStatusCount.stdout == maxPool_count.stdout"
+              until: "runningStatusCount.stdout == device_count"
               delay: 30
               retries: 10
           

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -15,178 +15,231 @@
         - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
-
-        - name: Getting the compute node name
-          shell: kubectl get nodes -l {{ node_label }} -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
-          register: nodes
-
-        - name: Replacing the pool type in SPC spec
-          replace:
-            path: ./spc.yml
-            regexp: "pool-type"
-            replace: "{{ pool_type }}"
-        
-        - block:
-
-           - name: Getting the Unclaimed block-device from each node when pool type is STRIPE
-             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
-             register: blockDevice
-             with_items: "{{ nodes.stdout_lines }}"
-
-           - name: Initialize an empty list to store block device names
-             set_fact:
-               bd_names: []
-
-           - name: Store name of all block devices in the list 
-             set_fact:
-               bd_names: "{{ bd_names + item.stdout_lines }}"
-             with_items:
-              - "{{ blockDevice.results }}"
-               
-           - name: Adding discovered block device into SPC spec
-             lineinfile:
-               path: "./spc.yml"
-               insertafter: 'blockDeviceList:'
-               line: '    - {{ item }}'
-             with_items: "{{ bd_names }}"
- 
-          when: pool_type == "striped" 
-
-        - block:
-
-           - name: Getting the Unclaimed block-devices from each node when pool type is MIRROR 
-             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 2
-             register: blockDevice
-             with_items: "{{ nodes.stdout_lines }}" 
-           
-           - name: Initialize an empty list to store block device names
-             set_fact:
-               bd_names: []
-
-           - name: Store name of all block devices in the list 
-             set_fact:
-               bd_names: "{{ bd_names + item.stdout_lines }}"
-             with_items:
-              - "{{ blockDevice.results }}"
-           
-           - name: Adding discovered block devices into SPC spec
-             lineinfile:
-               path: "./spc.yml"
-               insertafter: 'blockDeviceList:'
-               line: '    - {{ item }}'
-             with_items: "{{ bd_names }}"
-
-          when: pool_type == "mirrored"
-
-        - block:
-
-           - name: Getting the Unclaimed block-devices from each node when pool type is RAIDZ1
-             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 3
-             register: blockDevice
-             with_items: "{{ nodes.stdout_lines }}"
-
-           - name: Initialize an empty list to store block device names
-             set_fact:
-               bd_names: []
-
-           - name: Store name of all block devices in the list
-             set_fact:
-               bd_names: "{{ bd_names + item.stdout_lines }}"
-             with_items:
-              - "{{ blockDevice.results }}"
-
-           - name: Adding discovered block device into SPC spec
-             lineinfile:
-               path: "./spc.yml"
-               insertafter: 'blockDeviceList:'
-               line: '    - {{ item }}'
-             with_items: "{{ bd_names }}"
-
-          when: pool_type == "raidz"
-
-        - block:
-
-           - name: Getting the Unclaimed block-device from each node when pool type is RAIDZ2
-             shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 6
-             register: blockDevice
-             with_items: "{{ nodes.stdout_lines }}"
-
-           - name: Initialize an empty list to store block device names
-             set_fact:
-               bd_names: []
-
-           - name: Store name of all block devices in the list
-             set_fact:
-               bd_names: "{{ bd_names + item.stdout_lines }}"
-             with_items:
-              - "{{ blockDevice.results }}"
-             
-           - name: Adding discovered block device into SPC spec
-             lineinfile:
-               path: "./spc.yml"
-               insertafter: 'blockDeviceList:'
-               line: '    - {{ item }}'
-             with_items: "{{ bd_names }}" 
           
-          when: pool_type == "raidz2"  
+        - block: 
 
-        - set_fact:
-             device_count: "{{ blockDevice|length}}"  
+            - name: Getting the compute node name
+              shell: kubectl get nodes -l {{ node_label }} -o jsonpath='{.items[*].metadata.name}' | tr " " "\n"
+              register: nodes
 
-        - name: Replacing the pool name in SPC spec
-          replace:
-            path: ./spc.yml
-            regexp: "pool-name"
-            replace: "{{ pool_name }}"
+            - name: Replacing the pool type in SPC spec
+              replace:
+                path: ./spc.yml
+                regexp: "pool-type"
+                replace: "{{ pool_type }}"
+            
+            - block:
 
-        - name: Replacing the storage class name in SPC spec
-          replace:
-            path: ./spc.yml
-            regexp: "sc-name"
-            replace: "{{ sc_name }}"
+              - name: Getting the Unclaimed block-device from each node when pool type is STRIPE
+                shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
+                register: blockDevice
+                with_items: "{{ nodes.stdout_lines }}"
 
-        - name: Display spc.yml for verification 
-          debug: var=item
-          with_file:
-           - "spc.yml"
+              - name: Initialize an empty list to store block device names
+                set_fact:
+                  bd_names: []
 
-        - name: Create cstor disk pool
-          shell: kubectl apply -f spc.yml
-          args:
-            executable: /bin/bash
+              - name: Store name of all block devices in the list 
+                set_fact:
+                  bd_names: "{{ bd_names + item.stdout_lines }}"
+                with_items:
+                  - "{{ blockDevice.results }}"
+                  
+              - name: Adding discovered block device into SPC spec
+                lineinfile:
+                  path: "./spc.yml"
+                  insertafter: 'blockDeviceList:'
+                  line: '    - {{ item }}'
+                with_items: "{{ bd_names }}"
+    
+              when: pool_type == "striped" 
 
-        - name: Verify if cStor Disk Pool are Running
-          shell: >
-             kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
-             --no-headers -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: pool_count
-          until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
-          retries: 30
-          delay: 10
+            - block:
 
-        - name: Get cStor Disk Pool names to verify the container statuses
-          shell: >
-            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
-            --no-headers -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: cstor_pool_pod
+              - name: Getting the Unclaimed block-devices from each node when pool type is MIRROR 
+                shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 2
+                register: blockDevice
+                with_items: "{{ nodes.stdout_lines }}" 
+              
+              - name: Initialize an empty list to store block device names
+                set_fact:
+                  bd_names: []
 
-        - name: Get the runningStatus of pool pod
-          shell: >
-            kubectl get pod {{ item }} -n {{ operator_ns }}
-            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
-            grep -w running | wc -l
-          args:
-            executable: /bin/bash
-          register: runningStatusCount
-          with_items: "{{ cstor_pool_pod.stdout_lines }}"
-          until: "runningStatusCount.stdout == device_count"
-          delay: 30
-          retries: 10
+              - name: Store name of all block devices in the list 
+                set_fact:
+                  bd_names: "{{ bd_names + item.stdout_lines }}"
+                with_items:
+                  - "{{ blockDevice.results }}"
+              
+              - name: Adding discovered block devices into SPC spec
+                lineinfile:
+                  path: "./spc.yml"
+                  insertafter: 'blockDeviceList:'
+                  line: '    - {{ item }}'
+                with_items: "{{ bd_names }}"
 
+              when: pool_type == "mirrored"
+
+            - block:
+
+              - name: Getting the Unclaimed block-devices from each node when pool type is RAIDZ1
+                shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 3
+                register: blockDevice
+                with_items: "{{ nodes.stdout_lines }}"
+
+              - name: Initialize an empty list to store block device names
+                set_fact:
+                  bd_names: []
+
+              - name: Store name of all block devices in the list
+                set_fact:
+                  bd_names: "{{ bd_names + item.stdout_lines }}"
+                with_items:
+                  - "{{ blockDevice.results }}"
+
+              - name: Adding discovered block device into SPC spec
+                lineinfile:
+                  path: "./spc.yml"
+                  insertafter: 'blockDeviceList:'
+                  line: '    - {{ item }}'
+                with_items: "{{ bd_names }}"
+
+              when: pool_type == "raidz"
+
+            - block:
+
+              - name: Getting the Unclaimed block-device from each node when pool type is RAIDZ2
+                shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 6
+                register: blockDevice
+                with_items: "{{ nodes.stdout_lines }}"
+
+              - name: Initialize an empty list to store block device names
+                set_fact:
+                  bd_names: []
+
+              - name: Store name of all block devices in the list
+                set_fact:
+                  bd_names: "{{ bd_names + item.stdout_lines }}"
+                with_items:
+                  - "{{ blockDevice.results }}"
+                
+              - name: Adding discovered block device into SPC spec
+                lineinfile:
+                  path: "./spc.yml"
+                  insertafter: 'blockDeviceList:'
+                  line: '    - {{ item }}'
+                with_items: "{{ bd_names }}" 
+              
+              when: pool_type == "raidz2"  
+
+            - set_fact:
+                device_count: "{{ blockDevice|length}}"  
+
+            - name: Replacing the pool name in SPC spec
+              replace:
+                path: ./spc.yml
+                regexp: "pool-name"
+                replace: "{{ pool_name }}"
+
+            - name: Replacing the maxPool count in SPC spec
+              replace:
+                path: ./spc.yml
+                regexp: "maxpool-count"
+                replace: "{{ maxpool_count }}"
+
+            - name: Replacing the storage class name in SPC spec
+              replace:
+                path: ./spc.yml
+                regexp: "sc-name"
+                replace: "{{ sc_name }}"
+
+            - name: Display spc.yml for verification 
+              debug: var=item
+              with_file:
+              - "spc.yml"
+
+            - name: Create cstor disk pool
+              shell: kubectl apply -f spc.yml
+              args:
+                executable: /bin/bash
+
+            - name: Verify if cStor Disk Pool are Running
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+                --no-headers -o custom-columns=:status.phase
+              args:
+                executable: /bin/bash
+              register: pool_count
+              until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
+              retries: 30
+              delay: 10
+
+            - name: Obtain the maxPool clount from spc
+              shell: >
+                kubectl get spc {{ pool_name }} -o custom-columns=:.spec.maxPools --no-headers
+              args:
+                executable: /bin/bash
+              register: maxPool_count
+
+            - name: Get cStor Disk Pool names to verify the container statuses
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+                --no-headers -o=custom-columns=NAME:".metadata.name"
+              args:
+                executable: /bin/bash
+              register: cstor_pool_pod
+
+            - name: Get the runningStatus of pool pod
+              shell: >
+                kubectl get pod {{ item }} -n {{ operator_ns }}
+                -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+                grep -w running | wc -l
+              args:
+                executable: /bin/bash
+              register: runningStatusCount
+              with_items: "{{ cstor_pool_pod.stdout_lines }}"
+              until: "runningStatusCount.stdout == maxPool_count.stdout"
+              delay: 30
+              retries: 10
+          
+          when: deploy_mode == "create"
+
+        - block:
+
+            - name: Remove the SPC
+              shell: kubectl delete spc {{ pool_name }}
+              args:
+                executable: /bin/bash
+              
+            - name: Verify if the SPC is deleted
+              shell: kubectl get spc
+              args:
+                executable: /bin/bash
+              register: spc_status
+              until: '"{{ pool_name }}" not in spc_status.stdout'
+              retries: 30
+              delay: 10
+
+            - name: Verify if the CSP is getting removed
+              shell: kubectl get csp -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+              args:
+                executable: /bin/bash
+              register: csp_status
+              until: "'No resources found.' in csp_status.stderr"
+              retries: 30
+              delay: 10
+
+            - name: Verify if the cStor pool pods are deleted
+              shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+              args:
+                executable: /bin/bash
+              register: pool_status
+              until: "'No resources found.' in pool_status.stderr"
+              retries: 30
+              delay: 10
+
+          when: deploy_mode == "delete"
+            
         - set_fact:
             flag: "Pass"
     

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -56,6 +56,8 @@
 
             - block:
 
+              ## TODO : Obatin the blockDecice list with Inactive state also
+
               - name: Getting the Unclaimed block-devices from each node when pool type is MIRROR 
                 shell: kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 2
                 register: blockDevice
@@ -176,7 +178,7 @@
 
             - name: Obtain the maxPool clount from spc
               shell: >
-                kubectl get spc {{ pool_name }} -o custom-columns=:.spec.maxPools --no-headers
+                kubectl get spc -o jsonpath='{.items[?(@.metadata.name=="{{ pool_name }}")].spec.maxPools}'
               args:
                 executable: /bin/bash
               register: maxPool_count
@@ -205,6 +207,14 @@
           when: deploy_mode == "create"
 
         - block:
+
+            - name: Obtain the claimed blockDevice list from bdc
+              shell: >
+                kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+                -o custom-columns=:.spec.blockDeviceName --no-headers
+              args:
+                executable: /bin/bash
+              register: blockdevice_name
 
             - name: Remove the SPC
               shell: kubectl delete spc {{ pool_name }}
@@ -235,6 +245,27 @@
                 executable: /bin/bash
               register: pool_status
               until: "'No resources found.' in pool_status.stderr"
+              retries: 30
+              delay: 10
+
+            - name: Verify if the BDC are deleted
+              shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+              args:
+                executable: /bin/bash
+              register: bdc_status
+              until: "'No resources found.' in bdc_status.stderr"
+              retries: 30
+              delay: 10
+
+            - name: Verify if the blockDevices are unclaimed
+              shell: >
+                kubectl get blockdevices -n {{ operator_ns }} 
+                -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
+              args:
+                executable: /bin/bash
+              register: bd_status
+              with_items: "{{ blockdevice_name.stdout_lines }}"
+              until: "'Unclaimed' in bd_status.stdout"
               retries: 30
               delay: 10
 

--- a/providers/cstor/cstor-block-device-pool/test_vars.yml
+++ b/providers/cstor/cstor-block-device-pool/test_vars.yml
@@ -6,4 +6,5 @@ pool_name: "{{ lookup('env','POOL_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
 sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
-
+deploy_mode: "{{ lookup('env','DEPLOY_MODE') }}"
+maxpool_count: "{{ lookup('env','SPC_MAXPOOL_COUNT') }}"

--- a/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: mockbot/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -174,24 +174,37 @@
               shell: >
                 kubectl delete cspc {{ pool_name }} -n {{ operator_ns }}
               args: 
-                execuatble: /bin/bash
+                executable: /bin/bash
+
+            - name: Verify if the CStor Pool Cluster is deleted
+              shell: >
+                kubectl get cspc -n {{ operator_ns }}
               register: cspc_status
-              until: "{{ pool_name }} not in cspc_status.stdout"
+              until: '"{{ pool_name }}" not in cspc_status.stdout'
+              retries: 30
+              delay: 10
+
+            - name: Verify if the CSPI is getting removed
+              shell: >
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+              args:
+                executable: /bin/bash
+              register: cspi_status
+              until: "'No resources found.' in cspi_status.stderr"
               retries: 30
               delay: 10
 
             - name: Verify if the cStor pool pods are deleted
               shell:
                 kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
-                --no-headers -o custom-columns=:status.phase
               args:
                 executable: /bin/bash
               register: pool_status
-              until: "'No resources found. in pool_status.stdout"
+              until: "'No resources found.' in pool_status.stderr"
               retries: 30
               delay: 10
 
-          when: deploy_mode =="delete"
+          when: deploy_mode == "delete"
 
         - set_fact:
             flag: "Pass"

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -86,8 +86,8 @@
           replace:
             path: "{{ cspc_operator }}"
             regexp: quay.io/openebs/cspc-operator:ci
-            replace: quay.io/openebs/cspc-operator:{{ lookup('env','MAYA_APISERVER_IMAGE') }}
-          when: lookup('env','MAYA_APISERVER_IMAGE') | length > 0
+            replace: quay.io/openebs/cspc-operator:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+          when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
         - name: Change the openebs analytics value of openebs resources in operator YAML
           replace:

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -52,6 +52,8 @@ spec:
             value:        
           - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
             value:  
+          - name: CSPC_OPERATOR_IMAGE
+            value:
           - name: IMAGE_PULL_POLICY
             value:
           - name: OPENEBS_INFRA_CHAOS


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the pool pod and SPC creation LitmusBook using blockDevices 
- Included a task to delete the SPC and verify the status
- Modified the SPC spec by including the maxPool count as a variable

LitmusBook log for pool creation
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-08-26T18:54:13.946518 (delta: 0.041925)         elapsed: 0.041925 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-08-26T18:54:13.957013 (delta: 0.010445)         elapsed: 0.05242 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-08-26T18:54:19.146538 (delta: 5.189477)         elapsed: 5.241945 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-08-26T18:54:19.205596 (delta: 0.059023)         elapsed: 5.301003 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-08-26T18:54:19.250315 (delta: 0.044682)         elapsed: 5.345722 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-08-26T18:54:19.294080 (delta: 0.043726)         elapsed: 5.389487 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-26T18:54:19.366960 (delta: 0.072844)         elapsed: 5.462367 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1566845659.41-151146320130332/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:54:19.993017 (delta: 0.62602)         elapsed: 6.088424 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.645640", "end": "2019-08-26 18:54:20.887614", "rc": 0, "start": "2019-08-26 18:54:20.241974", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:54:20.927508 (delta: 0.934453)         elapsed: 7.022915 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.302581", "end": "2019-08-26 18:54:22.371670", "failed_when_result": false, "rc": 0, "start": "2019-08-26 18:54:21.069089", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-26T18:54:22.419370 (delta: 1.491824)         elapsed: 8.514777 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:54:22.461013 (delta: 0.041604)         elapsed: 8.55642 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:54:22.500095 (delta: 0.039027)         elapsed: 8.595502 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-08-26T18:54:22.542311 (delta: 0.04218)         elapsed: 8.637718 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l node-role.kubernetes.io/compute=true -o jsonpath='{.items[*].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:00.677489", "end": "2019-08-26 18:54:23.389558", "rc": 0, "start": "2019-08-26 18:54:22.712069", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Replacing the pool type in SPC spec] *************************************
2019-08-26T18:54:23.433016 (delta: 0.890642)         elapsed: 9.528423 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-08-26T18:54:23.730246 (delta: 0.297172)         elapsed: 9.825653 ******** 

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:54:23.772462 (delta: 0.042153)         elapsed: 9.867869 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:54:23.843111 (delta: 0.07061)         elapsed: 9.938518 ********* 

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:54:23.897812 (delta: 0.054644)         elapsed: 9.993219 ******** 

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-08-26T18:54:23.945221 (delta: 0.047369)         elapsed: 10.040628 ******* 

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:54:23.987153 (delta: 0.041875)         elapsed: 10.08256 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:54:24.041649 (delta: 0.054439)         elapsed: 10.137056 ******* 

TASK [Adding discovered block devices into SPC spec] ***************************
2019-08-26T18:54:24.084173 (delta: 0.042482)         elapsed: 10.17958 ******** 

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-08-26T18:54:24.127970 (delta: 0.04376)         elapsed: 10.223377 ******** 

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:54:24.169735 (delta: 0.041726)         elapsed: 10.265142 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:54:24.218056 (delta: 0.048267)         elapsed: 10.313463 ******* 

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:54:24.259186 (delta: 0.041073)         elapsed: 10.354593 ******* 

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-08-26T18:54:24.300834 (delta: 0.04159)         elapsed: 10.396241 ******** 

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:54:24.342180 (delta: 0.041304)         elapsed: 10.437587 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:54:24.390916 (delta: 0.048695)         elapsed: 10.486323 ******* 

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:54:24.432442 (delta: 0.04147)         elapsed: 10.527849 ******** 

TASK [set_fact] ****************************************************************
2019-08-26T18:54:24.480621 (delta: 0.04814)         elapsed: 10.576028 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "4"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2019-08-26T18:54:24.547494 (delta: 0.066832)         elapsed: 10.642901 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the maxPool count in SPC spec] *********************************
2019-08-26T18:54:24.778167 (delta: 0.230612)         elapsed: 10.873574 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the storage class name in SPC spec] ****************************
2019-08-26T18:54:24.983589 (delta: 0.205384)         elapsed: 11.078996 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2019-08-26T18:54:25.174773 (delta: 0.19113)         elapsed: 11.27018 ********* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-block-disk-pool
spec:
  name: cstor-block-disk-pool
  type: disk
  maxPools: 3
  poolSpec:
    poolType: striped
  blockDevices:
    blockDeviceList:

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-disk
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-block-disk-pool
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-block-disk-pool\nspec:\n  name: cstor-block-disk-pool\n  type: disk\n  maxPools: 3\n  poolSpec:\n    poolType: striped\n  blockDevices:\n    blockDeviceList:\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-disk\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-block-disk-pool\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-08-26T18:54:25.250875 (delta: 0.076046)         elapsed: 11.346282 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:00.997276", "end": "2019-08-26 18:54:26.404757", "rc": 0, "start": "2019-08-26 18:54:25.407481", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-block-disk-pool created\nstorageclass.storage.k8s.io/openebs-cstor-disk unchanged", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-block-disk-pool created", "storageclass.storage.k8s.io/openebs-cstor-disk unchanged"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-08-26T18:54:26.447755 (delta: 1.196839)         elapsed: 12.543162 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.700629", "end": "2019-08-26 18:54:38.118818", "rc": 0, "start": "2019-08-26 18:54:37.418189", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain the maxPool clount from spc] **************************************
2019-08-26T18:54:38.175073 (delta: 11.727254)         elapsed: 24.27048 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get spc cstor-block-disk-pool -o custom-columns=:.spec.maxPools --no-headers", "delta": "0:00:00.691734", "end": "2019-08-26 18:54:39.061330", "rc": 0, "start": "2019-08-26 18:54:38.369596", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-08-26T18:54:39.104499 (delta: 0.927001)         elapsed: 25.199906 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.782988", "end": "2019-08-26 18:54:40.057771", "rc": 0, "start": "2019-08-26 18:54:39.274783", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-ebb5-64c9d6c4d4-xb4rc\ncstor-block-disk-pool-ifo5-858d45667f-zzbb6\ncstor-block-disk-pool-ua5o-759b8f8687-rcvvz", "stdout_lines": ["cstor-block-disk-pool-ebb5-64c9d6c4d4-xb4rc", "cstor-block-disk-pool-ifo5-858d45667f-zzbb6", "cstor-block-disk-pool-ua5o-759b8f8687-rcvvz"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-08-26T18:54:40.103080 (delta: 0.998523)         elapsed: 26.198487 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ebb5-64c9d6c4d4-xb4rc) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-ebb5-64c9d6c4d4-xb4rc -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.811340", "end": "2019-08-26 18:54:41.090874", "item": "cstor-block-disk-pool-ebb5-64c9d6c4d4-xb4rc", "rc": 0, "start": "2019-08-26 18:54:40.279534", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ifo5-858d45667f-zzbb6) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-ifo5-858d45667f-zzbb6 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.686483", "end": "2019-08-26 18:54:41.923673", "item": "cstor-block-disk-pool-ifo5-858d45667f-zzbb6", "rc": 0, "start": "2019-08-26 18:54:41.237190", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-ua5o-759b8f8687-rcvvz) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-block-disk-pool-ua5o-759b8f8687-rcvvz -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.898484", "end": "2019-08-26 18:54:42.964764", "item": "cstor-block-disk-pool-ua5o-759b8f8687-rcvvz", "rc": 0, "start": "2019-08-26 18:54:42.066280", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Remove the SPC] **********************************************************
2019-08-26T18:54:43.012358 (delta: 2.909239)         elapsed: 29.107765 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the SPC is deleted] ********************************************
2019-08-26T18:54:43.061191 (delta: 0.048747)         elapsed: 29.156598 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CSP is getting removed] ************************************
2019-08-26T18:54:43.106779 (delta: 0.045549)         elapsed: 29.202186 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor pool pods are deleted] *******************************
2019-08-26T18:54:43.152195 (delta: 0.045379)         elapsed: 29.247602 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-08-26T18:54:43.197566 (delta: 0.045334)         elapsed: 29.292973 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-08-26T18:54:43.262151 (delta: 0.064547)         elapsed: 29.357558 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-26T18:54:43.332784 (delta: 0.070591)         elapsed: 29.428191 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:54:43.390979 (delta: 0.058155)         elapsed: 29.486386 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:54:43.437092 (delta: 0.046075)         elapsed: 29.532499 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-26T18:54:43.482635 (delta: 0.045504)         elapsed: 29.578042 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1566845683.53-238565100987/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:54:44.915389 (delta: 1.432716)         elapsed: 31.010796 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.607009", "end": "2019-08-26 18:54:45.720527", "rc": 0, "start": "2019-08-26 18:54:45.113518", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:54:45.761013 (delta: 0.845586)         elapsed: 31.85642 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.842497", "end": "2019-08-26 18:54:46.745854", "failed_when_result": false, "rc": 0, "start": "2019-08-26 18:54:45.903357", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=16   unreachable=0    failed=0   

2019-08-26T18:54:46.780607 (delta: 1.019557)         elapsed: 32.876014 ******* 
===============================================================================
```
LitmusBook log for pool deletion

```

No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-08-26T18:36:05.546873 (delta: 0.062673)         elapsed: 0.062673 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-08-26T18:36:05.562558 (delta: 0.015649)         elapsed: 0.078358 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-08-26T18:36:11.164497 (delta: 5.601894)         elapsed: 5.680297 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-08-26T18:36:11.226320 (delta: 0.061785)         elapsed: 5.74212 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-08-26T18:36:11.270273 (delta: 0.043916)         elapsed: 5.786073 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-08-26T18:36:11.314543 (delta: 0.044231)         elapsed: 5.830343 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-26T18:36:11.386762 (delta: 0.072181)         elapsed: 5.902562 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d5dfb54c5bb8e6eb7750290df0512d9d8a3a15f3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cb5451a21024995d77a2f78cccdce1b3", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1566844571.43-213914704083069/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:36:12.000721 (delta: 0.613921)         elapsed: 6.516521 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.587102", "end": "2019-08-26 18:36:12.912654", "rc": 0, "start": "2019-08-26 18:36:12.325552", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:36:12.952786 (delta: 0.952025)         elapsed: 7.468586 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.237624", "end": "2019-08-26 18:36:14.347506", "failed_when_result": false, "rc": 0, "start": "2019-08-26 18:36:13.109882", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision unchanged", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-26T18:36:14.394223 (delta: 1.441398)         elapsed: 8.910023 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:36:14.434337 (delta: 0.040076)         elapsed: 8.950137 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:36:14.474239 (delta: 0.039862)         elapsed: 8.990039 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-08-26T18:36:14.515671 (delta: 0.041394)         elapsed: 9.031471 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the pool type in SPC spec] *************************************
2019-08-26T18:36:14.562806 (delta: 0.047099)         elapsed: 9.078606 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2019-08-26T18:36:14.638763 (delta: 0.075916)         elapsed: 9.154563 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:36:14.686469 (delta: 0.047666)         elapsed: 9.202269 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:36:14.736522 (delta: 0.050014)         elapsed: 9.252322 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:36:14.787071 (delta: 0.050503)         elapsed: 9.302871 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2019-08-26T18:36:14.837991 (delta: 0.050879)         elapsed: 9.353791 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:36:14.885551 (delta: 0.04752)         elapsed: 9.401351 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:36:14.930176 (delta: 0.044531)         elapsed: 9.445976 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2019-08-26T18:36:14.977334 (delta: 0.047119)         elapsed: 9.493134 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2019-08-26T18:36:15.042238 (delta: 0.064865)         elapsed: 9.558038 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:36:15.096523 (delta: 0.054243)         elapsed: 9.612323 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:36:15.150175 (delta: 0.053611)         elapsed: 9.665975 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:36:15.202122 (delta: 0.0519)         elapsed: 9.717922 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2019-08-26T18:36:15.250868 (delta: 0.048708)         elapsed: 9.766668 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2019-08-26T18:36:15.298832 (delta: 0.047919)         elapsed: 9.814632 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2019-08-26T18:36:15.344263 (delta: 0.045393)         elapsed: 9.860063 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2019-08-26T18:36:15.393698 (delta: 0.048757)         elapsed: 9.909498 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-08-26T18:36:15.443368 (delta: 0.049627)         elapsed: 9.959168 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the pool name in SPC spec] *************************************
2019-08-26T18:36:15.487998 (delta: 0.044584)         elapsed: 10.003798 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the storage class name in SPC spec] ****************************
2019-08-26T18:36:15.553876 (delta: 0.065839)         elapsed: 10.069676 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display spc.yml for verification] ****************************************
2019-08-26T18:36:15.637925 (delta: 0.08401)         elapsed: 10.153725 ******** 
skipping: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: pool-name
spec:
  name: pool-name
  type: disk
  maxPools: 3
  poolSpec:
    poolType: pool-type
  blockDevices:
    blockDeviceList:

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: sc-name
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: pool-name
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi)  => {"item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: pool-name\nspec:\n  name: pool-name\n  type: disk\n  maxPools: 3\n  poolSpec:\n    poolType: pool-type\n  blockDevices:\n    blockDeviceList:\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: sc-name\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: pool-name\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"}
skipping: [127.0.0.1] => {"msg": "All items completed"}

TASK [Create cstor disk pool] **************************************************
2019-08-26T18:36:15.714230 (delta: 0.076268)         elapsed: 10.23003 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2019-08-26T18:36:15.765302 (delta: 0.051035)         elapsed: 10.281102 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-08-26T18:36:15.817792 (delta: 0.052432)         elapsed: 10.333592 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the runningStatus of pool pod] ***************************************
2019-08-26T18:36:15.878504 (delta: 0.060671)         elapsed: 10.394304 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove the SPC] **********************************************************
2019-08-26T18:36:15.927497 (delta: 0.048951)         elapsed: 10.443297 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete spc cstor-block-disk-pool", "delta": "0:00:00.852983", "end": "2019-08-26 18:36:16.947944", "rc": 0, "start": "2019-08-26 18:36:16.094961", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io \"cstor-block-disk-pool\" deleted", "stdout_lines": ["storagepoolclaim.openebs.io \"cstor-block-disk-pool\" deleted"]}

TASK [Verify if the SPC is deleted] ********************************************
2019-08-26T18:36:17.027001 (delta: 1.099464)         elapsed: 11.542801 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pool_name }}" not in spc_status.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get spc", "delta": "0:00:01.834306", "end": "2019-08-26 18:36:19.233853", "rc": 0, "start": "2019-08-26 18:36:17.399547", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the CSP is getting removed] ************************************
2019-08-26T18:36:19.296173 (delta: 2.269126)         elapsed: 13.811973 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -n openebs -l openebs.io/cstor-pool-cluster=cstor-block-disk-pool", "delta": "0:00:00.928202", "end": "2019-08-26 18:36:20.387384", "rc": 0, "start": "2019-08-26 18:36:19.459182", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the cStor pool pods are deleted] *******************************
2019-08-26T18:36:20.433165 (delta: 1.136953)         elapsed: 14.948965 ******* 
FAILED - RETRYING: Verify if the cStor pool pods are deleted (30 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (29 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (28 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-block-disk-pool", "delta": "0:00:00.729293", "end": "2019-08-26 18:37:06.360517", "rc": 0, "start": "2019-08-26 18:37:05.631224", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2019-08-26T18:37:06.424289 (delta: 45.991063)         elapsed: 60.940089 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-08-26T18:37:06.484338 (delta: 0.060009)         elapsed: 61.000138 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-08-26T18:37:06.554098 (delta: 0.069717)         elapsed: 61.069898 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:37:06.615089 (delta: 0.06095)         elapsed: 61.130889 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:37:06.660246 (delta: 0.04512)         elapsed: 61.176046 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-08-26T18:37:06.700738 (delta: 0.040453)         elapsed: 61.216538 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bc202e69a2bf74aada3034aaf45168b303007b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b8ca9efc2fc9bc3c4be8570bc9f560fa", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1566844626.75-134214167248971/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-08-26T18:37:08.217724 (delta: 1.516947)         elapsed: 62.733524 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.648374", "end": "2019-08-26 18:37:09.022596", "rc": 0, "start": "2019-08-26 18:37:08.374222", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-block-device-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-block-device-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-08-26T18:37:09.063670 (delta: 0.845908)         elapsed: 63.57947 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.864008", "end": "2019-08-26 18:37:10.076740", "failed_when_result": false, "rc": 0, "start": "2019-08-26 18:37:09.212732", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-block-device-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-block-device-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=15   changed=10   unreachable=0    failed=0   

2019-08-26T18:37:10.109817 (delta: 1.046107)         elapsed: 64.625617 ******* 
=============================================================================== 
```