### PR TITLE
(feat)remote-templates: add gitlab template for pod-delete chaos

### DIFF
--- a/ci/gitlab/templates/pod-delete/chaosengine.yaml
+++ b/ci/gitlab/templates/pod-delete/chaosengine.yaml
@@ -1,0 +1,15 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: engine
+spec:
+  monitor: false
+  appinfo: 
+    appns: %APP_NS
+    applabel: %APP_LABEL
+    appkind: %APP_KIND
+  chaosServiceAccount: %APP_SVC_ACC
+  experiments:
+    - name: pod-delete 
+      spec:
+        components: 

--- a/ci/gitlab/templates/pod-delete/pod-failure-template.yml
+++ b/ci/gitlab/templates/pod-delete/pod-failure-template.yml
@@ -1,0 +1,15 @@
+---
+variables:
+  app_ns: percona
+  app_label: "app=percona"
+  app_kind: deployment
+  app_svc_account: default
+
+.pod_failure_template:
+  image: litmuschaos/gitlab-runner:ci
+  script:
+    - kubectl get crds | grep chaos
+    - sed -i "s|%APP_NS|$app_ns|g; s|%APP_LABEL|$app_label|g; s|%APP_KIND|$app_kind|g; s|%APP_SVC_ACC|$app_svc_account|g" /gitlab/pod-templates/chaosengine.yaml 
+    - kubectl apply -f /gitlab/pod-templates/chaosengine.yaml
+    - sleep 240 
+  


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This enables app developers to use extend ready chaos templates for their environments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
