### PR TITLE
refactor[litmusbook]: Updated the volume replica failure litmusbook to check the data consistency

### DIFF
--- a/experiments/chaos/openebs_volume_replica_failure/README.md
+++ b/experiments/chaos/openebs_volume_replica_failure/README.md
@@ -2,7 +2,7 @@
 
 | Type  | Description                                                  | Storage | K8s Platform |
 | ----- | ------------------------------------------------------------ | ------- | ------------ |
-| Chaos | Delete the Jiva replica pod and ensure that it gets scheduled again | OpenEBS | Any          |
+| Chaos | Delete the Jiva replica pod and ensure that it gets scheduled again | OpenEBS | Any   |
 
 ## Entry-Criteria
 
@@ -23,14 +23,53 @@
 
 ## Associated Utils 
 
-- `jiva_replica_pod_failure.yaml`
+- `jiva_replica_pod_failure.yaml`,`data_persistence.j2`,`mysql_data_persistence.yml`,`busybox_data_persistence.yml`
 
-## Litmusbook Environment Variables
+## Litmus experiment Environment Variables
 
 ### Application
 
-| Parameter     | Description                                                  |
-| ------------- | ------------------------------------------------------------ |
-| APP_NAMESPACE | Namespace in which application pods are deployed             |
-| APP_LABEL     | Unique Labels in `key=value` format of application deployment |
+| Parameter     | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| APP_NAMESPACE    | Namespace in which application pods are deployed              |
+| APP_LABEL        | Unique Labels in `key=value` format of application deployment |
+| APP_PVC          | Name of persistent volume claim used for app's volume mounts  |
+| TARGET_NAMESPACE | Namespace where OpenEBS is installed                          |
+| DATA_PERSISTENCE | Specify the application name against which data consistency has to be ensured. Example: busybox |
 
+### Chaos
+
+| Parameter        | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| CHAOS_TYPE       | The type of chaos to be induced.                     |
+| TARGET_CONTAINER | The container against which chaos has to be induced. |
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of  env `DATA_PERSISTENCE`,  the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+```
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+```
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+```
+parameters.yml: |
+  dbuser: root
+  dbpassword: k8sDem0
+  dbname: tdb
+```
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.

--- a/experiments/chaos/openebs_volume_replica_failure/data_persistence.j2
+++ b/experiments/chaos/openebs_volume_replica_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_volume_replica_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: target-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -36,9 +45,16 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
-          - name: DATA_PERSISTENCY
+          - name: DATA_PERSISTENCE
             value: ""   
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_volume_replica_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: target-failure

--- a/experiments/chaos/openebs_volume_replica_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: target-failure
+  name: replica-failure
   namespace: litmus
 data:
   parameters.yml: |
@@ -57,4 +57,4 @@ spec:
       volumes:
         - name: parameters
           configMap:
-            name: target-failure
+            name: replica-failure

--- a/experiments/chaos/openebs_volume_replica_failure/test.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/test.yml
@@ -4,6 +4,7 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
@@ -13,6 +14,9 @@
           when: liveness_label != ''
 
         - include: test_prerequisites.yml
+
+        - include_vars:
+            file: data_persistence.yml
   
         - include_vars:
             file: chaosutil.yml
@@ -20,6 +24,11 @@
         - name: Record the chaos util path
           set_fact: 
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - include_tasks: /utils/fcm/create_testname.yml
@@ -35,10 +44,11 @@
           debug: 
             msg: 
               - "The application info is as follows:"
-              - "Namespace    : {{ namespace }}"
-              - "Label        : {{ label }}"
-              - "PVC          : {{ pvc }}"  
-              - "StorageClass : {{ sc }}"
+              - "Namespace        : {{ namespace }}"
+              # - "Target Namespace : {{ target_namespace }}"
+              - "Label            : {{ label }}"
+              - "PVC              : {{ pvc }}"  
+              - "StorageClass     : {{ sc }}"
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
@@ -59,22 +69,20 @@
             executable: /bin/bash
           register: app_pod_name
 
-        - name: Create some test data in the mysql database
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Create some test data
+          include_tasks: "{{ data_consistency_util_path }}"
           vars:
             status: 'LOAD'
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'
-          when: data_persistance != ''      
+          when: data_persistence != ''      
 
 
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
           app_ns: "{{ namespace }}"
+          target_ns: "{{ target_namespace }}"
           app_pvc: "{{ pvc }}"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
@@ -99,16 +107,13 @@
             executable: /bin/bash
           register: rescheduled_app_pod  
 
-        - name: Verify mysql data persistence  
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Verify application data persistence  
+          include_tasks: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'  
-          when: data_persistance != ''
+          when: data_persistence != ''
 
 
         - set_fact:

--- a/experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
@@ -50,3 +50,7 @@
     src: chaosutil.j2
     dest: chaosutil.yml
 
+- name: Identify the data consistency util to be invoked
+  template:
+    src: data_persistence.j2
+    dest: data_persistence.yml

--- a/experiments/chaos/openebs_volume_replica_failure/test_vars.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/test_vars.yml
@@ -4,6 +4,6 @@ label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 


### PR DESCRIPTION
Signed-off-by: Saksham Katiyar <saksham.katiyar@mayadata.io>

- Included changes to get the data consistency util for based on the application.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**MYSQL LOGS**:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_volume_replica_failure/test.yml

PLAY [localhost] ***************************************************************
2019-09-10T07:30:29.102484 (delta: 0.064563)         elapsed: 0.064563 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:2
2019-09-10T07:30:29.119041 (delta: 0.016502)         elapsed: 0.08112 ********* 
[root@master-1554817485 saksham]# kubectl logs -f openebs-volume-replica-failure-fghmz-8m2s4 -n litmus
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_volume_replica_failure/test.yml

PLAY [localhost] ***************************************************************
2019-09-10T07:30:29.102484 (delta: 0.064563)         elapsed: 0.064563 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:2
2019-09-10T07:30:29.119041 (delta: 0.016502)         elapsed: 0.08112 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:13
2019-09-10T07:30:39.018017 (delta: 9.898951)         elapsed: 9.980096 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:2
2019-09-10T07:30:39.098649 (delta: 0.080579)         elapsed: 10.060728 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.483765", "end": "2019-09-10 07:30:40.956495", "rc": 0, "start": "2019-09-10 07:30:39.472730", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:10
2019-09-10T07:30:41.038792 (delta: 1.940088)         elapsed: 12.000871 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.323527", "end": "2019-09-10 07:30:42.609680", "rc": 0, "start": "2019-09-10 07:30:41.286153", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:18
2019-09-10T07:30:42.685216 (delta: 1.646361)         elapsed: 13.647295 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:22
2019-09-10T07:30:42.797524 (delta: 0.112252)         elapsed: 13.759603 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:27
2019-09-10T07:30:42.896362 (delta: 0.098764)         elapsed: 13.858441 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.265587", "end": "2019-09-10 07:30:44.382440", "rc": 0, "start": "2019-09-10 07:30:43.116853", "stderr": "", "stderr_lines": [], "stdout": "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d", "stdout_lines": ["pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:35
2019-09-10T07:30:44.439774 (delta: 1.543318)         elapsed: 15.401853 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.491299", "end": "2019-09-10 07:30:46.154434", "rc": 0, "start": "2019-09-10 07:30:44.663135", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:43
2019-09-10T07:30:46.251647 (delta: 1.811818)         elapsed: 17.213726 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:48
2019-09-10T07:30:46.398205 (delta: 0.146472)         elapsed: 17.360284 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ac56380bcc9f7bcfd598e1059592ccc59fdc682", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "6082ba40ba1c8f1cd7f72c539dcbe47f", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1568100646.48-170301039236684/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:53
2019-09-10T07:30:47.367034 (delta: 0.968732)         elapsed: 18.329113 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1568100647.44-198656582334182/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:18
2019-09-10T07:30:47.834746 (delta: 0.467621)         elapsed: 18.796825 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:21
2019-09-10T07:30:47.932225 (delta: 0.09742)         elapsed: 18.894304 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_pod_failure.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:24
2019-09-10T07:30:48.056721 (delta: 0.124415)         elapsed: 19.0188 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_pod_failure.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:28
2019-09-10T07:30:48.173917 (delta: 0.117131)         elapsed: 19.135996 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:34
2019-09-10T07:30:48.310188 (delta: 0.136202)         elapsed: 19.272267 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-10T07:30:48.401324 (delta: 0.09108)         elapsed: 19.363403 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-10T07:30:48.471033 (delta: 0.069653)         elapsed: 19.433112 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:36
2019-09-10T07:30:48.539429 (delta: 0.068333)         elapsed: 19.501508 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-10T07:30:48.672116 (delta: 0.132632)         elapsed: 19.634195 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "46a9681baf51af739fe944f8e37ac0de8cf56874", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "801d881b0197ef1ef2e39156a656e1ab", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1568100648.73-149618894697135/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-10T07:30:49.104282 (delta: 0.432087)         elapsed: 20.066361 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.097905", "end": "2019-09-10 07:30:50.469872", "rc": 0, "start": "2019-09-10 07:30:49.371967", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-10T07:30:50.533311 (delta: 1.428951)         elapsed: 21.49539 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.776861", "end": "2019-09-10 07:30:52.510646", "failed_when_result": false, "rc": 0, "start": "2019-09-10 07:30:50.733785", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-volume-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-volume-replica-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-10T07:30:52.576652 (delta: 2.043288)         elapsed: 23.538731 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-10T07:30:52.633427 (delta: 0.056717)         elapsed: 23.595506 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-10T07:30:52.713215 (delta: 0.079727)         elapsed: 23.675294 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:43
2019-09-10T07:30:52.798664 (delta: 0.085354)         elapsed: 23.760743 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace        : app-percona-ns", 
        "Label            : name=percona", 
        "PVC              : percona-mysql-claim", 
        "StorageClass     : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:55
2019-09-10T07:30:52.926894 (delta: 0.128154)         elapsed: 23.888973 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-10T07:30:53.036007 (delta: 0.109059)         elapsed: 23.998086 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.306960", "end": "2019-09-10 07:30:54.599979", "rc": 0, "start": "2019-09-10 07:30:53.293019", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T05:32:27Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T05:32:27Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-10T07:30:54.673386 (delta: 1.637306)         elapsed: 25.635465 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.497340", "end": "2019-09-10 07:30:56.404873", "rc": 0, "start": "2019-09-10 07:30:54.907533", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:64
2019-09-10T07:30:56.492156 (delta: 1.818665)         elapsed: 27.454235 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.452813", "end": "2019-09-10 07:30:58.297837", "rc": 0, "start": "2019-09-10 07:30:56.845024", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-pk6r8", "stdout_lines": ["percona-7685f6f58-pk6r8"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:72
2019-09-10T07:30:58.395172 (delta: 1.902953)         elapsed: 29.357251 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-10T07:30:58.682289 (delta: 0.287037)         elapsed: 29.644368 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-pk6r8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:01.860685", "end": "2019-09-10 07:31:00.809984", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2019-09-10 07:30:58.949299", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-pk6r8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:01.636295", "end": "2019-09-10 07:31:02.840338", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2019-09-10 07:31:01.204043", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-pk6r8 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:01.820864", "end": "2019-09-10 07:31:04.947773", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2019-09-10 07:31:03.126909", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-10T07:31:05.143516 (delta: 6.461152)         elapsed: 36.105595 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-10T07:31:05.218989 (delta: 0.075413)         elapsed: 36.181068 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-10T07:31:05.299895 (delta: 0.080849)         elapsed: 36.261974 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-10T07:31:05.402265 (delta: 0.102291)         elapsed: 36.364344 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-10T07:31:05.485182 (delta: 0.08283)         elapsed: 36.447261 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-10T07:31:05.574995 (delta: 0.089741)         elapsed: 36.537074 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-10T07:31:05.662903 (delta: 0.087824)         elapsed: 36.624982 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-10T07:31:05.792166 (delta: 0.129179)         elapsed: 36.754245 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-10T07:31:05.909089 (delta: 0.116807)         elapsed: 36.871168 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:83
2019-09-10T07:31:06.032285 (delta: 0.123094)         elapsed: 36.994364 ******* 
included: /chaoslib/openebs/jiva_replica_pod_failure.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:1
2019-09-10T07:31:06.290124 (delta: 0.257741)         elapsed: 37.252203 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:01.287717", "end": "2019-09-10 07:31:07.887613", "rc": 0, "start": "2019-09-10 07:31:06.599896", "stderr": "", "stderr_lines": [], "stdout": "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d", "stdout_lines": ["pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d"]}

TASK [Record the jiva replica deployment of the PV] ****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:10
2019-09-10T07:31:08.009024 (delta: 1.718842)         elapsed: 38.971103 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_deploy": "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep"}, "changed": false}

TASK [Obtain the number of replicas in the deployment] *************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:15
2019-09-10T07:31:08.172400 (delta: 0.163281)         elapsed: 39.134479 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep -n app-percona-ns --no-headers -o custom-columns=:spec.replicas", "delta": "0:00:01.239204", "end": "2019-09-10 07:31:09.657808", "rc": 0, "start": "2019-09-10 07:31:08.418604", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy before fault injection] ****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:23
2019-09-10T07:31:09.744322 (delta: 1.571663)         elapsed: 40.706401 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep -n app-percona-ns --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.379456", "end": "2019-09-10 07:31:11.427066", "rc": 0, "start": "2019-09-10 07:31:10.047610", "stderr": "", "stderr_lines": [], "stdout": "2002909", "stdout_lines": ["2002909"]}

TASK [Randomly pick a jiva replica pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:31
2019-09-10T07:31:11.520952 (delta: 1.77656)         elapsed: 42.483031 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n app-percona-ns --no-headers | grep pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.470515", "end": "2019-09-10 07:31:13.261310", "rc": 0, "start": "2019-09-10 07:31:11.790795", "stderr": "", "stderr_lines": [], "stdout": "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-dxr88", "stdout_lines": ["pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-dxr88"]}

TASK [Kill the jiva replica pod] ***********************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:40
2019-09-10T07:31:13.346082 (delta: 1.825025)         elapsed: 44.308161 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-dxr88 -n app-percona-ns", "delta": "0:00:08.133068", "end": "2019-09-10 07:31:21.815917", "rc": 0, "start": "2019-09-10 07:31:13.682849", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-dxr88\" deleted", "stdout_lines": ["pod \"pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-dxr88\" deleted"]}

TASK [Check if the replica pod is scheduled back.] *****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:46
2019-09-10T07:31:21.969283 (delta: 8.623128)         elapsed: 52.931362 ******* 
FAILED - RETRYING: Check if the replica pod is scheduled back. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get deployment pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep -n app-percona-ns --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.462206", "end": "2019-09-10 07:31:55.526131", "rc": 0, "start": "2019-09-10 07:31:54.063925", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy after fault injection] *****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:57
2019-09-10T07:31:55.611056 (delta: 33.641678)         elapsed: 86.573135 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep -n app-percona-ns --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.461010", "end": "2019-09-10 07:31:57.341978", "rc": 0, "start": "2019-09-10 07:31:55.880968", "stderr": "", "stderr_lines": [], "stdout": "2030982", "stdout_lines": ["2030982"]}

TASK [Compare resourceVersions of replica deployment] **************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:65
2019-09-10T07:31:57.408867 (delta: 1.797732)         elapsed: 88.370946 ******* 
ok: [127.0.0.1] => {
    "msg": "Verified replica pods were restarted by fault injection"
}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:90
2019-09-10T07:31:57.559175 (delta: 0.150241)         elapsed: 88.521254 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-10T07:31:57.737085 (delta: 0.177833)         elapsed: 88.699164 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.391883", "end": "2019-09-10 07:31:59.445701", "rc": 0, "start": "2019-09-10 07:31:58.053818", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T05:32:27Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T05:32:27Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-10T07:31:59.552557 (delta: 1.81541)         elapsed: 90.514636 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.310125", "end": "2019-09-10 07:32:01.115784", "rc": 0, "start": "2019-09-10 07:31:59.805659", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:99
2019-09-10T07:32:01.215314 (delta: 1.662673)         elapsed: 92.177393 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:102
2019-09-10T07:32:01.309909 (delta: 0.09447)         elapsed: 92.271988 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.376276", "end": "2019-09-10 07:32:02.984513", "rc": 0, "start": "2019-09-10 07:32:01.608237", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-pk6r8", "stdout_lines": ["percona-7685f6f58-pk6r8"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:110
2019-09-10T07:32:03.063112 (delta: 1.75311)         elapsed: 94.025191 ******** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-10T07:32:03.275943 (delta: 0.212764)         elapsed: 94.238022 ******* 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-10T07:32:03.388352 (delta: 0.112351)         elapsed: 94.350431 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7685f6f58-pk6r8 -n app-percona-ns", "delta": "0:00:18.139971", "end": "2019-09-10 07:32:21.801350", "rc": 0, "start": "2019-09-10 07:32:03.661379", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7685f6f58-pk6r8\" deleted", "stdout_lines": ["pod \"percona-7685f6f58-pk6r8\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-10T07:32:21.952687 (delta: 18.564138)         elapsed: 112.914766 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:01.440183", "end": "2019-09-10 07:32:23.687015", "rc": 0, "start": "2019-09-10 07:32:22.246832", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY   STATUS    RESTARTS   AGE\npercona-7685f6f58-fh2vf                                          1/1     Running   0          18s\npvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-ctrl-77ff7cb986-nrnkp   2/2     Running   0          2h\npvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-c5q9c    1/1     Running   0          2h\npvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-g8jtg    1/1     Running   0          1m\npvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-hkf5w    1/1     Running   0          1h", "stdout_lines": ["NAME                                                             READY   STATUS    RESTARTS   AGE", "percona-7685f6f58-fh2vf                                          1/1     Running   0          18s", "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-ctrl-77ff7cb986-nrnkp   2/2     Running   0          2h", "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-c5q9c    1/1     Running   0          2h", "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-g8jtg    1/1     Running   0          1m", "pvc-4e9bbc0a-d38c-11e9-92b9-00505698550d-rep-588d5f6d89-hkf5w    1/1     Running   0          1h"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-10T07:32:23.950995 (delta: 1.998201)         elapsed: 114.913074 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.120336", "end": "2019-09-10 07:32:25.326871", "rc": 0, "start": "2019-09-10 07:32:24.206535", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-fh2vf", "stdout_lines": ["percona-7685f6f58-fh2vf"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-10T07:32:25.388794 (delta: 1.43769)         elapsed: 116.350873 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-7685f6f58-fh2vf\")].status.phase}'", "delta": "0:00:01.519340", "end": "2019-09-10 07:32:27.293697", "rc": 0, "start": "2019-09-10 07:32:25.774357", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-10T07:32:27.454344 (delta: 2.065491)         elapsed: 118.416423 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-7685f6f58-fh2vf\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.402937", "end": "2019-09-10 07:32:29.335067", "rc": 0, "start": "2019-09-10 07:32:27.932130", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T07:32:09Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T07:32:09Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-10T07:32:29.468846 (delta: 2.014329)         elapsed: 120.430925 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-fh2vf -n app-percona-ns -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:02.629261", "end": "2019-09-10 07:32:32.546637", "failed_when_result": false, "rc": 0, "start": "2019-09-10 07:32:29.917376", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-10T07:32:32.646394 (delta: 3.177423)         elapsed: 123.608473 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-fh2vf -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:01.632898", "end": "2019-09-10 07:32:34.597608", "failed_when_result": false, "rc": 0, "start": "2019-09-10 07:32:32.964710", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-10T07:32:34.730145 (delta: 2.083642)         elapsed: 125.692224 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-10T07:32:34.849477 (delta: 0.119246)         elapsed: 125.811556 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:119
2019-09-10T07:32:34.932337 (delta: 0.082768)         elapsed: 125.894416 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:130
2019-09-10T07:32:35.056778 (delta: 0.124308)         elapsed: 126.018857 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-10T07:32:35.253604 (delta: 0.196751)         elapsed: 126.215683 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-10T07:32:35.331097 (delta: 0.077413)         elapsed: 126.293176 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-10T07:32:35.399590 (delta: 0.06843)         elapsed: 126.361669 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-10T07:32:35.457289 (delta: 0.057637)         elapsed: 126.419368 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "3a0ddee67e92fc5d67d655c843d6c01edd905b11", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c5e717927c8cddd321301711df137d96", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1568100755.54-172209468668188/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-10T07:32:38.230363 (delta: 2.773015)         elapsed: 129.192442 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.123029", "end": "2019-09-10 07:32:39.650755", "rc": 0, "start": "2019-09-10 07:32:38.527726", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-10T07:32:39.729229 (delta: 1.498774)         elapsed: 130.691308 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.657743", "end": "2019-09-10 07:32:42.697917", "failed_when_result": false, "rc": 0, "start": "2019-09-10 07:32:40.040174", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-volume-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-volume-replica-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=33   unreachable=0    failed=0   

2019-09-10T07:32:42.804905 (delta: 3.075618)         elapsed: 133.766984 ****** 
=============================================================================== 
```
**BUSYBOX LOGS**
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_volume_replica_failure/test.yml

PLAY [localhost] ***************************************************************
2019-09-10T08:51:30.494164 (delta: 0.06477)         elapsed: 0.06477 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:2
2019-09-10T08:51:30.515312 (delta: 0.021089)         elapsed: 0.085918 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:13
2019-09-10T08:51:39.904794 (delta: 9.389447)         elapsed: 9.4754 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:2
2019-09-10T08:51:39.983308 (delta: 0.078462)         elapsed: 9.553914 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc busybox-claim -n bb --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.194827", "end": "2019-09-10 08:51:41.606651", "rc": 0, "start": "2019-09-10 08:51:40.411824", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:10
2019-09-10T08:51:41.675550 (delta: 1.692179)         elapsed: 11.246156 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:02.144699", "end": "2019-09-10 08:51:44.005702", "rc": 0, "start": "2019-09-10 08:51:41.861003", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:18
2019-09-10T08:51:44.088714 (delta: 2.413101)         elapsed: 13.65932 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:22
2019-09-10T08:51:44.182861 (delta: 0.094073)         elapsed: 13.753467 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:27
2019-09-10T08:51:44.287307 (delta: 0.104385)         elapsed: 13.857913 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc busybox-claim -n bb --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.339719", "end": "2019-09-10 08:51:45.855196", "rc": 0, "start": "2019-09-10 08:51:44.515477", "stderr": "", "stderr_lines": [], "stdout": "pvc-b3aead20-d3a7-11e9-92b9-00505698550d", "stdout_lines": ["pvc-b3aead20-d3a7-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:35
2019-09-10T08:51:45.943125 (delta: 1.655749)         elapsed: 15.513731 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-b3aead20-d3a7-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.059641", "end": "2019-09-10 08:51:47.276609", "rc": 0, "start": "2019-09-10 08:51:46.216968", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:43
2019-09-10T08:51:47.354536 (delta: 1.411322)         elapsed: 16.925142 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:48
2019-09-10T08:51:47.469076 (delta: 0.114473)         elapsed: 17.039682 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ac56380bcc9f7bcfd598e1059592ccc59fdc682", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "6082ba40ba1c8f1cd7f72c539dcbe47f", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1568105507.52-202773971807472/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:53
2019-09-10T08:51:48.389303 (delta: 0.920165)         elapsed: 17.959909 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1568105508.44-270876242327913/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:18
2019-09-10T08:51:48.906036 (delta: 0.516646)         elapsed: 18.476642 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:21
2019-09-10T08:51:49.007936 (delta: 0.101847)         elapsed: 18.578542 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_pod_failure.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:24
2019-09-10T08:51:49.121924 (delta: 0.113923)         elapsed: 18.69253 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_pod_failure.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:28
2019-09-10T08:51:49.268992 (delta: 0.146993)         elapsed: 18.839598 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:34
2019-09-10T08:51:49.491646 (delta: 0.222565)         elapsed: 19.062252 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-10T08:51:49.677986 (delta: 0.186259)         elapsed: 19.248592 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-10T08:51:49.800735 (delta: 0.122655)         elapsed: 19.371341 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:36
2019-09-10T08:51:49.924292 (delta: 0.123469)         elapsed: 19.494898 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-10T08:51:50.114476 (delta: 0.190104)         elapsed: 19.685082 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "46a9681baf51af739fe944f8e37ac0de8cf56874", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "801d881b0197ef1ef2e39156a656e1ab", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1568105510.17-151286303719961/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-10T08:51:50.706568 (delta: 0.592034)         elapsed: 20.277174 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.163603", "end": "2019-09-10 08:51:52.259557", "rc": 0, "start": "2019-09-10 08:51:51.095954", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-10T08:51:52.328276 (delta: 1.621618)         elapsed: 21.898882 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.825762", "end": "2019-09-10 08:51:54.424771", "failed_when_result": false, "rc": 0, "start": "2019-09-10 08:51:52.599009", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-volume-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-volume-replica-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-10T08:51:54.586030 (delta: 2.25768)         elapsed: 24.156636 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-10T08:51:54.724151 (delta: 0.137862)         elapsed: 24.294757 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-10T08:51:54.809221 (delta: 0.084988)         elapsed: 24.379827 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:43
2019-09-10T08:51:54.877626 (delta: 0.068333)         elapsed: 24.448232 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace        : bb", 
        "Label            : name=busybox", 
        "PVC              : busybox-claim", 
        "StorageClass     : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:55
2019-09-10T08:51:55.044249 (delta: 0.166542)         elapsed: 24.614855 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-10T08:51:55.158878 (delta: 0.114559)         elapsed: 24.729484 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n bb -l name=\"busybox\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.458541", "end": "2019-09-10 08:51:56.935327", "rc": 0, "start": "2019-09-10 08:51:55.476786", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T08:48:43Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T08:48:43Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-10T08:51:57.072557 (delta: 1.913611)         elapsed: 26.643163 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb -o jsonpath='{.items[?(@.metadata.labels.name==\"busybox\")].status.phase}'", "delta": "0:00:01.204896", "end": "2019-09-10 08:51:58.628636", "rc": 0, "start": "2019-09-10 08:51:57.423740", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:64
2019-09-10T08:51:58.712350 (delta: 1.63967)         elapsed: 28.282956 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n bb -l name=busybox --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.519573", "end": "2019-09-10 08:52:00.500219", "rc": 0, "start": "2019-09-10 08:51:58.980646", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-695d6fcc47-zsp9b", "stdout_lines": ["app-busybox-695d6fcc47-zsp9b"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:72
2019-09-10T08:52:00.584600 (delta: 1.872171)         elapsed: 30.155206 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-10T08:52:00.859600 (delta: 0.274914)         elapsed: 30.430206 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-695d6fcc47-zsp9b -n bb -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:01.700966", "end": "2019-09-10 08:52:02.797868", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-09-10 08:52:01.096902", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.068390 seconds, 58.5MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.068390 seconds, 58.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-695d6fcc47-zsp9b -n bb -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:01.630789", "end": "2019-09-10 08:52:04.973233", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-09-10 08:52:03.342444", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-10T08:52:05.142930 (delta: 4.283274)         elapsed: 34.713536 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-10T08:52:05.222816 (delta: 0.079828)         elapsed: 34.793422 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-10T08:52:05.295012 (delta: 0.072133)         elapsed: 34.865618 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-10T08:52:05.355871 (delta: 0.060799)         elapsed: 34.926477 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-10T08:52:05.424795 (delta: 0.068865)         elapsed: 34.995401 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-10T08:52:05.495020 (delta: 0.070161)         elapsed: 35.065626 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-10T08:52:05.581173 (delta: 0.086077)         elapsed: 35.151779 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-10T08:52:05.655130 (delta: 0.073883)         elapsed: 35.225736 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-10T08:52:05.747336 (delta: 0.092135)         elapsed: 35.317942 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-10T08:52:05.840822 (delta: 0.093387)         elapsed: 35.411428 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:83
2019-09-10T08:52:05.920471 (delta: 0.079573)         elapsed: 35.491077 ******* 
included: /chaoslib/openebs/jiva_replica_pod_failure.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:1
2019-09-10T08:52:06.125983 (delta: 0.205436)         elapsed: 35.696589 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc busybox-claim -o custom-columns=:spec.volumeName -n bb --no-headers", "delta": "0:00:01.215246", "end": "2019-09-10 08:52:07.582137", "rc": 0, "start": "2019-09-10 08:52:06.366891", "stderr": "", "stderr_lines": [], "stdout": "pvc-b3aead20-d3a7-11e9-92b9-00505698550d", "stdout_lines": ["pvc-b3aead20-d3a7-11e9-92b9-00505698550d"]}

TASK [Record the jiva replica deployment of the PV] ****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:10
2019-09-10T08:52:07.672993 (delta: 1.546951)         elapsed: 37.243599 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_deploy": "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep"}, "changed": false}

TASK [Obtain the number of replicas in the deployment] *************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:15
2019-09-10T08:52:07.864620 (delta: 0.191548)         elapsed: 37.435226 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep -n bb --no-headers -o custom-columns=:spec.replicas", "delta": "0:00:01.331094", "end": "2019-09-10 08:52:09.461574", "rc": 0, "start": "2019-09-10 08:52:08.130480", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy before fault injection] ****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:23
2019-09-10T08:52:09.544385 (delta: 1.679686)         elapsed: 39.114991 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep -n bb --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.374665", "end": "2019-09-10 08:52:11.264537", "rc": 0, "start": "2019-09-10 08:52:09.889872", "stderr": "", "stderr_lines": [], "stdout": "2049769", "stdout_lines": ["2049769"]}

TASK [Randomly pick a jiva replica pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:31
2019-09-10T08:52:11.354394 (delta: 1.809922)         elapsed: 40.925 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n bb --no-headers | grep pvc-b3aead20-d3a7-11e9-92b9-00505698550d | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.246041", "end": "2019-09-10 08:52:12.868341", "rc": 0, "start": "2019-09-10 08:52:11.622300", "stderr": "", "stderr_lines": [], "stdout": "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-k6c49", "stdout_lines": ["pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-k6c49"]}

TASK [Kill the jiva replica pod] ***********************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:40
2019-09-10T08:52:12.935447 (delta: 1.580933)         elapsed: 42.506053 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-k6c49 -n bb", "delta": "0:00:03.400632", "end": "2019-09-10 08:52:16.641949", "rc": 0, "start": "2019-09-10 08:52:13.241317", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-k6c49\" deleted", "stdout_lines": ["pod \"pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-k6c49\" deleted"]}

TASK [Check if the replica pod is scheduled back.] *****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:46
2019-09-10T08:52:16.711739 (delta: 3.776236)         elapsed: 46.282345 ******* 
FAILED - RETRYING: Check if the replica pod is scheduled back. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get deployment pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep -n bb --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.329179", "end": "2019-09-10 08:52:50.068119", "rc": 0, "start": "2019-09-10 08:52:48.738940", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy after fault injection] *****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:57
2019-09-10T08:52:50.169379 (delta: 33.457572)         elapsed: 79.739985 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep -n bb --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.270412", "end": "2019-09-10 08:52:51.734948", "rc": 0, "start": "2019-09-10 08:52:50.464536", "stderr": "", "stderr_lines": [], "stdout": "2050759", "stdout_lines": ["2050759"]}

TASK [Compare resourceVersions of replica deployment] **************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:65
2019-09-10T08:52:51.844044 (delta: 1.674538)         elapsed: 81.41465 ******** 
ok: [127.0.0.1] => {
    "msg": "Verified replica pods were restarted by fault injection"
}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:90
2019-09-10T08:52:52.009200 (delta: 0.165076)         elapsed: 81.579806 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-10T08:52:52.173325 (delta: 0.164041)         elapsed: 81.743931 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n bb -l name=\"busybox\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.264632", "end": "2019-09-10 08:52:53.763809", "rc": 0, "start": "2019-09-10 08:52:52.499177", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T08:48:43Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T08:48:43Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-10T08:52:53.854167 (delta: 1.680035)         elapsed: 83.424773 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb -o jsonpath='{.items[?(@.metadata.labels.name==\"busybox\")].status.phase}'", "delta": "0:00:01.323576", "end": "2019-09-10 08:52:55.491693", "rc": 0, "start": "2019-09-10 08:52:54.168117", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:99
2019-09-10T08:52:55.578307 (delta: 1.724044)         elapsed: 85.148913 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:102
2019-09-10T08:52:55.681507 (delta: 0.103131)         elapsed: 85.252113 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n bb -l name=busybox --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.076632", "end": "2019-09-10 08:52:57.044804", "rc": 0, "start": "2019-09-10 08:52:55.968172", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-695d6fcc47-zsp9b", "stdout_lines": ["app-busybox-695d6fcc47-zsp9b"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:110
2019-09-10T08:52:57.163807 (delta: 1.482224)         elapsed: 86.734413 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-10T08:52:57.459942 (delta: 0.296062)         elapsed: 87.030548 ******* 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-10T08:52:57.637980 (delta: 0.177955)         elapsed: 87.208586 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-695d6fcc47-zsp9b -n bb", "delta": "0:00:33.219838", "end": "2019-09-10 08:53:31.241682", "rc": 0, "start": "2019-09-10 08:52:58.021844", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-695d6fcc47-zsp9b\" deleted", "stdout_lines": ["pod \"app-busybox-695d6fcc47-zsp9b\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-10T08:53:31.398944 (delta: 33.76086)         elapsed: 120.96955 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb", "delta": "0:00:01.185818", "end": "2019-09-10 08:53:32.865652", "rc": 0, "start": "2019-09-10 08:53:31.679834", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                            READY   STATUS              RESTARTS   AGE\napp-busybox-695d6fcc47-s29st                                    0/1     ContainerCreating   0          33s\npvc-b3aead20-d3a7-11e9-92b9-00505698550d-ctrl-64fc895c6-9xnnc   2/2     Running             0          5m\npvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-2fs5r   1/1     Running             0          5m\npvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-6f4qd   1/1     Running             0          1m\npvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-pxr6m   1/1     Running             0          5m", "stdout_lines": ["NAME                                                            READY   STATUS              RESTARTS   AGE", "app-busybox-695d6fcc47-s29st                                    0/1     ContainerCreating   0          33s", "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-ctrl-64fc895c6-9xnnc   2/2     Running             0          5m", "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-2fs5r   1/1     Running             0          5m", "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-6f4qd   1/1     Running             0          1m", "pvc-b3aead20-d3a7-11e9-92b9-00505698550d-rep-55fbb89b5d-pxr6m   1/1     Running             0          5m"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-10T08:53:32.961995 (delta: 1.562943)         elapsed: 122.532601 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n bb -l name=busybox -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.394401", "end": "2019-09-10 08:53:34.627778", "rc": 0, "start": "2019-09-10 08:53:33.233377", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-695d6fcc47-s29st", "stdout_lines": ["app-busybox-695d6fcc47-s29st"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-10T08:53:34.702198 (delta: 1.740117)         elapsed: 124.272804 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
FAILED - RETRYING: Checking application pod is in running state (148 retries left).
FAILED - RETRYING: Checking application pod is in running state (147 retries left).
FAILED - RETRYING: Checking application pod is in running state (146 retries left).
FAILED - RETRYING: Checking application pod is in running state (145 retries left).
FAILED - RETRYING: Checking application pod is in running state (144 retries left).
FAILED - RETRYING: Checking application pod is in running state (143 retries left).
FAILED - RETRYING: Checking application pod is in running state (142 retries left).
changed: [127.0.0.1] => {"attempts": 10, "changed": true, "cmd": "kubectl get pods -n bb -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-695d6fcc47-s29st\")].status.phase}'", "delta": "0:00:01.197790", "end": "2019-09-10 08:54:08.535573", "rc": 0, "start": "2019-09-10 08:54:07.337783", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-10T08:54:08.648354 (delta: 33.946084)         elapsed: 158.21896 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-695d6fcc47-s29st\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.317011", "end": "2019-09-10 08:54:10.314098", "rc": 0, "start": "2019-09-10 08:54:08.997087", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-10T08:54:06Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-10T08:54:06Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-10T08:54:10.403365 (delta: 1.75437)         elapsed: 159.973971 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-695d6fcc47-s29st -n bb -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.858818", "end": "2019-09-10 08:54:12.533825", "failed_when_result": false, "rc": 0, "start": "2019-09-10 08:54:10.675007", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-10T08:54:12.712026 (delta: 2.308561)         elapsed: 162.282632 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-695d6fcc47-s29st -n bb -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.682132", "end": "2019-09-10 08:54:14.724576", "failed_when_result": false, "rc": 0, "start": "2019-09-10 08:54:13.042444", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-10T08:54:14.846762 (delta: 2.134635)         elapsed: 164.417368 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-10T08:54:14.981140 (delta: 0.134289)         elapsed: 164.551746 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-10T08:54:15.096420 (delta: 0.115196)         elapsed: 164.667026 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:119
2019-09-10T08:54:15.167584 (delta: 0.071099)         elapsed: 164.73819 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:130
2019-09-10T08:54:15.264850 (delta: 0.097201)         elapsed: 164.835456 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-10T08:54:15.419026 (delta: 0.15412)         elapsed: 164.989632 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-10T08:54:15.498150 (delta: 0.079058)         elapsed: 165.068756 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-10T08:54:15.606672 (delta: 0.108451)         elapsed: 165.177278 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-10T08:54:15.684552 (delta: 0.077806)         elapsed: 165.255158 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "3a0ddee67e92fc5d67d655c843d6c01edd905b11", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c5e717927c8cddd321301711df137d96", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1568105655.77-56438104432099/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-10T08:54:18.759769 (delta: 3.075151)         elapsed: 168.330375 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.106998", "end": "2019-09-10 08:54:20.087168", "rc": 0, "start": "2019-09-10 08:54:18.980170", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-10T08:54:20.146689 (delta: 1.386862)         elapsed: 169.717295 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.605506", "end": "2019-09-10 08:54:21.993358", "failed_when_result": false, "rc": 0, "start": "2019-09-10 08:54:20.387852", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-volume-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-volume-replica-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=33   unreachable=0    failed=0   

2019-09-10T08:54:22.071463 (delta: 1.924717)         elapsed: 171.642069 ****** 
=============================================================================== 
```