### PR TITLE
fix[cspc-litmusbook]: Included a task to get the device count

### DIFF
--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -32,13 +32,21 @@
               loop: "{{ lookup('dict', bd_count) }}"
               when: "'{{ pool_type }}' in item.key"
 
-            # Creating the blockdevice template from blockdevice_stripe.j2 jinja template for each node
+            # Creating the blockdevice template from blockdevice.j2 jinja template for each node
             - name: Add node labels for each nodes and create blockdevice template
               template:
                 src: ./blockdevice.j2
                 dest: ./blockdevice-{{ item[0] }}.yml
               with_together:
                 - "{{ nodes.stdout_lines }}"
+
+            - name: Getting the Unclaimed block-device count
+              shell: kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n "{{ disk_count }}"
+              register: bd_count
+              with_items: "{{ nodes.stdout_lines }}"
+
+            - set_fact:
+                device_count: "{{ bd_count|length}}"
 
             - name: Add the block devices for each node's block device template
               include_tasks: add_blockdevice.yml
@@ -59,9 +67,6 @@
                   {{ lookup('file', './blockdevice-{{ item }}.yml') }}
               with_items:
                 - "{{ nodes.stdout_lines }}"
-
-            - set_fact:
-                device_count: "{{ blockDevice|length}}"              
 
             - name: Replacing the pool name in CSPC spec
               replace:


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- This PR will have the task to get the device count to check the cspc container status

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-09-04T10:52:42.395840 (delta: 0.064127)         elapsed: 0.064127 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-09-04T10:52:42.414540 (delta: 0.018649)         elapsed: 0.082827 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-09-04T10:52:52.052227 (delta: 9.637656)         elapsed: 9.720514 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-09-04T10:52:52.206954 (delta: 0.154645)         elapsed: 9.875241 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-09-04T10:52:52.296047 (delta: 0.089031)         elapsed: 9.964334 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-09-04T10:52:52.413901 (delta: 0.117789)         elapsed: 10.082188 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-04T10:52:52.681420 (delta: 0.267436)         elapsed: 10.349707 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1567594372.76-53648974586502/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-04T10:52:53.725568 (delta: 1.044097)         elapsed: 11.393855 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.975735", "end": "2019-09-04 10:52:55.254857", "rc": 0, "start": "2019-09-04 10:52:54.279122", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-04T10:52:55.332534 (delta: 1.606887)         elapsed: 13.000821 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.418685", "end": "2019-09-04 10:52:56.950040", "failed_when_result": false, "rc": 0, "start": "2019-09-04 10:52:55.531355", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-pool-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-04T10:52:57.026648 (delta: 1.69405)         elapsed: 14.694935 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-04T10:52:57.090969 (delta: 0.064238)         elapsed: 14.759256 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-04T10:52:57.151186 (delta: 0.060164)         elapsed: 14.819473 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2019-09-04T10:52:57.227255 (delta: 0.075999)         elapsed: 14.895542 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'}", "delta": "0:00:01.062890", "end": "2019-09-04 10:52:58.487829", "rc": 0, "start": "2019-09-04 10:52:57.424939", "stderr": "", "stderr_lines": [], "stdout": "node1-1558702621.mayalabs.io\nnode2-1558702621.mayalabs.io\nnode3-1558702621.mayalabs.io", "stdout_lines": ["node1-1558702621.mayalabs.io", "node2-1558702621.mayalabs.io", "node3-1558702621.mayalabs.io"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2019-09-04T10:52:58.568803 (delta: 1.341484)         elapsed: 16.23709 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:01.186516", "end": "2019-09-04 10:52:59.960000", "failed_when_result": false, "rc": 0, "start": "2019-09-04 10:52:58.773484", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2019-09-04T10:53:00.034359 (delta: 1.465419)         elapsed: 17.702646 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2019-09-04T10:53:00.234405 (delta: 0.199986)         elapsed: 17.902692 ******* 
changed: [127.0.0.1] => (item=[u'node1-1558702621.mayalabs.io']) => {"changed": true, "checksum": "af77948b482a2d8af2e2bf9956ef8f03c4baa85f", "dest": "./blockdevice-node1-1558702621.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["node1-1558702621.mayalabs.io"], "md5sum": "fdb093bae0cb0bfbe0a0aaf9d27999da", "mode": "0644", "owner": "root", "size": 387, "src": "/root/.ansible/tmp/ansible-tmp-1567594380.32-166919363158059/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'node2-1558702621.mayalabs.io']) => {"changed": true, "checksum": "5fde826441915767fe4f23ccee861c2913914217", "dest": "./blockdevice-node2-1558702621.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["node2-1558702621.mayalabs.io"], "md5sum": "7dbd0c1909558d33492d3ce7e98bb03f", "mode": "0644", "owner": "root", "size": 387, "src": "/root/.ansible/tmp/ansible-tmp-1567594380.72-266179131463823/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'node3-1558702621.mayalabs.io']) => {"changed": true, "checksum": "961fca07498507c3b598b9f45850e18df67cbedb", "dest": "./blockdevice-node3-1558702621.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["node3-1558702621.mayalabs.io"], "md5sum": "0a58e8870c92da7c1cb5128a2c87efd6", "mode": "0644", "owner": "root", "size": 387, "src": "/root/.ansible/tmp/ansible-tmp-1567594381.11-268846834920005/source", "state": "file", "uid": 0}

TASK [Getting the Unclaimed block-device from each node] ***********************
2019-09-04T10:53:01.522955 (delta: 1.288476)         elapsed: 19.191242 ******* 
changed: [127.0.0.1] => (item=node1-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.320569", "end": "2019-09-04 10:53:03.048613", "item": "node1-1558702621.mayalabs.io", "rc": 0, "start": "2019-09-04 10:53:01.728044", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0a34b0dfb0ffe3919d25483eae682a95", "stdout_lines": ["blockdevice-0a34b0dfb0ffe3919d25483eae682a95"]}
changed: [127.0.0.1] => (item=node2-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.141005", "end": "2019-09-04 10:53:04.403292", "item": "node2-1558702621.mayalabs.io", "rc": 0, "start": "2019-09-04 10:53:03.262287", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-14d6729653277c482e2172be73b3ff77", "stdout_lines": ["blockdevice-14d6729653277c482e2172be73b3ff77"]}
changed: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.296909", "end": "2019-09-04 10:53:05.882505", "item": "node3-1558702621.mayalabs.io", "rc": 0, "start": "2019-09-04 10:53:04.585596", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1e044d8f893b306e5ddbe5a098351bd9", "stdout_lines": ["blockdevice-1e044d8f893b306e5ddbe5a098351bd9"]}

TASK [Add the block devices for each node's block device template] *************
2019-09-04T10:53:05.957678 (delta: 4.434669)         elapsed: 23.625965 ******* 
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1

TASK [Getting the Unclaimed block-device from each node] ***********************
2019-09-04T10:53:06.146862 (delta: 0.189126)         elapsed: 23.815149 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node1-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.348215", "end": "2019-09-04 10:53:07.726389", "rc": 0, "start": "2019-09-04 10:53:06.378174", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0a34b0dfb0ffe3919d25483eae682a95", "stdout_lines": ["blockdevice-0a34b0dfb0ffe3919d25483eae682a95"]}

TASK [set_fact] ****************************************************************
2019-09-04T10:53:07.853747 (delta: 1.70683)         elapsed: 25.522034 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "11"}, "changed": false}

TASK [Add the block devices] ***************************************************
2019-09-04T10:53:08.066848 (delta: 0.212978)         elapsed: 25.735135 ******* 
changed: [127.0.0.1] => (item=blockdevice-0a34b0dfb0ffe3919d25483eae682a95) => {"backup": "", "changed": true, "item": "blockdevice-0a34b0dfb0ffe3919d25483eae682a95", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2019-09-04T10:53:08.641706 (delta: 0.574783)         elapsed: 26.309993 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node2-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.264545", "end": "2019-09-04 10:53:10.174273", "rc": 0, "start": "2019-09-04 10:53:08.909728", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-14d6729653277c482e2172be73b3ff77", "stdout_lines": ["blockdevice-14d6729653277c482e2172be73b3ff77"]}

TASK [set_fact] ****************************************************************
2019-09-04T10:53:10.288292 (delta: 1.646523)         elapsed: 27.956579 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "11"}, "changed": false}

TASK [Add the block devices] ***************************************************
2019-09-04T10:53:10.474886 (delta: 0.186514)         elapsed: 28.143173 ******* 
changed: [127.0.0.1] => (item=blockdevice-14d6729653277c482e2172be73b3ff77) => {"backup": "", "changed": true, "item": "blockdevice-14d6729653277c482e2172be73b3ff77", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2019-09-04T10:53:10.811555 (delta: 0.336602)         elapsed: 28.479842 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=node3-1558702621.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.382738", "end": "2019-09-04 10:53:12.587055", "rc": 0, "start": "2019-09-04 10:53:11.204317", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1e044d8f893b306e5ddbe5a098351bd9", "stdout_lines": ["blockdevice-1e044d8f893b306e5ddbe5a098351bd9"]}

TASK [set_fact] ****************************************************************
2019-09-04T10:53:12.684862 (delta: 1.873202)         elapsed: 30.353149 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "11"}, "changed": false}

TASK [Add the block devices] ***************************************************
2019-09-04T10:53:12.899732 (delta: 0.214778)         elapsed: 30.568019 ******* 
changed: [127.0.0.1] => (item=blockdevice-1e044d8f893b306e5ddbe5a098351bd9) => {"backup": "", "changed": true, "item": "blockdevice-1e044d8f893b306e5ddbe5a098351bd9", "msg": "line added"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2019-09-04T10:53:13.292955 (delta: 0.393127)         elapsed: 30.961242 ******* 
changed: [127.0.0.1] => (item=node1-1558702621.mayalabs.io) => {"changed": true, "item": "node1-1558702621.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=node2-1558702621.mayalabs.io) => {"changed": true, "item": "node2-1558702621.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=node3-1558702621.mayalabs.io) => {"changed": true, "item": "node3-1558702621.mayalabs.io", "msg": "Block inserted"}

TASK [set_fact] ****************************************************************
2019-09-04T10:53:14.355311 (delta: 1.062298)         elapsed: 32.023598 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in CSPC spec] ************************************
2019-09-04T10:53:14.650281 (delta: 0.29488)         elapsed: 32.318568 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replacing the pool group id in CSPC spec] ********************************
2019-09-04T10:53:15.270704 (delta: 0.62029)         elapsed: 32.938991 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the storage class name in CSPC spec] ***************************
2019-09-04T10:53:15.625600 (delta: 0.354789)         elapsed: 33.293887 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Replacing the namespace in CSPC spec] ************************************
2019-09-04T10:53:16.035662 (delta: 0.409998)         elapsed: 33.703949 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the pool type in CSPC spec] ************************************
2019-09-04T10:53:16.371548 (delta: 0.335826)         elapsed: 34.039835 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "6 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2019-09-04T10:53:16.726274 (delta: 0.354647)         elapsed: 34.394561 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: CStorPoolCluster
metadata:
  name: cstor-cspc-disk-pool
  namespace: openebs
spec:
  pools:
## node3-1558702621.mayalabs.io Ansible Config ##
    - nodeSelector:
        kubernetes.io/hostname: node3-1558702621.mayalabs.io
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-1e044d8f893b306e5ddbe5a098351bd9
        type: stripe
        name: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
## node3-1558702621.mayalabs.io Ansible Config ##
## node2-1558702621.mayalabs.io Ansible Config ##
    - nodeSelector:
        kubernetes.io/hostname: node2-1558702621.mayalabs.io
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-14d6729653277c482e2172be73b3ff77
        type: stripe
        name: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
## node2-1558702621.mayalabs.io Ansible Config ##
## node1-1558702621.mayalabs.io Ansible Config ##
    - nodeSelector:
        kubernetes.io/hostname: node1-1558702621.mayalabs.io
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-0a34b0dfb0ffe3919d25483eae682a95
        type: stripe
        name: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
## node1-1558702621.mayalabs.io Ansible Config ##

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: sc-name
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-cspc-disk-pool
      - name: ReplicaCount
        value: "3"
#      - name: VolumeControllerImage
#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}
#      - name: VolumeTargetImage
#        value: openebs/cstor-istgt:{{ cstor_image }}
#      - name: VolumeMonitorImage
#        value: openebs/m-exporter:{{ cstor_image }}
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: CStorPoolCluster\nmetadata:\n  name: cstor-cspc-disk-pool\n  namespace: openebs\nspec:\n  pools:\n## node3-1558702621.mayalabs.io Ansible Config ##\n    - nodeSelector:\n        kubernetes.io/hostname: node3-1558702621.mayalabs.io\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-1e044d8f893b306e5ddbe5a098351bd9\n        type: stripe\n        name: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n## node3-1558702621.mayalabs.io Ansible Config ##\n## node2-1558702621.mayalabs.io Ansible Config ##\n    - nodeSelector:\n        kubernetes.io/hostname: node2-1558702621.mayalabs.io\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-14d6729653277c482e2172be73b3ff77\n        type: stripe\n        name: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n## node2-1558702621.mayalabs.io Ansible Config ##\n## node1-1558702621.mayalabs.io Ansible Config ##\n    - nodeSelector:\n        kubernetes.io/hostname: node1-1558702621.mayalabs.io\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-0a34b0dfb0ffe3919d25483eae682a95\n        type: stripe\n        name: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n## node1-1558702621.mayalabs.io Ansible Config ##\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: sc-name\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-cspc-disk-pool\n      - name: ReplicaCount\n        value: \"3\"\n#      - name: VolumeControllerImage\n#        value: openebs/cstor-volume-mgmt:{{ cstor_image }}\n#      - name: VolumeTargetImage\n#        value: openebs/cstor-istgt:{{ cstor_image }}\n#      - name: VolumeMonitorImage\n#        value: openebs/m-exporter:{{ cstor_image }}\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2019-09-04T10:53:16.903343 (delta: 0.176997)         elapsed: 34.57163 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc.yml", "delta": "0:00:01.511166", "end": "2019-09-04 10:53:18.813872", "rc": 0, "start": "2019-09-04 10:53:17.302706", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor-cspc-disk-pool created\nstorageclass.storage.k8s.io/sc-name unchanged", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor-cspc-disk-pool created", "storageclass.storage.k8s.io/sc-name unchanged"]}

TASK [Check whether cspc is created] *******************************************
2019-09-04T10:53:18.947033 (delta: 2.04361)         elapsed: 36.61532 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspc -n openebs -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.277937", "end": "2019-09-04 10:53:20.723902", "rc": 0, "start": "2019-09-04 10:53:19.445965", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool", "stdout_lines": ["cstor-cspc-disk-pool"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2019-09-04T10:53:20.865400 (delta: 1.918264)         elapsed: 38.533687 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.365518", "end": "2019-09-04 10:53:22.680542", "rc": 0, "start": "2019-09-04 10:53:21.315024", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-br6t\ncstor-cspc-disk-pool-rsn4\ncstor-cspc-disk-pool-rzgk", "stdout_lines": ["cstor-cspc-disk-pool-br6t", "cstor-cspc-disk-pool-rsn4", "cstor-cspc-disk-pool-rzgk"]}

TASK [Verify the status of CSPI] ***********************************************
2019-09-04T10:53:22.764833 (delta: 1.899332)         elapsed: 40.43312 ******** 
FAILED - RETRYING: Verify the status of CSPI (30 retries left).
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-br6t) => {"attempts": 2, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-br6t\")].status.phase}'", "delta": "0:00:01.198336", "end": "2019-09-04 10:53:30.885362", "item": "cstor-cspc-disk-pool-br6t", "rc": 0, "start": "2019-09-04 10:53:29.687026", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rsn4) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-rsn4\")].status.phase}'", "delta": "0:00:01.241064", "end": "2019-09-04 10:53:32.411274", "item": "cstor-cspc-disk-pool-rsn4", "rc": 0, "start": "2019-09-04 10:53:31.170210", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rzgk) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-rzgk\")].status.phase}'", "delta": "0:00:01.315797", "end": "2019-09-04 10:53:34.106405", "item": "cstor-cspc-disk-pool-rzgk", "rc": 0, "start": "2019-09-04 10:53:32.790608", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify if cStor Pool are Running] ****************************************
2019-09-04T10:53:34.206564 (delta: 11.441655)         elapsed: 51.874851 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-br6t) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-br6t --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.278725", "end": "2019-09-04 10:53:35.939706", "item": "cstor-cspc-disk-pool-br6t", "rc": 0, "start": "2019-09-04 10:53:34.660981", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rsn4) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-rsn4 --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.396567", "end": "2019-09-04 10:53:37.695951", "item": "cstor-cspc-disk-pool-rsn4", "rc": 0, "start": "2019-09-04 10:53:36.299384", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rzgk) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-rzgk --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.265270", "end": "2019-09-04 10:53:39.318652", "item": "cstor-cspc-disk-pool-rzgk", "rc": 0, "start": "2019-09-04 10:53:38.053382", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get cStor Pool names to verify the container statuses] *******************
2019-09-04T10:53:39.461977 (delta: 5.255307)         elapsed: 57.130264 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.216599", "end": "2019-09-04 10:53:41.032870", "rc": 0, "start": "2019-09-04 10:53:39.816271", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-br6t-754885b597-z8zsl\ncstor-cspc-disk-pool-rsn4-7f997df5dc-cwq7s\ncstor-cspc-disk-pool-rzgk-78477cb654-bwq9f", "stdout_lines": ["cstor-cspc-disk-pool-br6t-754885b597-z8zsl", "cstor-cspc-disk-pool-rsn4-7f997df5dc-cwq7s", "cstor-cspc-disk-pool-rzgk-78477cb654-bwq9f"]}

TASK [Get the runningStatus of pool pod] ***************************************
2019-09-04T10:53:41.145758 (delta: 1.68369)         elapsed: 58.814045 ******** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-br6t-754885b597-z8zsl) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-br6t-754885b597-z8zsl -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.447115", "end": "2019-09-04 10:53:42.906877", "item": "cstor-cspc-disk-pool-br6t-754885b597-z8zsl", "rc": 0, "start": "2019-09-04 10:53:41.459762", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rsn4-7f997df5dc-cwq7s) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-rsn4-7f997df5dc-cwq7s -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.272685", "end": "2019-09-04 10:53:44.485129", "item": "cstor-cspc-disk-pool-rsn4-7f997df5dc-cwq7s", "rc": 0, "start": "2019-09-04 10:53:43.212444", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-rzgk-78477cb654-bwq9f) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-rzgk-78477cb654-bwq9f -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.265179", "end": "2019-09-04 10:53:46.046407", "item": "cstor-cspc-disk-pool-rzgk-78477cb654-bwq9f", "rc": 0, "start": "2019-09-04 10:53:44.781228", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Remove the CStor Pool Cluster] *******************************************
2019-09-04T10:53:46.195669 (delta: 5.049822)         elapsed: 63.863956 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CStor Pool Cluster is deleted] *****************************
2019-09-04T10:53:46.425507 (delta: 0.229699)         elapsed: 64.093794 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CSPI is getting removed] ***********************************
2019-09-04T10:53:46.513264 (delta: 0.087584)         elapsed: 64.181551 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor pool pods are deleted] *******************************
2019-09-04T10:53:46.592086 (delta: 0.07875)         elapsed: 64.260373 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-09-04T10:53:46.676516 (delta: 0.084366)         elapsed: 64.344803 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-09-04T10:53:46.812312 (delta: 0.135724)         elapsed: 64.480599 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-04T10:53:47.038626 (delta: 0.226231)         elapsed: 64.706913 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-04T10:53:47.108775 (delta: 0.070047)         elapsed: 64.777062 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-04T10:53:47.174925 (delta: 0.06609)         elapsed: 64.843212 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-04T10:53:47.263676 (delta: 0.088686)         elapsed: 64.931963 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "501786648ab66e7fc2a021e95e8fcc53f8ff4f77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "23c79b43245ac077305a179ea8f3e971", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1567594427.35-206552668704427/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-04T10:53:49.874609 (delta: 2.610844)         elapsed: 67.542896 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.970377", "end": "2019-09-04 10:53:51.130704", "rc": 0, "start": "2019-09-04 10:53:50.160327", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-04T10:53:51.217190 (delta: 1.342483)         elapsed: 68.885477 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.709630", "end": "2019-09-04 10:53:53.235132", "failed_when_result": false, "rc": 0, "start": "2019-09-04 10:53:51.525502", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-pool-provision configured", "stdout_lines": ["litmusresult.litmus.io/cstor-pool-provision configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=43   changed=28   unreachable=0    failed=0   

2019-09-04T10:53:53.282629 (delta: 2.065335)         elapsed: 70.950916 ******* 
=============================================================================== 
```
