### PR TITLE
Included a path for the application parameters in docker file

### DIFF
--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -33,3 +33,4 @@ COPY ./utils ./utils/
 COPY ./tools/plugins /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/
 COPY experiments ./experiments
 COPY executor ./executor
+CMD touch /mnt/parameters.yml


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included path for parameters file in docker image

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
