### PR TITLE
refactor[litmusbook]: include data consistency checks in target-failure scenario

### DIFF
--- a/experiments/chaos/openebs_target_failure/data_persistence.j2
+++ b/experiments/chaos/openebs_target_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: target-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,8 +49,8 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
-          - name: DATA_PERSISTENCY
-            value: ""            
+          - name: DATA_PERSISTENCE
+            value: "" 
 
             # CHOS_TYPE values :  target-zrepl-kill , target-kill , target-delete 
           - name: CHAOS_TYPE
@@ -58,3 +67,10 @@ spec:
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_target_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: target-failure

--- a/experiments/chaos/openebs_target_failure/test.yml
+++ b/experiments/chaos/openebs_target_failure/test.yml
@@ -4,6 +4,7 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
@@ -13,13 +14,21 @@
           when: liveness_label != ''
 
         - include: test_prerequisites.yml
-  
+
+        - include_vars:
+            file: data_persistence.yml
+
         - include_vars:
             file: chaosutil.yml
 
         - name: Record the chaos util path
           set_fact: 
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - include_tasks: /utils/fcm/create_testname.yml
@@ -60,17 +69,13 @@
             executable: /bin/bash
           register: app_pod_name    
 
-        - name: Create some test data in the mysql database
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Create some test data
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'LOAD'
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb' 
-          when: data_persistance != ''     
-
+          when: data_persistence != ''
 
         ## STORAGE FAULT INJECTION 
 
@@ -94,7 +99,6 @@
             delay: 5
             retries: 60        
 
-
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
@@ -107,16 +111,13 @@
             executable: /bin/bash
           register: rescheduled_app_pod  
 
-        - name: Verify mysql data persistence  
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
-            pod_name: "{{ rescheduled_app_pod.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb' 
-          when: data_persistance != ''       
+            pod_name: "{{ rescheduled_app_pod.stdout }}"                 
+          when: data_persistence != ''
 
         ## Check application-target pod affinity
         - include_tasks: /utils/scm/openebs/target_affinity_check.yml

--- a/experiments/chaos/openebs_target_failure/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_failure/test_prerequisites.yml
@@ -50,3 +50,8 @@
     src: chaosutil.j2
     dest: chaosutil.yml
 
+- name: Identify the data consistency util to be invoked
+  template:
+    src: data_persistence.j2
+    dest: data_persistence.yml
+    

--- a/experiments/chaos/openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/openebs_target_failure/test_vars.yml
@@ -13,7 +13,7 @@ label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 chaos_type: "{{ lookup('env','CHAOS_TYPE') }}"
 target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
 chaos_duration: 360

--- a/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/experiments/chaos/openebs_target_network_delay/test.yml
@@ -72,7 +72,6 @@
             dbname: 'tdb'   
           when: data_persistance != ''    
 
-
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
@@ -105,7 +104,6 @@
             dbpassword: 'k8sDem0'
             dbname: 'tdb'
           when: data_persistance != ''      
-
           
         - set_fact:
             flag: "Pass"

--- a/utils/scm/applications/busybox/busybox_data_persistence.yml
+++ b/utils/scm/applications/busybox/busybox_data_persistence.yml
@@ -4,14 +4,14 @@
    - name: Create some test data in the busybox app
      shell: >
        kubectl exec {{ pod_name }} -n {{ ns }} 
-       -- {{ item }}
+       -- sh -c "{{ item }}"
      args:
        executable: /bin/bash
      register: result
      failed_when: "result.rc != 0"
      with_items:
-       - dd if=/dev/urandom of={{ testfile }} bs={{ blocksize }} count={{ blockcount }} 
-       - md5sum {{ testfile }} > {{ testfile }}-pre-chaos-md5
+       - "dd if=/dev/urandom of=/busybox/{{ testfile }} bs={{ blocksize }} count={{ blockcount }}"
+       - "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-pre-chaos-md5"
 
   when: status == "LOAD"
 
@@ -60,16 +60,16 @@
    - name: Check the md5sum of stored data file
      shell: >
        kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
-       --  md5sum {{ testfile }} > {{ testfile }}-post-chaos-md5
+       -- sh -c "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-post-chaos-md5"
      args:
        executable: /bin/bash
      register: status 
-     failed_when: "'OK' not in status.stdout"
+     failed_when: "status.rc != 0"
 
    - name: Verify whether data is consistent
      shell: >
            kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
-           -- diff {{ testfile }}-pre-chaos-md5 {{ testfile }}-post-chaos-md5
+           -- sh -c "diff /busybox/{{ testfile }}-pre-chaos-md5 /busybox/{{ testfile }}-post-chaos-md5"
      args:
        executable: /bin/bash
      register: result 
@@ -89,7 +89,7 @@
    - name: Delete/drop the files 
      shell: > 
        kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
-       -- rm -f {{ testfile }}*
+       -- sh -c "rm -f /busybox/{{ testfile }}*"
      args:
        executable: /bin/bash
      register: status 
@@ -97,7 +97,7 @@
    - name: Verify successful file delete 
      shell: > 
            kubectl exec {{ newpod_name.stdout }} -n {{ ns }}
-           -- ls
+           -- ls /busybox/
      args:
        executable: /bin/bash
      register: result 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a jinja template to get the data consistency util for based on the application
- Modified busybox-data-persistence util
- In case of busybox application, the configmap values will be
    ```
        parameters.yml: |
          blocksize: 4k
          blockcount: 1024
          testfile: difiletest
    ```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_failure/test.yml

PLAY [localhost] ***************************************************************
2019-09-04T16:11:56.390897 (delta: 0.062956)         elapsed: 0.062956 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:2
2019-09-04T16:11:56.408112 (delta: 0.017165)         elapsed: 0.080171 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:13
2019-09-04T16:12:05.956256 (delta: 9.54812)         elapsed: 9.628315 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:2
2019-09-04T16:12:06.032136 (delta: 0.075835)         elapsed: 9.704195 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.376283", "end": "2019-09-04 16:12:07.941800", "rc": 0, "start": "2019-09-04 16:12:06.565517", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:10
2019-09-04T16:12:08.065054 (delta: 2.032835)         elapsed: 11.737113 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.239447", "end": "2019-09-04 16:12:09.580002", "rc": 0, "start": "2019-09-04 16:12:08.340555", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:18
2019-09-04T16:12:09.667661 (delta: 1.602417)         elapsed: 13.33972 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:22
2019-09-04T16:12:09.833913 (delta: 0.166173)         elapsed: 13.505972 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:27
2019-09-04T16:12:10.025246 (delta: 0.191202)         elapsed: 13.697305 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.378875", "end": "2019-09-04 16:12:11.727019", "rc": 0, "start": "2019-09-04 16:12:10.348144", "stderr": "", "stderr_lines": [], "stdout": "pvc-faee26f2-cf20-11e9-afac-005056985c20", "stdout_lines": ["pvc-faee26f2-cf20-11e9-afac-005056985c20"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:35
2019-09-04T16:12:11.826070 (delta: 1.80077)         elapsed: 15.498129 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-faee26f2-cf20-11e9-afac-005056985c20 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.294376", "end": "2019-09-04 16:12:13.572057", "rc": 0, "start": "2019-09-04 16:12:12.277681", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:43
2019-09-04T16:12:13.647986 (delta: 1.821787)         elapsed: 17.320045 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:48
2019-09-04T16:12:13.781099 (delta: 0.132996)         elapsed: 17.453158 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "75caae513fb8040b9a471456809a572f8f53fd14", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "04d579e9ac54a8a2eac3266cb21f5c9b", "mode": "0644", "owner": "root", "size": 70, "src": "/root/.ansible/tmp/ansible-tmp-1567613533.87-43191930565117/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:53
2019-09-04T16:12:14.819742 (delta: 1.038561)         elapsed: 18.491801 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1567613534.91-154322446070899/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:18
2019-09-04T16:12:15.407835 (delta: 0.588008)         elapsed: 19.079894 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:21
2019-09-04T16:12:15.504942 (delta: 0.097046)         elapsed: 19.177001 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_container_kill.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:24
2019-09-04T16:12:15.642799 (delta: 0.137794)         elapsed: 19.314858 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_container_kill.yml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_failure/test.yml:28
2019-09-04T16:12:15.767041 (delta: 0.124166)         elapsed: 19.4391 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:34
2019-09-04T16:12:15.927524 (delta: 0.160372)         elapsed: 19.599583 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-04T16:12:16.076126 (delta: 0.148481)         elapsed: 19.748185 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-04T16:12:16.202402 (delta: 0.126196)         elapsed: 19.874461 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:36
2019-09-04T16:12:16.333016 (delta: 0.130534)         elapsed: 20.005075 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-04T16:12:16.534181 (delta: 0.201038)         elapsed: 20.20624 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "fcf16f3a460fff9d12212bc22032c93546eff753", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "011dcf638c469f0cb145e5bca99d8413", "mode": "0644", "owner": "root", "size": 458, "src": "/root/.ansible/tmp/ansible-tmp-1567613536.6-87608236883283/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-04T16:12:17.084631 (delta: 0.550398)         elapsed: 20.75669 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.019049", "end": "2019-09-04 16:12:18.366283", "rc": 0, "start": "2019-09-04 16:12:17.347234", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_container_kill \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_container_kill ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-04T16:12:18.438474 (delta: 1.353787)         elapsed: 22.110533 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.565789", "end": "2019-09-04 16:12:20.327944", "failed_when_result": false, "rc": 0, "start": "2019-09-04 16:12:18.762155", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-04T16:12:20.414720 (delta: 1.976162)         elapsed: 24.086779 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-04T16:12:20.505570 (delta: 0.090725)         elapsed: 24.177629 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-04T16:12:20.613063 (delta: 0.107415)         elapsed: 24.285122 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_failure/test.yml:43
2019-09-04T16:12:20.754626 (delta: 0.141432)         elapsed: 24.426685 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace           : app-busybox-ns", 
        "Target Namespace    : openebs", 
        "Label               : app=busybox-sts", 
        "PVC                 : openebs-busybox", 
        "StorageClass        : openebs-cstor-disk"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_failure/test.yml:55
2019-09-04T16:12:20.940993 (delta: 0.186264)         elapsed: 24.613052 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-04T16:12:21.047365 (delta: 0.106317)         elapsed: 24.719424 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.319915", "end": "2019-09-04 16:12:22.625370", "rc": 0, "start": "2019-09-04 16:12:21.305455", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-04T16:05:38Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-04T16:05:38Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-04T16:12:22.776236 (delta: 1.728795)         elapsed: 26.448295 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.328081", "end": "2019-09-04 16:12:24.406312", "rc": 0, "start": "2019-09-04 16:12:23.078231", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:64
2019-09-04T16:12:24.532005 (delta: 1.755683)         elapsed: 28.204064 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.215976", "end": "2019-09-04 16:12:25.998905", "rc": 0, "start": "2019-09-04 16:12:24.782929", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-54fjt", "stdout_lines": ["app-busybox-546d66979-54fjt"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_target_failure/test.yml:83
2019-09-04T16:12:26.139067 (delta: 1.606962)         elapsed: 29.811126 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-04T16:12:26.440854 (delta: 0.301612)         elapsed: 30.112913 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-54fjt -n app-busybox-ns -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:01.523890", "end": "2019-09-04 16:12:28.320539", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-09-04 16:12:26.796649", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.068517 seconds, 58.4MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.068517 seconds, 58.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-54fjt -n app-busybox-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:01.406881", "end": "2019-09-04 16:12:30.180052", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-09-04 16:12:28.773171", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-04T16:12:30.318479 (delta: 3.877573)         elapsed: 33.990538 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-04T16:12:30.454255 (delta: 0.13568)         elapsed: 34.126314 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-04T16:12:30.592627 (delta: 0.138264)         elapsed: 34.264686 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-04T16:12:30.744974 (delta: 0.152197)         elapsed: 34.417033 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-04T16:12:30.873253 (delta: 0.12812)         elapsed: 34.545312 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-04T16:12:30.995049 (delta: 0.121698)         elapsed: 34.667108 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-04T16:12:31.104556 (delta: 0.10933)         elapsed: 34.776615 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-04T16:12:31.235838 (delta: 0.131187)         elapsed: 34.907897 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-04T16:12:31.346632 (delta: 0.110699)         elapsed: 35.018691 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-04T16:12:31.465505 (delta: 0.11878)         elapsed: 35.137564 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:93
2019-09-04T16:12:31.590883 (delta: 0.125285)         elapsed: 35.262942 ******* 
included: /chaoslib/openebs/cstor_target_container_kill.yml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:1
2019-09-04T16:12:31.756599 (delta: 0.165605)         elapsed: 35.428658 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.161705", "end": "2019-09-04 16:12:33.170326", "rc": 0, "start": "2019-09-04 16:12:32.008621", "stderr": "", "stderr_lines": [], "stdout": "pvc-faee26f2-cf20-11e9-afac-005056985c20", "stdout_lines": ["pvc-faee26f2-cf20-11e9-afac-005056985c20"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:10
2019-09-04T16:12:33.247793 (delta: 1.491143)         elapsed: 36.919852 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-faee26f2-cf20-11e9-afac-005056985c20 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.265465", "end": "2019-09-04 16:12:34.892699", "rc": 0, "start": "2019-09-04 16:12:33.627234", "stderr": "", "stderr_lines": [], "stdout": "pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq", "stdout_lines": ["pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq"]}

TASK [Get the restartCount of cstor-istgt container] ***************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:19
2019-09-04T16:12:34.986929 (delta: 1.739074)         elapsed: 38.658988 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==''\"cstor-volume-mgmt\"'')].restartCount}'", "delta": "0:00:01.284785", "end": "2019-09-04 16:12:36.545388", "rc": 0, "start": "2019-09-04 16:12:35.260603", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [include_tasks] ***********************************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:27
2019-09-04T16:12:36.637956 (delta: 1.650943)         elapsed: 40.310015 ******* 
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:4
2019-09-04T16:12:36.926216 (delta: 0.28819)         elapsed: 40.598275 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:01.408308", "end": "2019-09-04 16:12:38.640706", "rc": 0, "start": "2019-09-04 16:12:37.232398", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba unchanged", "stdout_lines": ["daemonset.extensions/pumba unchanged"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:13
2019-09-04T16:12:38.719472 (delta: 1.793201)         elapsed: 42.391531 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:01.410046", "end": "2019-09-04 16:12:40.359896", "rc": 0, "start": "2019-09-04 16:12:38.949850", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Select the app pod] ******************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:27
2019-09-04T16:12:40.499852 (delta: 1.780307)         elapsed: 44.171911 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36
2019-09-04T16:12:40.655675 (delta: 0.155688)         elapsed: 44.327734 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record application pod name] *********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43
2019-09-04T16:12:40.732901 (delta: 0.077145)         elapsed: 44.40496 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_pod_ut": "pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq"}, "changed": false}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49
2019-09-04T16:12:40.853274 (delta: 0.120312)         elapsed: 44.525333 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.234318", "end": "2019-09-04 16:12:42.301292", "rc": 0, "start": "2019-09-04 16:12:41.066974", "stderr": "", "stderr_lines": [], "stdout": "node1-1552853078.mayalabs.io", "stdout_lines": ["node1-1552853078.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:57
2019-09-04T16:12:42.377028 (delta: 1.523697)         elapsed: 46.049087 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "node1-1552853078.mayalabs.io"}, "changed": false}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:63
2019-09-04T16:12:42.538209 (delta: 0.161096)         elapsed: 46.210268 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:70
2019-09-04T16:12:42.683778 (delta: 0.145491)         elapsed: 46.355837 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:76
2019-09-04T16:12:42.841110 (delta: 0.157198)         elapsed: 46.513169 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep node1-1552853078.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.132081", "end": "2019-09-04 16:12:44.370480", "rc": 0, "start": "2019-09-04 16:12:43.238399", "stderr": "", "stderr_lines": [], "stdout": "pumba-bgpxv", "stdout_lines": ["pumba-bgpxv"]}

TASK [Record restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:85
2019-09-04T16:12:44.488611 (delta: 1.647398)         elapsed: 48.16067 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-volume-mgmt\")].restartCount}'", "delta": "0:00:01.339318", "end": "2019-09-04 16:12:46.173328", "rc": 0, "start": "2019-09-04 16:12:44.834010", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:93
2019-09-04T16:12:46.265877 (delta: 1.777171)         elapsed: 49.937936 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-bgpxv -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-volume-mgmt_;", "delta": "0:00:03.102815", "end": "2019-09-04 16:12:49.721560", "rc": 0, "start": "2019-09-04 16:12:46.618745", "stderr": "time=\"2019-09-04T16:12:48Z\" level=info msg=\"Kill containers\" \ntime=\"2019-09-04T16:12:49Z\" level=info msg=\"Killing /k8s_cstor-volume-mgmt_pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq_openebs_fb3d27c7-cf20-11e9-afac-005056985c20_2 (115c04ef875b122f6ea9992a3907c1179d4402186f8e52720a89cbee1d713303) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-09-04T16:12:48Z\" level=info msg=\"Kill containers\" ", "time=\"2019-09-04T16:12:49Z\" level=info msg=\"Killing /k8s_cstor-volume-mgmt_pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq_openebs_fb3d27c7-cf20-11e9-afac-005056985c20_2 (115c04ef875b122f6ea9992a3907c1179d4402186f8e52720a89cbee1d713303) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}

TASK [Verify restartCount] *****************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:102
2019-09-04T16:12:49.806134 (delta: 3.540181)         elapsed: 53.478193 ******* 
FAILED - RETRYING: Verify restartCount (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-volume-mgmt\")].restartCount}'", "delta": "0:00:01.322115", "end": "2019-09-04 16:12:55.070742", "rc": 0, "start": "2019-09-04 16:12:53.748627", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if pumba is indeed running] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:117
2019-09-04T16:12:55.169669 (delta: 5.363479)         elapsed: 58.841728 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:132
2019-09-04T16:12:55.298662 (delta: 0.128899)         elapsed: 58.970721 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:139
2019-09-04T16:12:55.410373 (delta: 0.111612)         elapsed: 59.082432 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for target pod in running state] ***********************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:34
2019-09-04T16:12:55.524847 (delta: 0.114377)         elapsed: 59.196906 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:01.301925", "end": "2019-09-04 16:12:57.109309", "rc": 0, "start": "2019-09-04 16:12:55.807384", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Get the runningStatus of target pod] *************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:45
2019-09-04T16:12:57.255834 (delta: 1.730881)         elapsed: 60.927893 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.360693", "end": "2019-09-04 16:12:58.905742", "rc": 0, "start": "2019-09-04 16:12:57.545049", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the restartCount of cstor-istgt container] ***************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:57
2019-09-04T16:12:59.000156 (delta: 1.744229)         elapsed: 62.672215 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-faee26f2-cf20-11e9-afac-005056985c20-target-b8d9964d9-hfntq -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==''\"cstor-volume-mgmt\"'')].restartCount}'", "delta": "0:00:01.361902", "end": "2019-09-04 16:13:00.683294", "rc": 0, "start": "2019-09-04 16:12:59.321392", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Compare restartCounts] ***************************************************
task path: /chaoslib/openebs/cstor_target_container_kill.yml:65
2019-09-04T16:13:00.784165 (delta: 1.783939)         elapsed: 64.456224 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "Verified pool pods were restarted by fault injection", 
        "Before: 2", 
        "After: 3"
    ]
}

TASK [Wait (soak) for I/O on pools] ********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:100
2019-09-04T16:13:00.945450 (delta: 0.161181)         elapsed: 64.617509 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 360, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_failure/test.yml:104
2019-09-04T16:19:01.683294 (delta: 360.737789)         elapsed: 425.355353 **** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-04T16:19:01.800509 (delta: 0.117154)         elapsed: 425.472568 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.226330", "end": "2019-09-04 16:19:03.257188", "rc": 0, "start": "2019-09-04 16:19:02.030858", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-04T16:05:38Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-04T16:05:38Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-04T16:19:03.340323 (delta: 1.539748)         elapsed: 427.012382 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.294912", "end": "2019-09-04 16:19:04.888655", "rc": 0, "start": "2019-09-04 16:19:03.593743", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:114
2019-09-04T16:19:04.969529 (delta: 1.629131)         elapsed: 428.641588 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:117
2019-09-04T16:19:05.038620 (delta: 0.069012)         elapsed: 428.710679 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.271077", "end": "2019-09-04 16:19:06.542802", "rc": 0, "start": "2019-09-04 16:19:05.271725", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-54fjt", "stdout_lines": ["app-busybox-546d66979-54fjt"]}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:125
2019-09-04T16:19:06.638449 (delta: 1.59977)         elapsed: 430.310508 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-04T16:19:06.937555 (delta: 0.299032)         elapsed: 430.609614 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-04T16:19:07.025973 (delta: 0.088365)         elapsed: 430.698032 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-546d66979-54fjt -n app-busybox-ns", "delta": "0:00:39.897032", "end": "2019-09-04 16:19:47.210422", "rc": 0, "start": "2019-09-04 16:19:07.313390", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-546d66979-54fjt\" deleted", "stdout_lines": ["pod \"app-busybox-546d66979-54fjt\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-04T16:19:47.334937 (delta: 40.308908)         elapsed: 471.006996 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns", "delta": "0:00:01.323254", "end": "2019-09-04 16:19:49.111470", "rc": 0, "start": "2019-09-04 16:19:47.788216", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS    RESTARTS   AGE\napp-busybox-546d66979-w7z5d   1/1     Running   0          41s", "stdout_lines": ["NAME                          READY   STATUS    RESTARTS   AGE", "app-busybox-546d66979-w7z5d   1/1     Running   0          41s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-04T16:19:49.226436 (delta: 1.891371)         elapsed: 472.898495 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.523645", "end": "2019-09-04 16:19:51.151392", "rc": 0, "start": "2019-09-04 16:19:49.627747", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-w7z5d", "stdout_lines": ["app-busybox-546d66979-w7z5d"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-04T16:19:51.221405 (delta: 1.994873)         elapsed: 474.893464 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-w7z5d\")].status.phase}'", "delta": "0:00:01.097123", "end": "2019-09-04 16:19:52.563797", "rc": 0, "start": "2019-09-04 16:19:51.466674", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-04T16:19:52.714012 (delta: 1.492527)         elapsed: 476.386071 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-w7z5d\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.302378", "end": "2019-09-04 16:19:54.306413", "rc": 0, "start": "2019-09-04 16:19:53.004035", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-04T16:19:11Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-04T16:19:11Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-04T16:19:54.415746 (delta: 1.701602)         elapsed: 478.087805 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-w7z5d -n app-busybox-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.704520", "end": "2019-09-04 16:19:56.399870", "failed_when_result": false, "rc": 0, "start": "2019-09-04 16:19:54.695350", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-04T16:19:56.550656 (delta: 2.134828)         elapsed: 480.222715 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-w7z5d -n app-busybox-ns -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.636791", "end": "2019-09-04 16:19:58.471984", "failed_when_result": false, "rc": 0, "start": "2019-09-04 16:19:56.835193", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-04T16:19:58.592065 (delta: 2.041277)         elapsed: 482.264124 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-04T16:19:58.727226 (delta: 0.13499)         elapsed: 482.399285 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-04T16:19:58.877304 (delta: 0.149967)         elapsed: 482.549363 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:145
2019-09-04T16:19:58.965908 (delta: 0.088465)         elapsed: 482.637967 ****** 
included: /utils/scm/openebs/target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
task path: /utils/scm/openebs/target_affinity_check.yml:1
2019-09-04T16:19:59.189435 (delta: 0.223448)         elapsed: 482.861494 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=busybox-sts -n app-busybox-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:02.450209", "end": "2019-09-04 16:20:01.871009", "rc": 0, "start": "2019-09-04 16:19:59.420800", "stderr": "", "stderr_lines": [], "stdout": "node1-1552853078.mayalabs.io", "stdout_lines": ["node1-1552853078.mayalabs.io"]}

TASK [Derive PV from application PVC] ******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:9
2019-09-04T16:20:02.017351 (delta: 2.827855)         elapsed: 485.68941 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.377206", "end": "2019-09-04 16:20:03.759839", "rc": 0, "start": "2019-09-04 16:20:02.382633", "stderr": "", "stderr_lines": [], "stdout": "pvc-faee26f2-cf20-11e9-afac-005056985c20", "stdout_lines": ["pvc-faee26f2-cf20-11e9-afac-005056985c20"]}

TASK [Derive storage engine from PV] *******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:18
2019-09-04T16:20:03.827625 (delta: 1.810138)         elapsed: 487.499684 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-faee26f2-cf20-11e9-afac-005056985c20 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:02.128178", "end": "2019-09-04 16:20:06.198504", "rc": 0, "start": "2019-09-04 16:20:04.070326", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:26
2019-09-04T16:20:06.333365 (delta: 2.505683)         elapsed: 490.005424 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:35
2019-09-04T16:20:06.447718 (delta: 0.114258)         elapsed: 490.119777 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"target_label": "openebs.io/target=cstor-target", "target_ns": "openebs"}, "changed": false}

TASK [Obtain the node where PV target pod resides] *****************************
task path: /utils/scm/openebs/target_affinity_check.yml:40
2019-09-04T16:20:06.658036 (delta: 0.210224)         elapsed: 490.330095 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/target=cstor-target -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume==\"pvc-faee26f2-cf20-11e9-afac-005056985c20\")].spec.nodeName}'", "delta": "0:00:01.433284", "end": "2019-09-04 16:20:08.408806", "rc": 0, "start": "2019-09-04 16:20:06.975522", "stderr": "", "stderr_lines": [], "stdout": "node1-1552853078.mayalabs.io", "stdout_lines": ["node1-1552853078.mayalabs.io"]}

TASK [Verify whether the app & target pod co-exist on same node] ***************
task path: /utils/scm/openebs/target_affinity_check.yml:49
2019-09-04T16:20:08.482659 (delta: 1.824489)         elapsed: 492.154718 ****** 
ok: [127.0.0.1] => {
    "msg": "App and Target affinity is maintained"
}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:154
2019-09-04T16:20:08.609457 (delta: 0.126735)         elapsed: 492.281516 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:160
2019-09-04T16:20:08.731795 (delta: 0.122256)         elapsed: 492.403854 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:171
2019-09-04T16:20:08.917883 (delta: 0.185985)         elapsed: 492.589942 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-04T16:20:09.103590 (delta: 0.185569)         elapsed: 492.775649 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-04T16:20:09.170820 (delta: 0.067171)         elapsed: 492.842879 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-04T16:20:09.256902 (delta: 0.086023)         elapsed: 492.928961 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-04T16:20:09.346960 (delta: 0.089977)         elapsed: 493.019019 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "45eaa4dbfb2d132afce3aa4f55e79457027e61ea", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "33e46b2d590adef0d53505850422ec3b", "mode": "0644", "owner": "root", "size": 456, "src": "/root/.ansible/tmp/ansible-tmp-1567614009.43-124093235240487/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-04T16:20:12.358195 (delta: 3.01116)         elapsed: 496.030254 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.176970", "end": "2019-09-04 16:20:13.814036", "rc": 0, "start": "2019-09-04 16:20:12.637066", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_container_kill \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_container_kill ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-04T16:20:13.884723 (delta: 1.52646)         elapsed: 497.556782 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.620980", "end": "2019-09-04 16:20:16.724297", "failed_when_result": false, "rc": 0, "start": "2019-09-04 16:20:14.103317", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=69   changed=43   unreachable=0    failed=0   

2019-09-04T16:20:16.805674 (delta: 2.920875)         elapsed: 500.477733 ****** 
===============================================================================
```