### PR TITLE
Refactor litmusbook for jiva-snapshot-delete

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
@@ -11,6 +11,6 @@
   args:
     executable: /bin/bash
   register: snapshot_number
-  until: snapshot_number.stdout|int < 11
+  until: "((snapshot_number.stdout)|int) <= 11"
   delay: 5
   retries: 50


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

**Following is the log of ansible-test container:**
```
PLAY [localhost] ***************************************************************
2019-09-11T06:36:56.750375 (delta: 0.060316)         elapsed: 0.060316 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-09-11T06:36:56.765387 (delta: 0.014957)         elapsed: 0.075328 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2019-09-11T06:37:06.865854 (delta: 10.100434)         elapsed: 10.175795 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-09-11T06:37:06.936308 (delta: 0.070402)         elapsed: 10.246249 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-09-11T06:37:07.054350 (delta: 0.117974)         elapsed: 10.364291 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-11T06:37:07.324635 (delta: 0.270183)         elapsed: 10.634576 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "4f7f39fd2db6a0c714c6b7ce7c1ab581a1bc8178", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cbbaaefff371dec0810f1845792a5639", "mode": "0644", "owner": "root", "size": 429, "src": "/root/.ansible/tmp/ansible-tmp-1568183827.41-234050930423249/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:37:08.236948 (delta: 0.912238)         elapsed: 11.546889 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.265007", "end": "2019-09-11 06:37:09.954201", "rc": 0, "start": "2019-09-11 06:37:08.689194", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:37:10.022988 (delta: 1.785984)         elapsed: 13.332929 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.701448", "end": "2019-09-11 06:37:12.004588", "failed_when_result": false, "rc": 0, "start": "2019-09-11 06:37:10.303140", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-11T06:37:12.076826 (delta: 2.053764)         elapsed: 15.386767 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:37:12.139512 (delta: 0.062616)         elapsed: 15.449453 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:37:12.207999 (delta: 0.068427)         elapsed: 15.51794 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-09-11T06:37:12.262159 (delta: 0.054092)         elapsed: 15.5721 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default", "delta": "0:00:01.238614", "end": "2019-09-11 06:37:13.723730", "rc": 0, "start": "2019-09-11 06:37:12.485116", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-jiva-default   openebs.io/provisioner-iscsi   1d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-jiva-default   openebs.io/provisioner-iscsi   1d"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-09-11T06:37:13.782392 (delta: 1.52017)         elapsed: 17.092333 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-09-11T06:37:14.255267 (delta: 0.472816)         elapsed: 17.565208 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-09-11T06:37:14.354937 (delta: 0.09961)         elapsed: 17.664878 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.155075", "end": "2019-09-11 06:37:15.704680", "rc": 0, "start": "2019-09-11 06:37:14.549605", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmongo-cstor\nmongo-jiva\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\npercona-cstor\npercona-jiva", "stdout_lines": ["default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "mongo-cstor", "mongo-jiva", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "percona-cstor", "percona-jiva"]}

TASK [Create test specific namespace.] *****************************************
2019-09-11T06:37:15.765520 (delta: 1.410504)         elapsed: 19.075461 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:01.352011", "end": "2019-09-11 06:37:17.319972", "rc": 0, "start": "2019-09-11 06:37:15.967961", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [include_tasks] ***********************************************************
2019-09-11T06:37:17.389622 (delta: 1.624039)         elapsed: 20.699563 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-09-11T06:37:17.493702 (delta: 0.103968)         elapsed: 20.803643 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.319776", "end": "2019-09-11 06:37:19.123036", "rc": 0, "start": "2019-09-11 06:37:17.803260", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2019-09-11T06:37:19.203749 (delta: 1.709973)         elapsed: 22.51369 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:02.554966", "end": "2019-09-11 06:37:22.009764", "rc": 0, "start": "2019-09-11 06:37:19.454798", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [set_fact] ****************************************************************
2019-09-11T06:37:22.186177 (delta: 2.982346)         elapsed: 25.496118 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"execute": 1, "pvc_label": "demo-vol1-claim"}, "changed": false}

TASK [Get pv name] *************************************************************
2019-09-11T06:37:22.269496 (delta: 0.083176)         elapsed: 25.579437 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc --no-headers -n fio -l name=demo-vol1-claim -o jsonpath='{range .items[*]}{.spec.volumeName}'", "delta": "0:00:01.498957", "end": "2019-09-11 06:37:23.994833", "rc": 0, "start": "2019-09-11 06:37:22.495876", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2019-09-11T06:37:24.058746 (delta: 1.789183)         elapsed: 27.368687 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pv_name": ""}, "changed": false}

TASK [Replace the data sample size with the provider sample size in fio-write.yml] ***
2019-09-11T06:37:24.155910 (delta: 0.097078)         elapsed: 27.465851 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy fio write test job] ***********************************************
2019-09-11T06:37:24.445371 (delta: 0.289402)         elapsed: 27.755312 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:01.532425", "end": "2019-09-11 06:37:26.201635", "rc": 0, "start": "2019-09-11 06:37:24.669210", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2019-09-11T06:37:26.278769 (delta: 1.833329)         elapsed: 29.58871 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:02.345047", "end": "2019-09-11 06:37:28.885275", "rc": 0, "start": "2019-09-11 06:37:26.540228", "stderr": "", "stderr_lines": [], "stdout": "fio-sckc6", "stdout_lines": ["fio-sckc6"]}

TASK [Check the status of pod] *************************************************
2019-09-11T06:37:29.011969 (delta: 2.733143)         elapsed: 32.32191 ******** 
FAILED - RETRYING: Check the status of pod (100 retries left).
FAILED - RETRYING: Check the status of pod (99 retries left).
FAILED - RETRYING: Check the status of pod (98 retries left).
FAILED - RETRYING: Check the status of pod (97 retries left).
FAILED - RETRYING: Check the status of pod (96 retries left).
FAILED - RETRYING: Check the status of pod (95 retries left).
FAILED - RETRYING: Check the status of pod (94 retries left).
FAILED - RETRYING: Check the status of pod (93 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get po fio-sckc6 -n fio -o jsonpath={.status.phase}", "delta": "0:00:01.364633", "end": "2019-09-11 06:38:25.833570", "rc": 0, "start": "2019-09-11 06:38:24.468937", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Populate the iterator with the values to loop] ***************************
2019-09-11T06:38:25.904548 (delta: 56.892475)         elapsed: 89.214489 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "shuf -i 1-20 -n 15", "delta": "0:00:01.137180", "end": "2019-09-11 06:38:27.250810", "rc": 0, "start": "2019-09-11 06:38:26.113630", "stderr": "", "stderr_lines": [], "stdout": "18\n6\n3\n11\n19\n2\n20\n10\n16\n1\n14\n15\n5\n17\n7", "stdout_lines": ["18", "6", "3", "11", "19", "2", "20", "10", "16", "1", "14", "15", "5", "17", "7"]}

TASK [Include replica restart test] ********************************************
2019-09-11T06:38:27.328894 (delta: 1.424283)         elapsed: 90.638835 ******* 
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=18)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=6)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=3)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=11)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=19)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=2)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=20)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=10)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=16)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=1)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=14)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=15)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=5)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=17)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=7)

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:38:27.737515 (delta: 0.408539)         elapsed: 91.047456 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume= -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.500730", "end": "2019-09-11 06:38:29.475148", "rc": 0, "start": "2019-09-11 06:38:27.974418", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:38:29.552829 (delta: 1.815256)         elapsed: 92.86277 ******** 
fatal: [127.0.0.1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: list object has no element 2\n\nThe error appears to have been in '/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set the replica pod name to variable based on latest creation timestamp\n  ^ here\n"}

TASK [set_fact] ****************************************************************
2019-09-11T06:38:29.637180 (delta: 0.084284)         elapsed: 92.947121 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [Cleanup the jobs] ********************************************************
2019-09-11T06:38:29.735513 (delta: 0.098266)         elapsed: 93.045454 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete ns fio", "delta": "0:00:24.071514", "end": "2019-09-11 06:38:54.037523", "rc": 0, "start": "2019-09-11 06:38:29.966009", "stderr": "", "stderr_lines": [], "stdout": "namespace \"fio\" deleted", "stdout_lines": ["namespace \"fio\" deleted"]}

TASK [include_tasks] ***********************************************************
2019-09-11T06:38:54.160978 (delta: 24.425407)         elapsed: 117.470919 ***** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-11T06:38:54.392588 (delta: 0.231503)         elapsed: 117.702529 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:38:54.454328 (delta: 0.061679)         elapsed: 117.764269 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:38:54.533449 (delta: 0.079051)         elapsed: 117.84339 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-11T06:38:54.603965 (delta: 0.070435)         elapsed: 117.913906 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "5e6c85cf4de53137eaa5c825609b1e65d415a4fa", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3b09558171014f87e82e11fa9fcc8087", "mode": "0644", "owner": "root", "size": 427, "src": "/root/.ansible/tmp/ansible-tmp-1568183934.68-277658563299931/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:38:57.245354 (delta: 2.641319)         elapsed: 120.555295 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.138148", "end": "2019-09-11 06:38:58.622605", "rc": 0, "start": "2019-09-11 06:38:57.484457", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:38:58.677728 (delta: 1.432301)         elapsed: 121.987669 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.770760", "end": "2019-09-11 06:39:00.753080", "failed_when_result": false, "rc": 0, "start": "2019-09-11 06:38:58.982320", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=43   changed=20   unreachable=0    failed=1   

2019-09-11T06:39:00.833510 (delta: 2.155726)         elapsed: 124.143451 ****** 
=============================================================================== 
[root@master-1552853078 ~]# kubectl delete job --all -n litmus
job.batch "litmus-di-fio-snap-del-65l4m" deleted
[root@master-1552853078 ~]# kubectl create -f run.yaml 
job.batch "litmus-di-fio-snap-del-wkjmb" created
[root@master-1552853078 ~]# kubectl get po -n litmus
NAME                                 READY     STATUS    RESTARTS   AGE
litmus-di-fio-snap-del-wkjmb-nlt5b   1/1       Running   0          7s
[root@master-1552853078 ~]# kubectl logs -f litmus-di-fio-snap-del-wkjmb-nlt5b -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-09-11T06:44:09.384553 (delta: 0.065951)         elapsed: 0.065951 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-09-11T06:44:09.399953 (delta: 0.015341)         elapsed: 0.081351 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2019-09-11T06:44:20.236387 (delta: 10.836399)         elapsed: 10.917785 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-09-11T06:44:20.329916 (delta: 0.093473)         elapsed: 11.011314 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-09-11T06:44:20.426414 (delta: 0.096404)         elapsed: 11.107812 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-11T06:44:20.612875 (delta: 0.186362)         elapsed: 11.294273 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "4f7f39fd2db6a0c714c6b7ce7c1ab581a1bc8178", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cbbaaefff371dec0810f1845792a5639", "mode": "0644", "owner": "root", "size": 429, "src": "/root/.ansible/tmp/ansible-tmp-1568184260.67-134761761402339/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:44:21.497959 (delta: 0.885029)         elapsed: 12.179357 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.194754", "end": "2019-09-11 06:44:23.126142", "rc": 0, "start": "2019-09-11 06:44:21.931388", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:44:23.182144 (delta: 1.684125)         elapsed: 13.863542 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.689463", "end": "2019-09-11 06:44:25.094201", "failed_when_result": false, "rc": 0, "start": "2019-09-11 06:44:23.404738", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-11T06:44:25.207649 (delta: 2.02545)         elapsed: 15.889047 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T06:44:25.308437 (delta: 0.100666)         elapsed: 15.989835 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T06:44:25.401251 (delta: 0.092732)         elapsed: 16.082649 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-09-11T06:44:25.529936 (delta: 0.128591)         elapsed: 16.211334 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default", "delta": "0:00:01.273158", "end": "2019-09-11 06:44:27.188150", "rc": 0, "start": "2019-09-11 06:44:25.914992", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-jiva-default   openebs.io/provisioner-iscsi   1d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-jiva-default   openebs.io/provisioner-iscsi   1d"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-09-11T06:44:27.283341 (delta: 1.7533)         elapsed: 17.964739 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-09-11T06:44:27.853320 (delta: 0.569903)         elapsed: 18.534718 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-09-11T06:44:28.008915 (delta: 0.15549)         elapsed: 18.690313 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.411379", "end": "2019-09-11 06:44:29.734633", "rc": 0, "start": "2019-09-11 06:44:28.323254", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nmongo-cstor\nmongo-jiva\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\npercona-cstor\npercona-jiva", "stdout_lines": ["default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "mongo-cstor", "mongo-jiva", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "percona-cstor", "percona-jiva"]}

TASK [Create test specific namespace.] *****************************************
2019-09-11T06:44:29.836405 (delta: 1.827387)         elapsed: 20.517803 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:01.328026", "end": "2019-09-11 06:44:31.406430", "rc": 0, "start": "2019-09-11 06:44:30.078404", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [include_tasks] ***********************************************************
2019-09-11T06:44:31.501700 (delta: 1.665208)         elapsed: 22.183098 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-09-11T06:44:31.686092 (delta: 0.184284)         elapsed: 22.36749 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.375394", "end": "2019-09-11 06:44:33.326307", "rc": 0, "start": "2019-09-11 06:44:31.950913", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2019-09-11T06:44:33.468268 (delta: 1.782036)         elapsed: 24.149666 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:01.575218", "end": "2019-09-11 06:44:35.476188", "rc": 0, "start": "2019-09-11 06:44:33.900970", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [set_fact] ****************************************************************
2019-09-11T06:44:35.594006 (delta: 2.125621)         elapsed: 26.275404 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"execute": 1, "pvc_label": "demo-vol1-claim"}, "changed": false}

TASK [Get pv name] *************************************************************
2019-09-11T06:44:35.763356 (delta: 0.169233)         elapsed: 26.444754 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc --no-headers -n fio -l name=demo-vol1-claim -o jsonpath='{range .items[*]}{.spec.volumeName}'", "delta": "0:00:01.369012", "end": "2019-09-11 06:44:37.357361", "rc": 0, "start": "2019-09-11 06:44:35.988349", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20"]}

TASK [set_fact] ****************************************************************
2019-09-11T06:44:37.418079 (delta: 1.654637)         elapsed: 28.099477 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pv_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20"}, "changed": false}

TASK [Replace the data sample size with the provider sample size in fio-write.yml] ***
2019-09-11T06:44:37.529648 (delta: 0.11151)         elapsed: 28.211046 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy fio write test job] ***********************************************
2019-09-11T06:44:37.977458 (delta: 0.447709)         elapsed: 28.658856 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:01.505401", "end": "2019-09-11 06:44:39.720888", "rc": 0, "start": "2019-09-11 06:44:38.215487", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2019-09-11T06:44:39.847493 (delta: 1.869944)         elapsed: 30.528891 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.370372", "end": "2019-09-11 06:44:41.417414", "rc": 0, "start": "2019-09-11 06:44:40.047042", "stderr": "", "stderr_lines": [], "stdout": "fio-f8crc", "stdout_lines": ["fio-f8crc"]}

TASK [Check the status of pod] *************************************************
2019-09-11T06:44:41.483363 (delta: 1.6358)         elapsed: 32.164761 ********* 
FAILED - RETRYING: Check the status of pod (100 retries left).
FAILED - RETRYING: Check the status of pod (99 retries left).
FAILED - RETRYING: Check the status of pod (98 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get po fio-f8crc -n fio -o jsonpath={.status.phase}", "delta": "0:00:02.265077", "end": "2019-09-11 06:45:03.437233", "rc": 0, "start": "2019-09-11 06:45:01.172156", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Populate the iterator with the values to loop] ***************************
2019-09-11T06:45:03.509142 (delta: 22.025717)         elapsed: 54.19054 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "shuf -i 1-20 -n 15", "delta": "0:00:01.219358", "end": "2019-09-11 06:45:04.953160", "rc": 0, "start": "2019-09-11 06:45:03.733802", "stderr": "", "stderr_lines": [], "stdout": "18\n7\n2\n15\n3\n9\n13\n5\n4\n11\n17\n1\n6\n10\n20", "stdout_lines": ["18", "7", "2", "15", "3", "9", "13", "5", "4", "11", "17", "1", "6", "10", "20"]}

TASK [Include replica restart test] ********************************************
2019-09-11T06:45:05.020233 (delta: 1.511029)         elapsed: 55.701631 ******* 
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=18)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=7)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=2)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=15)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=3)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=9)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=13)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=5)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=4)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=11)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=17)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=1)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=6)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=10)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=20)

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:45:05.535183 (delta: 0.514881)         elapsed: 56.216581 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.403952", "end": "2019-09-11 06:45:07.244042", "rc": 0, "start": "2019-09-11 06:45:05.840090", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:45:07.326071 (delta: 1.790692)         elapsed: 58.007469 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:45:07.475840 (delta: 0.149695)         elapsed: 58.157238 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd -n fio", "delta": "0:00:11.913865", "end": "2019-09-11 06:45:19.640467", "rc": 0, "start": "2019-09-11 06:45:07.726602", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ntdpd\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:45:19.793192 (delta: 12.317263)         elapsed: 70.47459 ******* 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:45:19.905915", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:46:19.906208", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:46:19.941482 (delta: 60.148184)         elapsed: 130.62288 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.428765", "end": "2019-09-11 06:46:21.621787", "rc": 0, "start": "2019-09-11 06:46:20.193022", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:46:21.716402 (delta: 1.774862)         elapsed: 132.3978 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:46:21.899979 (delta: 0.183484)         elapsed: 132.581377 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh -n fio", "delta": "0:00:07.496754", "end": "2019-09-11 06:46:29.630712", "rc": 0, "start": "2019-09-11 06:46:22.133958", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vg2dh\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:46:29.780089 (delta: 7.880043)         elapsed: 140.461487 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:46:29.881176", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:47:29.881417", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:47:29.921565 (delta: 60.141362)         elapsed: 200.602963 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.581237", "end": "2019-09-11 06:47:31.775145", "rc": 0, "start": "2019-09-11 06:47:30.193908", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:47:31.900465 (delta: 1.978837)         elapsed: 202.581863 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:47:32.112951 (delta: 0.212357)         elapsed: 202.794349 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt -n fio", "delta": "0:00:03.634835", "end": "2019-09-11 06:47:36.056565", "rc": 0, "start": "2019-09-11 06:47:32.421730", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2d2vt\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:47:36.157409 (delta: 4.044308)         elapsed: 206.838807 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:47:36.257093", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:48:36.257381", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:48:36.298137 (delta: 60.14064)         elapsed: 266.979535 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.415684", "end": "2019-09-11 06:48:37.966314", "rc": 0, "start": "2019-09-11 06:48:36.550630", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:48:38.034547 (delta: 1.736347)         elapsed: 268.715945 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:48:38.139994 (delta: 0.105384)         elapsed: 268.821392 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl -n fio", "delta": "0:00:03.731824", "end": "2019-09-11 06:48:42.144187", "rc": 0, "start": "2019-09-11 06:48:38.412363", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-5vgbl\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:48:42.267319 (delta: 4.127246)         elapsed: 272.948717 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:48:42.383507", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:49:42.383740", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:49:42.414509 (delta: 60.147092)         elapsed: 333.095907 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.306776", "end": "2019-09-11 06:49:43.922138", "rc": 0, "start": "2019-09-11 06:49:42.615362", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:49:43.984913 (delta: 1.57034)         elapsed: 334.666311 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:49:44.080820 (delta: 0.095854)         elapsed: 334.762218 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2 -n fio", "delta": "0:00:05.286816", "end": "2019-09-11 06:49:49.609093", "rc": 0, "start": "2019-09-11 06:49:44.322277", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-tn5x2\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:49:49.743779 (delta: 5.662899)         elapsed: 340.425177 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:49:49.849399", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:50:49.849704", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:50:49.887100 (delta: 60.143218)         elapsed: 400.568498 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.327111", "end": "2019-09-11 06:50:51.437427", "rc": 0, "start": "2019-09-11 06:50:50.110316", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:50:51.518268 (delta: 1.631113)         elapsed: 402.199666 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:50:51.634371 (delta: 0.116004)         elapsed: 402.315769 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg -n fio", "delta": "0:00:07.734806", "end": "2019-09-11 06:50:59.640816", "rc": 0, "start": "2019-09-11 06:50:51.906010", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-pg7kg\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:50:59.711322 (delta: 8.07688)         elapsed: 410.39272 ******** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:50:59.769101", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:51:59.769294", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:51:59.800956 (delta: 60.089568)         elapsed: 470.482354 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.270848", "end": "2019-09-11 06:52:01.277923", "rc": 0, "start": "2019-09-11 06:52:00.007075", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:52:01.350657 (delta: 1.549637)         elapsed: 472.032055 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:52:01.460482 (delta: 0.109694)         elapsed: 472.14188 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf -n fio", "delta": "0:00:07.869877", "end": "2019-09-11 06:52:09.639081", "rc": 0, "start": "2019-09-11 06:52:01.769204", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-6k9hf\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:52:09.734544 (delta: 8.273995)         elapsed: 480.415942 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:52:09.859519", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:53:09.859915", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:53:09.891325 (delta: 60.156695)         elapsed: 540.572723 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.315890", "end": "2019-09-11 06:53:11.422270", "rc": 0, "start": "2019-09-11 06:53:10.106380", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:53:11.531585 (delta: 1.640199)         elapsed: 542.212983 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:53:11.683372 (delta: 0.1516)         elapsed: 542.36477 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf -n fio", "delta": "0:00:07.736592", "end": "2019-09-11 06:53:19.632308", "rc": 0, "start": "2019-09-11 06:53:11.895716", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-lt7mf\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:53:19.695199 (delta: 8.011764)         elapsed: 550.376597 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:53:19.757846", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:54:19.758098", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:54:19.789856 (delta: 60.094596)         elapsed: 610.471254 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.367215", "end": "2019-09-11 06:54:21.433216", "rc": 0, "start": "2019-09-11 06:54:20.066001", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:54:21.510408 (delta: 1.720498)         elapsed: 612.191806 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:54:21.619201 (delta: 0.108738)         elapsed: 612.300599 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25 -n fio", "delta": "0:00:07.803167", "end": "2019-09-11 06:54:29.634969", "rc": 0, "start": "2019-09-11 06:54:21.831802", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-ncd25\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:54:29.709419 (delta: 8.09015)         elapsed: 620.390817 ******* 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:54:29.774497", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:55:29.774747", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:55:29.819649 (delta: 60.110173)         elapsed: 680.501047 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.446688", "end": "2019-09-11 06:55:31.458941", "rc": 0, "start": "2019-09-11 06:55:30.012253", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:55:31.542982 (delta: 1.723249)         elapsed: 682.22438 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:55:31.716461 (delta: 0.173388)         elapsed: 682.397859 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp -n fio", "delta": "0:00:07.657849", "end": "2019-09-11 06:55:39.607475", "rc": 0, "start": "2019-09-11 06:55:31.949626", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-f67kp\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:55:39.684071 (delta: 7.967487)         elapsed: 690.365469 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:55:39.746779", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:56:39.747030", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:56:39.790075 (delta: 60.105946)         elapsed: 750.471473 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.408555", "end": "2019-09-11 06:56:41.409949", "rc": 0, "start": "2019-09-11 06:56:40.001394", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:56:41.479140 (delta: 1.689003)         elapsed: 752.160538 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:56:41.597075 (delta: 0.117873)         elapsed: 752.278473 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c -n fio", "delta": "0:00:03.832130", "end": "2019-09-11 06:56:45.765173", "rc": 0, "start": "2019-09-11 06:56:41.933043", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-9657c\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:56:45.931015 (delta: 4.333865)         elapsed: 756.612413 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:56:46.038054", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:57:46.038411", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:57:46.070708 (delta: 60.139543)         elapsed: 816.752106 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.343771", "end": "2019-09-11 06:57:47.648559", "rc": 0, "start": "2019-09-11 06:57:46.304788", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:57:47.758750 (delta: 1.687978)         elapsed: 818.440148 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:57:47.926227 (delta: 0.167362)         elapsed: 818.607625 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc -n fio", "delta": "0:00:11.441106", "end": "2019-09-11 06:57:59.610596", "rc": 0, "start": "2019-09-11 06:57:48.169490", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-vckgc\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:57:59.686774 (delta: 11.760481)         elapsed: 830.368172 ***** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:57:59.740699", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 06:58:59.740907", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T06:58:59.776562 (delta: 60.089703)         elapsed: 890.45796 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.337470", "end": "2019-09-11 06:59:01.312023", "rc": 0, "start": "2019-09-11 06:58:59.974553", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T06:59:01.417034 (delta: 1.640413)         elapsed: 892.098432 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T06:59:01.593244 (delta: 0.176121)         elapsed: 892.274642 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs -n fio", "delta": "0:00:07.575344", "end": "2019-09-11 06:59:09.642283", "rc": 0, "start": "2019-09-11 06:59:02.066939", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2hljs\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T06:59:09.711265 (delta: 8.117932)         elapsed: 900.392663 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 06:59:09.782339", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 07:00:09.782636", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T07:00:09.822381 (delta: 60.111048)         elapsed: 960.503779 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.459018", "end": "2019-09-11 07:00:11.530258", "rc": 0, "start": "2019-09-11 07:00:10.071240", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T07:00:11.624289 (delta: 1.80182)         elapsed: 962.305687 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T07:00:11.751148 (delta: 0.126777)         elapsed: 962.432546 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc -n fio", "delta": "0:00:08.628398", "end": "2019-09-11 07:00:20.645133", "rc": 0, "start": "2019-09-11 07:00:12.016735", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-67wlc\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T07:00:20.765588 (delta: 9.01436)         elapsed: 971.446986 ******* 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 07:00:20.901616", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 07:01:20.901854", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-09-11T07:01:20.934143 (delta: 60.168381)         elapsed: 1031.615541 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.425120", "end": "2019-09-11 07:01:22.591062", "rc": 0, "start": "2019-09-11 07:01:21.165942", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6\npvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp\n}", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-2ln9m", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-8thm6", "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-09-11T07:01:22.702654 (delta: 1.768455)         elapsed: 1033.384052 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-09-11T07:01:22.879243 (delta: 0.176423)         elapsed: 1033.560641 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp -n fio", "delta": "0:00:03.229034", "end": "2019-09-11 07:01:26.474101", "rc": 0, "start": "2019-09-11 07:01:23.245067", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp\" deleted", "stdout_lines": ["pod \"pvc-9e504cd5-d45f-11e9-acc9-005056985c20-rep-8b7797694-dmcnp\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-09-11T07:01:26.571732 (delta: 3.692366)         elapsed: 1037.25313 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-09-11 07:01:26.632655", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-09-11 07:02:26.632888", "user_input": ""}

TASK [Include replica count test] **********************************************
2019-09-11T07:02:26.667453 (delta: 60.095657)         elapsed: 1097.348851 **** 
included: /experiments/functional/snapshot_deletion/jiva/check_replica_count.yml for 127.0.0.1

TASK [Get controller svc] ******************************************************
2019-09-11T07:02:26.821217 (delta: 0.153695)         elapsed: 1097.502615 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n fio --no-headers -o custom-columns=:spec.clusterIP", "delta": "0:00:01.429803", "end": "2019-09-11 07:02:28.482035", "failed_when_result": false, "rc": 0, "start": "2019-09-11 07:02:27.052232", "stderr": "", "stderr_lines": [], "stdout": "172.24.190.111", "stdout_lines": ["172.24.190.111"]}

TASK [Get total replica count from controller] *********************************
2019-09-11T07:02:28.565489 (delta: 1.744211)         elapsed: 1099.246887 ***** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "connection": "close", "content": "{\"data\":[{\"actions\":{\"deleteSnapshot\":\"http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=deleteSnapshot\",\"revert\":\"http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=revert\",\"shutdown\":\"http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=shutdown\",\"snapshot\":\"http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=snapshot\"},\"id\":\"cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==\",\"links\":{\"self\":\"http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==\"},\"name\":\"pvc-9e504cd5-d45f-11e9-acc9-005056985c20\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://172.24.190.111:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}\n", "content_length": "910", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 11 Sep 2019 07:02:29 GMT", "json": {"data": [{"actions": {"deleteSnapshot": "http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=deleteSnapshot", "revert": "http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=revert", "shutdown": "http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=shutdown", "snapshot": "http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==?action=snapshot"}, "id": "cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA==", "links": {"self": "http://172.24.190.111:9501/v1/volumes/cHZjLTllNTA0Y2Q1LWQ0NWYtMTFlOS1hY2M5LTAwNTA1Njk4NWMyMA=="}, "name": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20", "readOnly": "false", "replicaCount": 3, "type": "volume"}], "links": {"self": "http://172.24.190.111:9501/v1/volumes"}, "resourceType": "volume", "type": "collection"}, "msg": "OK (910 bytes)", "redirected": false, "status": 200, "url": "http://172.24.190.111:9501/v1/volumes", "x_api_schemas": "http://172.24.190.111:9501/v1/schemas"}

TASK [Get rw replica status from controller] ***********************************
2019-09-11T07:02:29.247595 (delta: 0.682045)         elapsed: 1099.928993 ***** 
FAILED - RETRYING: Get rw replica status from controller (20 retries left).
FAILED - RETRYING: Get rw replica status from controller (19 retries left).
FAILED - RETRYING: Get rw replica status from controller (18 retries left).
FAILED - RETRYING: Get rw replica status from controller (17 retries left).
FAILED - RETRYING: Get rw replica status from controller (16 retries left).
FAILED - RETRYING: Get rw replica status from controller (15 retries left).
ok: [127.0.0.1] => {"attempts": 7, "changed": false, "connection": "close", "content": "{\"createTypes\":{\"replica\":\"http://172.24.190.111:9501/v1/replicas\"},\"data\":[{\"actions\":{\"preparerebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==?action=verifyrebuild\"},\"address\":\"tcp://172.23.4.35:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==\",\"links\":{\"self\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==?action=verifyrebuild\"},\"address\":\"tcp://172.23.2.36:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==\",\"links\":{\"self\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==?action=verifyrebuild\"},\"address\":\"tcp://172.23.6.46:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==\",\"links\":{\"self\":\"http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==\"},\"mode\":\"RW\",\"type\":\"replica\"}],\"links\":{\"self\":\"http://172.24.190.111:9501/v1/replicas\"},\"resourceType\":\"replica\",\"type\":\"collection\"}\n", "content_length": "1480", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 11 Sep 2019 07:05:31 GMT", "json": {"createTypes": {"replica": "http://172.24.190.111:9501/v1/replicas"}, "data": [{"actions": {"preparerebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==?action=preparerebuild", "verifyrebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==?action=verifyrebuild"}, "address": "tcp://172.23.4.35:9502", "id": "dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg==", "links": {"self": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMzU6OTUwMg=="}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==?action=preparerebuild", "verifyrebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==?action=verifyrebuild"}, "address": "tcp://172.23.2.36:9502", "id": "dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg==", "links": {"self": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMzY6OTUwMg=="}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==?action=preparerebuild", "verifyrebuild": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==?action=verifyrebuild"}, "address": "tcp://172.23.6.46:9502", "id": "dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg==", "links": {"self": "http://172.24.190.111:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuNDY6OTUwMg=="}, "mode": "RW", "type": "replica"}], "links": {"self": "http://172.24.190.111:9501/v1/replicas"}, "resourceType": "replica", "type": "collection"}, "msg": "OK (1480 bytes)", "redirected": false, "status": 200, "url": "http://172.24.190.111:9501/v1/replicas", "x_api_schemas": "http://172.24.190.111:9501/v1/schemas"}

TASK [Check if fio write job is completed] *************************************
2019-09-11T07:05:31.721255 (delta: 182.473571)         elapsed: 1282.402653 *** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-write\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:01.564142", "end": "2019-09-11 07:05:33.506406", "rc": 0, "start": "2019-09-11 07:05:31.942264", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the fio logs to check if run is complete w/o errors] **************
2019-09-11T07:05:33.677823 (delta: 1.956504)         elapsed: 1284.359221 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-f8crc -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.402643", "end": "2019-09-11 07:05:35.345119", "failed_when_result": false, "rc": 0, "start": "2019-09-11 07:05:33.942476", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Deploy fio read test job] ************************************************
2019-09-11T07:05:35.466604 (delta: 1.788661)         elapsed: 1286.148002 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-read.yml -n fio", "delta": "0:00:01.648766", "end": "2019-09-11 07:05:37.552853", "rc": 0, "start": "2019-09-11 07:05:35.904087", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic-read created\njob.batch/fio-read created", "stdout_lines": ["configmap/basic-read created", "job.batch/fio-read created"]}

TASK [Obtaining the fio read job pod name] *************************************
2019-09-11T07:05:37.625623 (delta: 2.158906)         elapsed: 1288.307021 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-read -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.332957", "end": "2019-09-11 07:05:39.283098", "rc": 0, "start": "2019-09-11 07:05:37.950141", "stderr": "", "stderr_lines": [], "stdout": "fio-read-l25v7", "stdout_lines": ["fio-read-l25v7"]}

TASK [Check if fio read job is completed] **************************************
2019-09-11T07:05:39.359039 (delta: 1.733304)         elapsed: 1290.040437 ***** 
FAILED - RETRYING: Check if fio read job is completed (20 retries left).
FAILED - RETRYING: Check if fio read job is completed (19 retries left).
FAILED - RETRYING: Check if fio read job is completed (18 retries left).
FAILED - RETRYING: Check if fio read job is completed (17 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-read\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:01.296722", "end": "2019-09-11 07:09:47.887679", "rc": 0, "start": "2019-09-11 07:09:46.590957", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the data integrity check] *****************************************
2019-09-11T07:09:47.953184 (delta: 248.59407)         elapsed: 1538.634582 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-read-l25v7 -n fio | grep -i '\"error\"' | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.976747", "end": "2019-09-11 07:09:50.141639", "failed_when_result": false, "rc": 0, "start": "2019-09-11 07:09:48.164892", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Verify Snapshot deletion] ************************************************
2019-09-11T07:09:50.215980 (delta: 2.262735)         elapsed: 1540.897378 ***** 
included: /experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml for 127.0.0.1

TASK [Get the name of controller pod] ******************************************
2019-09-11T07:09:50.383773 (delta: 0.167726)         elapsed: 1541.065171 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=pvc-9e504cd5-d45f-11e9-acc9-005056985c20 -n fio -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "delta": "0:00:01.312350", "end": "2019-09-11 07:09:51.982436", "rc": 0, "start": "2019-09-11 07:09:50.670086", "stderr": "", "stderr_lines": [], "stdout": "pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-95bbbcc86-8wl44", "stdout_lines": ["pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-95bbbcc86-8wl44"]}

TASK [Getting number of snapshots] *********************************************
2019-09-11T07:09:52.082633 (delta: 1.698769)         elapsed: 1542.764031 ***** 
FAILED - RETRYING: Getting number of snapshots (50 retries left).
FAILED - RETRYING: Getting number of snapshots (49 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-95bbbcc86-8wl44 -n fio -- jivactl snapshot ls | grep -v ID | wc -l", "delta": "0:00:02.351180", "end": "2019-09-11 07:10:09.091034", "rc": 0, "start": "2019-09-11 07:10:06.739854", "stderr": "Defaulting container name to pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-con.\nUse 'kubectl describe pod/pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-95bbbcc86-8wl44 -n fio' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-con.", "Use 'kubectl describe pod/pvc-9e504cd5-d45f-11e9-acc9-005056985c20-ctrl-95bbbcc86-8wl44 -n fio' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "10", "stdout_lines": ["10"]}

TASK [set_fact] ****************************************************************
2019-09-11T07:10:09.169867 (delta: 17.087115)         elapsed: 1559.851265 **** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-09-11T07:10:09.269504 (delta: 0.099543)         elapsed: 1559.950902 ***** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-09-11T07:10:09.449232 (delta: 0.179661)         elapsed: 1560.13063 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T07:10:09.508218 (delta: 0.058908)         elapsed: 1560.189616 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T07:10:09.569108 (delta: 0.060832)         elapsed: 1560.250506 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-09-11T07:10:09.659063 (delta: 0.089879)         elapsed: 1560.340461 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7d051c9ab2830b420ab57e65c1a77919cc01ffae", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "27037d02b557dafa06fac7875ada3e9a", "mode": "0644", "owner": "root", "size": 427, "src": "/root/.ansible/tmp/ansible-tmp-1568185809.76-122576748139144/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-09-11T07:10:12.260463 (delta: 2.601298)         elapsed: 1562.941861 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.187486", "end": "2019-09-11 07:10:13.661788", "rc": 0, "start": "2019-09-11 07:10:12.474302", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-09-11T07:10:13.721892 (delta: 1.461345)         elapsed: 1564.40329 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.539845", "end": "2019-09-11 07:10:16.522966", "failed_when_result": false, "rc": 0, "start": "2019-09-11 07:10:13.983121", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=114  changed=57   unreachable=0    failed=0 
```
**What this PR does / why we need it**:

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
