### PR TITLE
refactor[util]: Included a task to restart the application pod in mysql data persistence util

### DIFF
--- a/utils/scm/applications/mysql/mysql_data_persistence.yml
+++ b/utils/scm/applications/mysql/mysql_data_persistence.yml
@@ -18,9 +18,49 @@
 
 - block:
 
+   - name: Kill the application pod
+     shell: >
+       kubectl delete pod {{ pod_name }} -n {{ ns }}
+     args:
+       executable: /bin/bash
+
+   - name: Verify if the applicaion pod is deleted
+     shell: >
+       kubectl get pods -n {{ ns }}
+     args:
+       executable: /bin/bash
+     register: podstatus
+     until: '"{{ pod_name }}" not in podstatus.stdout'
+     retries: 2
+     delay: 150
+
+   - name: Obtain the newly created pod name for applicaion
+     shell: >
+       kubectl get pods -n {{ ns }} -o jsonpath='{.items[].metadata.name}'
+     args:
+       executable: /bin/bash
+     register: newpod_name
+
+   - name: Checking application pod is in running state
+     shell: kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.phase}'
+     register: result
+     until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+     delay: 2
+     retries: 150
+
+   - name: Get the container status of application.
+     shell: >
+        kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[].state}' | grep running
+     args:
+       executable: /bin/bash
+     register: containerStatus
+     until: "'running' in containerStatus.stdout"
+     delay: 2
+     retries: 150
+
    - name: Checking for the Corrupted tables
      shell: >
-       kubectl exec {{ pod_name }} -n {{ ns }}
+       kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
        -- mysqlcheck -c {{ dbname }} -u{{ dbuser }} -p{{ dbpassword }}
      args:
        executable: /bin/bash
@@ -29,7 +69,7 @@
 
    - name: Verify mysql data persistence 
      shell: >
-           kubectl exec {{ pod_name }} -n {{ ns }}
+           kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
            -- mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'select * from ttbl' {{ dbname }};
      args:
        executable: /bin/bash
@@ -58,3 +98,4 @@
      failed_when: "dbname in result.stdout"   
 
   when: status == "DELETE"
+

--- a/utils/scm/applications/mysql/mysql_data_persistence.yml
+++ b/utils/scm/applications/mysql/mysql_data_persistence.yml
@@ -36,7 +36,7 @@
 
    - name: Obtain the newly created pod name for applicaion
      shell: >
-       kubectl get pods -n {{ ns }} -o jsonpath='{.items[].metadata.name}'
+       kubectl get pods -n {{ ns }} -l {{ label }} -o jsonpath='{.items[].metadata.name}'
      args:
        executable: /bin/bash
      register: newpod_name


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a task to delete the application pod to verify the data persistence.
- Verified this with target network delay chaos experiment.
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_delay/test.yml

PLAY [localhost] ***************************************************************
2019-08-29T13:54:42.206878 (delta: 0.062302)         elapsed: 0.062302 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:2
2019-08-29T13:54:42.226431 (delta: 0.019497)         elapsed: 0.081855 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:12
2019-08-29T13:54:51.680781 (delta: 9.454313)         elapsed: 9.536205 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:16
2019-08-29T13:54:51.812110 (delta: 0.131245)         elapsed: 9.667534 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-08-29T13:54:51.994629 (delta: 0.182412)         elapsed: 9.850053 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-08-29T13:54:52.094704 (delta: 0.099995)         elapsed: 9.950128 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:2
2019-08-29T13:54:52.177117 (delta: 0.082323)         elapsed: 10.032541 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.325870", "end": "2019-08-29 13:54:53.943473", "rc": 0, "start": "2019-08-29 13:54:52.617603", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:10
2019-08-29T13:54:54.022181 (delta: 1.844958)         elapsed: 11.877605 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:02.186474", "end": "2019-08-29 13:54:56.466824", "rc": 0, "start": "2019-08-29 13:54:54.280350", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:18
2019-08-29T13:54:56.589853 (delta: 2.567604)         elapsed: 14.445277 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:22
2019-08-29T13:54:56.778632 (delta: 0.188668)         elapsed: 14.634056 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:27
2019-08-29T13:54:56.889318 (delta: 0.110605)         elapsed: 14.744742 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.099416", "end": "2019-08-29 13:54:58.283045", "rc": 0, "start": "2019-08-29 13:54:57.183629", "stderr": "", "stderr_lines": [], "stdout": "pvc-1db79e75-ca64-11e9-bbac-0050569846e3", "stdout_lines": ["pvc-1db79e75-ca64-11e9-bbac-0050569846e3"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:35
2019-08-29T13:54:58.380321 (delta: 1.49092)         elapsed: 16.235745 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-1db79e75-ca64-11e9-bbac-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.438913", "end": "2019-08-29 13:55:00.061289", "rc": 0, "start": "2019-08-29 13:54:58.622376", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:43
2019-08-29T13:55:00.207490 (delta: 1.827093)         elapsed: 18.062914 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:48
2019-08-29T13:55:00.436966 (delta: 0.229336)         elapsed: 18.29239 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1567086900.5-176407040854848/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:20
2019-08-29T13:55:01.472470 (delta: 1.035219)         elapsed: 19.327894 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:23
2019-08-29T13:55:01.562806 (delta: 0.090282)         elapsed: 19.41823 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:29
2019-08-29T13:55:01.655772 (delta: 0.092912)         elapsed: 19.511196 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-08-29T13:55:01.774451 (delta: 0.118619)         elapsed: 19.629875 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d033ea974d5ef085c993c50e7a6f965c34548b8d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "847944374d12ae8e25882f4315d7c96c", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1567086901.83-258737630958187/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-08-29T13:55:02.273465 (delta: 0.498952)         elapsed: 20.128889 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.205806", "end": "2019-08-29 13:55:03.756976", "rc": 0, "start": "2019-08-29 13:55:02.551170", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-08-29T13:55:03.837871 (delta: 1.564343)         elapsed: 21.693295 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.749689", "end": "2019-08-29 13:55:05.926645", "failed_when_result": false, "rc": 0, "start": "2019-08-29 13:55:04.176956", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-08-29T13:55:06.005273 (delta: 2.167314)         elapsed: 23.860697 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-08-29T13:55:06.085892 (delta: 0.080553)         elapsed: 23.941316 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-08-29T13:55:06.156350 (delta: 0.070395)         elapsed: 24.011774 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:36
2019-08-29T13:55:06.240045 (delta: 0.083624)         elapsed: 24.095469 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-cstor-disk"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:47
2019-08-29T13:55:06.393995 (delta: 0.153863)         elapsed: 24.249419 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-08-29T13:55:06.540215 (delta: 0.14616)         elapsed: 24.395639 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.310191", "end": "2019-08-29 13:55:08.093738", "rc": 0, "start": "2019-08-29 13:55:06.783547", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-08-29T13:52:39Z]]", "stdout_lines": ["map[running:map[startedAt:2019-08-29T13:52:39Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-08-29T13:55:08.165992 (delta: 1.625707)         elapsed: 26.021416 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.131604", "end": "2019-08-29 13:55:09.511940", "rc": 0, "start": "2019-08-29 13:55:08.380336", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:56
2019-08-29T13:55:09.585366 (delta: 1.419318)         elapsed: 27.44079 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.265653", "end": "2019-08-29 13:55:11.094655", "rc": 0, "start": "2019-08-29 13:55:09.829002", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-5r4t8", "stdout_lines": ["percona-cb697f8b4-5r4t8"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:64
2019-08-29T13:55:11.159865 (delta: 1.57444)         elapsed: 29.015289 ******** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-08-29T13:55:11.350125 (delta: 0.190201)         elapsed: 29.205549 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-5r4t8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:01.683241", "end": "2019-08-29 13:55:13.262169", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2019-08-29 13:55:11.578928", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-5r4t8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:01.783667", "end": "2019-08-29 13:55:15.313902", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2019-08-29 13:55:13.530235", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-5r4t8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:01.757160", "end": "2019-08-29 13:55:17.450859", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2019-08-29 13:55:15.693699", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-08-29T13:55:17.617470 (delta: 6.267284)         elapsed: 35.472894 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-08-29T13:55:17.742092 (delta: 0.124479)         elapsed: 35.597516 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-08-29T13:55:17.817187 (delta: 0.075033)         elapsed: 35.672611 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-08-29T13:55:17.888616 (delta: 0.071369)         elapsed: 35.74404 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-08-29T13:55:17.958734 (delta: 0.070055)         elapsed: 35.814158 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-08-29T13:55:18.022306 (delta: 0.063511)         elapsed: 35.87773 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-08-29T13:55:18.089740 (delta: 0.067374)         elapsed: 35.945164 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-08-29T13:55:18.159859 (delta: 0.07006)         elapsed: 36.015283 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-08-29T13:55:18.237098 (delta: 0.07715)         elapsed: 36.092522 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:78
2019-08-29T13:55:18.309001 (delta: 0.071829)         elapsed: 36.164425 ******* 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-08-29T13:55:18.548453 (delta: 0.239389)         elapsed: 36.403877 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:01.577406", "end": "2019-08-29 13:55:20.352800", "rc": 0, "start": "2019-08-29 13:55:18.775394", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-08-29T13:55:20.455826 (delta: 1.907312)         elapsed: 38.31125 ******** 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:01.376643", "end": "2019-08-29 13:55:43.590181", "rc": 0, "start": "2019-08-29 13:55:42.213538", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-08-29T13:55:43.708985 (delta: 23.253063)         elapsed: 61.564409 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:01.381344", "end": "2019-08-29 13:55:45.480260", "rc": 0, "start": "2019-08-29 13:55:44.098916", "stderr": "", "stderr_lines": [], "stdout": "pvc-1db79e75-ca64-11e9-bbac-0050569846e3", "stdout_lines": ["pvc-1db79e75-ca64-11e9-bbac-0050569846e3"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-08-29T13:55:45.627276 (delta: 1.918196)         elapsed: 63.4827 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-1db79e75-ca64-11e9-bbac-0050569846e3 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.336405", "end": "2019-08-29 13:55:47.434809", "rc": 0, "start": "2019-08-29 13:55:46.098404", "stderr": "", "stderr_lines": [], "stdout": "pvc-1db79e75-ca64-11e9-bbac-0050569846e3-target-75bd77f94fbbxps", "stdout_lines": ["pvc-1db79e75-ca64-11e9-bbac-0050569846e3-target-75bd77f94fbbxps"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-08-29T13:55:47.522818 (delta: 1.895428)         elapsed: 65.378242 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-1db79e75-ca64-11e9-bbac-0050569846e3"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-08-29T13:55:47.655549 (delta: 0.132667)         elapsed: 65.510973 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-1db79e75-ca64-11e9-bbac-0050569846e3-target-75bd77f94fbbxps -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.237100", "end": "2019-08-29 13:55:49.239546", "rc": 0, "start": "2019-08-29 13:55:48.002446", "stderr": "", "stderr_lines": [], "stdout": "node3-1558702621.mayalabs.io", "stdout_lines": ["node3-1558702621.mayalabs.io"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-08-29T13:55:49.310991 (delta: 1.655337)         elapsed: 67.166415 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n app-percona-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"node3-1558702621.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.107515", "end": "2019-08-29 13:55:50.673204", "rc": 0, "start": "2019-08-29 13:55:49.565689", "stderr": "", "stderr_lines": [], "stdout": "pumba-fktf9", "stdout_lines": ["pumba-fktf9"]}

TASK [Inject egress delay of 60000ms on cstor target for 60s] ******************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-08-29T13:55:50.785399 (delta: 1.474346)         elapsed: 68.640823 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-fktf9 -n app-percona-ns -- pumba netem --interface eth0 --duration 60s delay --time 60000 re2:k8s_cstor-istgt_pvc-1db79e75-ca64-11e9-bbac-0050569846e3", "delta": "0:01:04.677890", "end": "2019-08-29 13:56:55.810696", "rc": 0, "start": "2019-08-29 13:55:51.132806", "stderr": "time=\"2019-08-29T13:55:52Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-08-29T13:55:55Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a for 1m0s\" \ntime=\"2019-08-29T13:55:55Z\" level=info msg=\"Start netem for container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2019-08-29T13:56:55Z\" level=info msg=\"Stopping netem on container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a\" \ntime=\"2019-08-29T13:56:55Z\" level=info msg=\"Stop netem for container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a on 'eth0'\" ", "stderr_lines": ["time=\"2019-08-29T13:55:52Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-08-29T13:55:55Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a for 1m0s\" ", "time=\"2019-08-29T13:55:55Z\" level=info msg=\"Start netem for container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2019-08-29T13:56:55Z\" level=info msg=\"Stopping netem on container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a\" ", "time=\"2019-08-29T13:56:55Z\" level=info msg=\"Stop netem for container 73db4af12811085aaf8ed223b179731880249d2141b948406265fbd33b9fbf7a on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-08-29T13:56:55.953106 (delta: 65.16763)         elapsed: 133.80853 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-08-29T13:57:06.556332 (delta: 10.603101)         elapsed: 144.411756 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:01.261384", "end": "2019-08-29 13:57:08.136901", "rc": 0, "start": "2019-08-29 13:57:06.875517", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-08-29T13:57:08.249819 (delta: 1.693426)         elapsed: 146.105243 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n app-percona-ns", "delta": "0:00:01.112298", "end": "2019-08-29 13:57:09.591755", "rc": 0, "start": "2019-08-29 13:57:08.479457", "stderr": "", "stderr_lines": [], "stdout": "pumba-9d8js   0/1   Terminating   0     1m\npumba-fktf9   0/1   Terminating   0     1m\npumba-llgw2   0/1   Terminating   0     1m", "stdout_lines": ["pumba-9d8js   0/1   Terminating   0     1m", "pumba-fktf9   0/1   Terminating   0     1m", "pumba-llgw2   0/1   Terminating   0     1m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:86
2019-08-29T13:57:09.664422 (delta: 1.414539)         elapsed: 147.519846 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-08-29T13:57:09.784597 (delta: 0.120112)         elapsed: 147.640021 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.322773", "end": "2019-08-29 13:57:11.315821", "rc": 0, "start": "2019-08-29 13:57:09.993048", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-08-29T13:52:39Z]]", "stdout_lines": ["map[running:map[startedAt:2019-08-29T13:52:39Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-08-29T13:57:11.430824 (delta: 1.646157)         elapsed: 149.286248 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.216473", "end": "2019-08-29 13:57:13.011864", "rc": 0, "start": "2019-08-29 13:57:11.795391", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:95
2019-08-29T13:57:13.154763 (delta: 1.723853)         elapsed: 151.010187 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:98
2019-08-29T13:57:13.296989 (delta: 0.14211)         elapsed: 151.152413 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-08-29T13:57:13.489105 (delta: 0.192007)         elapsed: 151.344529 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-08-29T13:57:13.589061 (delta: 0.099891)         elapsed: 151.444485 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-cb697f8b4-5r4t8 -n app-percona-ns", "delta": "0:00:06.115450", "end": "2019-08-29 13:57:19.946689", "rc": 0, "start": "2019-08-29 13:57:13.831239", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-cb697f8b4-5r4t8\" deleted", "stdout_lines": ["pod \"percona-cb697f8b4-5r4t8\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-08-29T13:57:20.096147 (delta: 6.507024)         elapsed: 157.951571 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:02.226418", "end": "2019-08-29 13:57:22.576749", "rc": 0, "start": "2019-08-29 13:57:20.350331", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-772zz   1/1     Running   0          7s", "stdout_lines": ["NAME                      READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-772zz   1/1     Running   0          7s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-08-29T13:57:22.670403 (delta: 2.57414)         elapsed: 160.525827 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.247509", "end": "2019-08-29 13:57:24.144467", "rc": 0, "start": "2019-08-29 13:57:22.896958", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-772zz", "stdout_lines": ["percona-cb697f8b4-772zz"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-08-29T13:57:24.218288 (delta: 1.54782)         elapsed: 162.073712 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-772zz\")].status.phase}'", "delta": "0:00:01.122151", "end": "2019-08-29 13:57:25.551926", "rc": 0, "start": "2019-08-29 13:57:24.429775", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-08-29T13:57:25.628427 (delta: 1.410072)         elapsed: 163.483851 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-772zz\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.240648", "end": "2019-08-29 13:57:27.073394", "rc": 0, "start": "2019-08-29 13:57:25.832746", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-08-29T13:57:17Z]]", "stdout_lines": ["map[running:map[startedAt:2019-08-29T13:57:17Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-08-29T13:57:27.145815 (delta: 1.517328)         elapsed: 165.001239 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-772zz -n app-percona-ns -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:01.324372", "end": "2019-08-29 13:57:28.673327", "failed_when_result": false, "rc": 0, "start": "2019-08-29 13:57:27.348955", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-08-29T13:57:28.774478 (delta: 1.628603)         elapsed: 166.629902 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-772zz -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:01.473333", "end": "2019-08-29 13:57:30.476815", "failed_when_result": false, "rc": 0, "start": "2019-08-29 13:57:29.003482", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-08-29T13:57:30.552894 (delta: 1.778307)         elapsed: 168.408318 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-08-29T13:57:30.622235 (delta: 0.069279)         elapsed: 168.477659 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:110
2019-08-29T13:57:30.700103 (delta: 0.077788)         elapsed: 168.555527 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:121
2019-08-29T13:57:30.827663 (delta: 0.127482)         elapsed: 168.683087 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-08-29T13:57:31.008817 (delta: 0.181069)         elapsed: 168.864241 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-08-29T13:57:31.094183 (delta: 0.085307)         elapsed: 168.949607 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-08-29T13:57:31.285790 (delta: 0.191549)         elapsed: 169.141214 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-08-29T13:57:31.387799 (delta: 0.101942)         elapsed: 169.243223 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e7f0f790b1fb82156ee809c231d7445cd5cd07b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "89296e59cc89d49e5b7cbb6d0f0c8848", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1567087051.49-249252215683900/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-08-29T13:57:34.198286 (delta: 2.810388)         elapsed: 172.05371 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.967756", "end": "2019-08-29 13:57:35.368239", "rc": 0, "start": "2019-08-29 13:57:34.400483", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-08-29T13:57:35.440854 (delta: 1.242494)         elapsed: 173.296278 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.506858", "end": "2019-08-29 13:57:37.157064", "failed_when_result": false, "rc": 0, "start": "2019-08-29 13:57:35.650206", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=51   changed=33   unreachable=0    failed=0   

2019-08-29T13:57:37.216173 (delta: 1.775255)         elapsed: 175.071597 ****** 
=============================================================================== 
```