### PR TITLE
refactor[litmusbook]: Updated target_network_loss litmusbook to check the data consistency

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/README.md
+++ b/experiments/chaos/openebs_target_network_loss/README.md
@@ -25,7 +25,7 @@ Chaos |Inject n/w delay on storage target/controller| OpenEBS    | Percona MySQL
 
 - `cstor_target_network_delay.yaml`, `jiva_controller_network_delay.yaml`
 
-## Litmusbook Environment Variables
+## Litmus experiment Environment Variables
 
 ### Application
 
@@ -50,4 +50,28 @@ LIVENESS_APP_NAMESPACE| Namespace in which external liveness pods are deployed, 
 LIVENESS_APP_LABEL    | Unique Labels in `key=value` format for external liveness pod, if any
 DATA_PERSISTENCY      | Data accessibility & integrity verification post recovery (enabled, disabled)
 
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+parameters.yml: |
+  dbuser: root
+  dbpassword: k8sDem0
+  dbname: tdb
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
 

--- a/experiments/chaos/openebs_target_network_loss/README.md
+++ b/experiments/chaos/openebs_target_network_loss/README.md
@@ -63,15 +63,15 @@ Based on the value of env DATA_PERSISTENCE, the corresponding data consistency u
       blocksize: 4k
       blockcount: 1024
       testfile: difiletest
+
 It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
 
 For percona-mysql, the following parameters are to be injected into configmap.
 
-parameters.yml: |
-  dbuser: root
-  dbpassword: k8sDem0
-  dbname: tdb
-The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
 
-Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
 

--- a/experiments/chaos/openebs_target_network_loss/data_persistence.j2
+++ b/experiments/chaos/openebs_target_network_loss/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_target_network_loss/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_network_loss/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: target-network-loss
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -45,8 +54,16 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
-          - name: DATA_PERSISTENCY
-            value: 'enable'
+          - name: DATA_PERSISTENCE
+            value: ""
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_target_network_loss/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: target-network-loss  

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -96,40 +96,6 @@
             delay: 5
             retries: 60
 
-        - name: Delete the application pod
-          shell: kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}
-          args:
-           executable: /bin/bash
-          register: app_pod
-
-        - name: Check whether the application pod is deleted 
-          shell: kubectl get pods -n {{ namespace }}
-          args:
-            executable: /bin/bash
-          register: pod_status
-          until: "app_pod_name.stdout not in pod_status.stdout"
-          delay: 20
-          retries: 15
-
-        - name: Check the application pod is rescheduled
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: new_app_status
-          until: "((new_app_status.stdout_lines|unique)|length) == 1 and 'Running' in new_app_status.stdout"
-          delay: 10
-          retries: 15
-
-        - name: Get the rescheduled  application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: new_pod_name
-
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
 

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -75,9 +75,6 @@
             status: 'LOAD'
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'
           when: data_persistence != ''
 
         ## STORAGE FAULT INJECTION
@@ -142,9 +139,6 @@
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ new_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'
           when: data_persistence != ''
 
         - set_fact:

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -4,6 +4,7 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
@@ -16,11 +17,19 @@
         - include: test_prerequisites.yml
 
         - include_vars:
+            file: data_persistence.yml
+
+        - include_vars:
             file: chaosutil.yml
 
         - name: Record the chaos util path
           set_fact:
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
         
@@ -60,8 +69,8 @@
             executable: /bin/bash
           register: app_pod_name
 
-        - name: Create some test data in the mysql database
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Create some test data
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'LOAD'
             ns: "{{ namespace }}"
@@ -69,7 +78,7 @@
             dbuser: 'root'
             dbpassword: 'k8sDem0'
             dbname: 'tdb'
-          when: data_persistance != ''
+          when: data_persistence != ''
 
         ## STORAGE FAULT INJECTION
 
@@ -127,8 +136,8 @@
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
 
-        - name: Verify mysql data persistence
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
@@ -136,7 +145,7 @@
             dbuser: 'root'
             dbpassword: 'k8sDem0'
             dbname: 'tdb'
-          when: data_persistance != ''
+          when: data_persistence != ''
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
@@ -50,3 +50,7 @@
     src: chaosutil.j2
     dest: chaosutil.yml
 
+- name: Identify the data consistency util to be invoked
+  template:
+    src: data_persistence.j2
+    dest: data_persistence.yml

--- a/experiments/chaos/openebs_target_network_loss/test_vars.yml
+++ b/experiments/chaos/openebs_target_network_loss/test_vars.yml
@@ -7,5 +7,5 @@ c_duration: "{{ lookup('env','CHAOS_DURATION') }}"
 operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

1. Updated the target_network_loss litmusbook to check the data consistency.

## Logs for data consistency check against busybox --->

 config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Jul  9 2019, 16:51:35) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************
2019-09-12T05:36:43.309024 (delta: 0.066784)         elapsed: 0.066784 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2019-09-12T05:36:43.324956 (delta: 0.01585)         elapsed: 0.082716 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2019-09-12T05:36:53.058013 (delta: 9.733027)         elapsed: 9.815773 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2019-09-12T05:36:53.199982 (delta: 0.141899)         elapsed: 9.957742 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n aman-busybox --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.419569", "end": "2019-09-12 05:36:55.261243", "rc": 0, "start": "2019-09-12 05:36:53.841674", "stderr": "", "stderr_lines": [], "stdout": "openebs-sparse-sc-statefulset", "stdout_lines": ["openebs-sparse-sc-statefulset"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2019-09-12T05:36:55.346624 (delta: 2.14651)         elapsed: 12.104384 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-sparse-sc-statefulset --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.318661", "end": "2019-09-12 05:36:56.877688", "rc": 0, "start": "2019-09-12 05:36:55.559027", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2019-09-12T05:36:56.982066 (delta: 1.635364)         elapsed: 13.739826 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-sparse-sc-statefulset"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2019-09-12T05:36:57.169218 (delta: 0.187047)         elapsed: 13.926978 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2019-09-12T05:36:57.369470 (delta: 0.200119)         elapsed: 14.12723 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n aman-busybox --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.339449", "end": "2019-09-12 05:36:58.972430", "rc": 0, "start": "2019-09-12 05:36:57.632981", "stderr": "", "stderr_lines": [], "stdout": "pvc-17ca3243-d51e-11e9-92b9-00505698550d", "stdout_lines": ["pvc-17ca3243-d51e-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2019-09-12T05:36:59.046826 (delta: 1.677236)         elapsed: 15.804586 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-17ca3243-d51e-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.355354", "end": "2019-09-12 05:37:00.790474", "rc": 0, "start": "2019-09-12 05:36:59.435120", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2019-09-12T05:37:00.907589 (delta: 1.860667)         elapsed: 17.665349 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:48
2019-09-12T05:37:01.084185 (delta: 0.176487)         elapsed: 17.841945 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1568266621.15-203235618832307/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:53
2019-09-12T05:37:02.051251 (delta: 0.967011)         elapsed: 18.809011 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1568266622.1-100631116222930/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2019-09-12T05:37:02.485290 (delta: 0.433962)         elapsed: 19.24305 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2019-09-12T05:37:02.584064 (delta: 0.098715)         elapsed: 19.341824 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2019-09-12T05:37:02.694249 (delta: 0.110117)         elapsed: 19.452009 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2019-09-12T05:37:02.855005 (delta: 0.160643)         elapsed: 19.612765 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2019-09-12T05:37:03.077408 (delta: 0.222308)         elapsed: 19.835168 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-12T05:37:03.213140 (delta: 0.13565)         elapsed: 19.9709 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-12T05:37:03.367639 (delta: 0.154398)         elapsed: 20.125399 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2019-09-12T05:37:03.541582 (delta: 0.173846)         elapsed: 20.299342 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-12T05:37:03.796376 (delta: 0.254669)         elapsed: 20.554136 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d9860de79e81adfa6880e9749445e534e4d83205", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7802862277f22fe3145e79fb5cb57dce", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1568266623.86-281454730037486/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-12T05:37:04.239957 (delta: 0.443524)         elapsed: 20.997717 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.111031", "end": "2019-09-12 05:37:05.549548", "rc": 0, "start": "2019-09-12 05:37:04.438517", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-12T05:37:05.615308 (delta: 1.375293)         elapsed: 22.373068 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.707293", "end": "2019-09-12 05:37:07.590798", "failed_when_result": false, "rc": 0, "start": "2019-09-12 05:37:05.883505", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-12T05:37:07.664803 (delta: 2.049434)         elapsed: 24.422563 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-12T05:37:07.744002 (delta: 0.07913)         elapsed: 24.501762 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-12T05:37:07.811214 (delta: 0.06715)         elapsed: 24.568974 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2019-09-12T05:37:07.875232 (delta: 0.063917)         elapsed: 24.632992 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : aman-busybox", 
        "Label        : app=busybox", 
        "PVC          : openebs-busybox", 
        "StorageClass : openebs-sparse-sc-statefulset"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2019-09-12T05:37:07.985119 (delta: 0.109798)         elapsed: 24.742879 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-12T05:37:08.083798 (delta: 0.098621)         elapsed: 24.841558 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n aman-busybox -l app=\"busybox\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.134679", "end": "2019-09-12 05:37:09.454495", "rc": 0, "start": "2019-09-12 05:37:08.319816", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T05:28:29Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T05:28:29Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-12T05:37:09.559141 (delta: 1.475277)         elapsed: 26.316901 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox\")].status.phase}'", "delta": "0:00:01.230671", "end": "2019-09-12 05:37:11.094141", "rc": 0, "start": "2019-09-12 05:37:09.863470", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2019-09-12T05:37:11.225407 (delta: 1.666192)         elapsed: 27.983167 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n aman-busybox -l app=busybox --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:02.276065", "end": "2019-09-12 05:37:13.841590", "rc": 0, "start": "2019-09-12 05:37:11.565525", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-c8bffd58b-46b78", "stdout_lines": ["app-busybox-c8bffd58b-46b78"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2019-09-12T05:37:13.903202 (delta: 2.677692)         elapsed: 30.660962 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-12T05:37:14.105354 (delta: 0.202099)         elapsed: 30.863114 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-c8bffd58b-46b78 -n aman-busybox -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:01.644680", "end": "2019-09-12 05:37:16.007632", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-09-12 05:37:14.362952", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.082219 seconds, 48.7MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.082219 seconds, 48.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-c8bffd58b-46b78 -n aman-busybox -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:01.670162", "end": "2019-09-12 05:37:18.103236", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-09-12 05:37:16.433074", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-12T05:37:18.237173 (delta: 4.131754)         elapsed: 34.994933 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-12T05:37:18.392226 (delta: 0.15492)         elapsed: 35.149986 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-12T05:37:18.477960 (delta: 0.085546)         elapsed: 35.23572 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-12T05:37:18.544795 (delta: 0.066762)         elapsed: 35.302555 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-12T05:37:18.619763 (delta: 0.074906)         elapsed: 35.377523 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-12T05:37:18.698987 (delta: 0.079163)         elapsed: 35.456747 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-12T05:37:18.770757 (delta: 0.071707)         elapsed: 35.528517 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-12T05:37:18.864163 (delta: 0.093331)         elapsed: 35.621923 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-12T05:37:18.990020 (delta: 0.125776)         elapsed: 35.74778 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-12T05:37:19.115086 (delta: 0.124935)         elapsed: 35.872846 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:85
2019-09-12T05:37:19.252052 (delta: 0.13687)         elapsed: 36.009812 ******** 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-09-12T05:37:19.448460 (delta: 0.196305)         elapsed: 36.20622 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n aman-busybox", "delta": "0:00:01.524569", "end": "2019-09-12 05:37:21.221947", "rc": 0, "start": "2019-09-12 05:37:19.697378", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-09-12T05:37:21.285511 (delta: 1.836999)         elapsed: 38.043271 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n aman-busybox | sort | uniq", "delta": "0:00:01.284827", "end": "2019-09-12 05:37:44.317105", "rc": 0, "start": "2019-09-12 05:37:43.032278", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-09-12T05:37:44.406826 (delta: 23.121255)         elapsed: 61.164586 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n aman-busybox --no-headers", "delta": "0:00:01.343284", "end": "2019-09-12 05:37:46.038506", "rc": 0, "start": "2019-09-12 05:37:44.695222", "stderr": "", "stderr_lines": [], "stdout": "pvc-17ca3243-d51e-11e9-92b9-00505698550d", "stdout_lines": ["pvc-17ca3243-d51e-11e9-92b9-00505698550d"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-09-12T05:37:46.125185 (delta: 1.718264)         elapsed: 62.882945 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-17ca3243-d51e-11e9-92b9-00505698550d | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.422874", "end": "2019-09-12 05:37:47.892752", "rc": 0, "start": "2019-09-12 05:37:46.469878", "stderr": "", "stderr_lines": [], "stdout": "pvc-17ca3243-d51e-11e9-92b9-00505698550d-target-7c744fc69cqw8tj", "stdout_lines": ["pvc-17ca3243-d51e-11e9-92b9-00505698550d-target-7c744fc69cqw8tj"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-09-12T05:37:48.016182 (delta: 1.890897)         elapsed: 64.773942 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-17ca3243-d51e-11e9-92b9-00505698550d"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-09-12T05:37:48.220786 (delta: 0.204474)         elapsed: 64.978546 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-17ca3243-d51e-11e9-92b9-00505698550d-target-7c744fc69cqw8tj -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.417478", "end": "2019-09-12 05:37:49.957246", "rc": 0, "start": "2019-09-12 05:37:48.539768", "stderr": "", "stderr_lines": [], "stdout": "node3-1554817485.mayalabs.io", "stdout_lines": ["node3-1554817485.mayalabs.io"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-09-12T05:37:50.064948 (delta: 1.844066)         elapsed: 66.822708 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n aman-busybox -o jsonpath='{.items[?(@.spec.nodeName==''\"node3-1554817485.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.401137", "end": "2019-09-12 05:37:51.982606", "rc": 0, "start": "2019-09-12 05:37:50.581469", "stderr": "", "stderr_lines": [], "stdout": "pumba-pj2cz", "stdout_lines": ["pumba-pj2cz"]}

TASK [Inject egress delay of 240000ms on cstor target for 240s] ****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-09-12T05:37:52.079896 (delta: 2.014854)         elapsed: 68.837656 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-pj2cz -n aman-busybox -- pumba netem --interface eth0 --duration 240s delay --time 240000 re2:k8s_cstor-istgt_pvc-17ca3243-d51e-11e9-92b9-00505698550d", "delta": "0:04:04.305316", "end": "2019-09-12 05:41:56.745196", "rc": 0, "start": "2019-09-12 05:37:52.439880", "stderr": "time=\"2019-09-12T05:37:54Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-09-12T05:37:56Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 for 4m0s\" \ntime=\"2019-09-12T05:37:56Z\" level=info msg=\"Start netem for container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" \ntime=\"2019-09-12T05:41:56Z\" level=info msg=\"Stopping netem on container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28\" \ntime=\"2019-09-12T05:41:56Z\" level=info msg=\"Stop netem for container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 on 'eth0'\" ", "stderr_lines": ["time=\"2019-09-12T05:37:54Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-09-12T05:37:56Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 for 4m0s\" ", "time=\"2019-09-12T05:37:56Z\" level=info msg=\"Start netem for container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" ", "time=\"2019-09-12T05:41:56Z\" level=info msg=\"Stopping netem on container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28\" ", "time=\"2019-09-12T05:41:56Z\" level=info msg=\"Stop netem for container a70e90ff1058ba662880c5831ecd57510a4a60914c4e9f56dc523cc20acf1b28 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-09-12T05:41:56.806638 (delta: 244.72667)         elapsed: 313.564398 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-09-12T05:42:07.306857 (delta: 10.500155)         elapsed: 324.064617 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n aman-busybox", "delta": "0:00:01.360118", "end": "2019-09-12 05:42:08.880695", "rc": 0, "start": "2019-09-12 05:42:07.520577", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-09-12T05:42:08.944708 (delta: 1.637795)         elapsed: 325.702468 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n aman-busybox", "delta": "0:00:01.253769", "end": "2019-09-12 05:42:10.451765", "rc": 0, "start": "2019-09-12 05:42:09.197996", "stderr": "", "stderr_lines": [], "stdout": "pumba-g7jcs   0/1   Terminating   0     4m\npumba-nxbcd   0/1   Terminating   0     4m\npumba-pj2cz   1/1   Terminating   0     4m", "stdout_lines": ["pumba-g7jcs   0/1   Terminating   0     4m", "pumba-nxbcd   0/1   Terminating   0     4m", "pumba-pj2cz   1/1   Terminating   0     4m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:93
2019-09-12T05:42:10.544186 (delta: 1.59942)         elapsed: 327.301946 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-12T05:42:10.681020 (delta: 0.136771)         elapsed: 327.43878 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n aman-busybox -l app=\"busybox\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.219970", "end": "2019-09-12 05:42:12.137899", "rc": 0, "start": "2019-09-12 05:42:10.917929", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T05:28:29Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T05:28:29Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-12T05:42:12.205995 (delta: 1.52491)         elapsed: 328.963755 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox\")].status.phase}'", "delta": "0:00:01.307074", "end": "2019-09-12 05:42:13.763850", "rc": 0, "start": "2019-09-12 05:42:12.456776", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Delete the application pod] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:102
2019-09-12T05:42:13.834030 (delta: 1.627981)         elapsed: 330.59179 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-c8bffd58b-46b78 -n aman-busybox", "delta": "0:00:34.424737", "end": "2019-09-12 05:42:48.462574", "rc": 0, "start": "2019-09-12 05:42:14.037837", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-c8bffd58b-46b78\" deleted", "stdout_lines": ["pod \"app-busybox-c8bffd58b-46b78\" deleted"]}

TASK [Check whether the application pod is deleted] ****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:108
2019-09-12T05:42:48.609747 (delta: 34.775654)         elapsed: 365.367507 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox", "delta": "0:00:01.148483", "end": "2019-09-12 05:42:50.051914", "rc": 0, "start": "2019-09-12 05:42:48.903431", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS    RESTARTS   AGE\napp-busybox-c8bffd58b-xd282   1/1     Running   0          35s", "stdout_lines": ["NAME                          READY   STATUS    RESTARTS   AGE", "app-busybox-c8bffd58b-xd282   1/1     Running   0          35s"]}

TASK [Check the application pod is rescheduled] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:117
2019-09-12T05:42:50.120055 (delta: 1.5102)         elapsed: 366.877815 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox -l app=busybox --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.239009", "end": "2019-09-12 05:42:51.573317", "rc": 0, "start": "2019-09-12 05:42:50.334308", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the rescheduled  application pod name] *******************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:128
2019-09-12T05:42:51.648852 (delta: 1.528741)         elapsed: 368.406612 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n aman-busybox -l app=busybox --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.180830", "end": "2019-09-12 05:42:53.060506", "rc": 0, "start": "2019-09-12 05:42:51.879676", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-c8bffd58b-xd282", "stdout_lines": ["app-busybox-c8bffd58b-xd282"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:136
2019-09-12T05:42:53.123383 (delta: 1.474464)         elapsed: 369.881143 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:139
2019-09-12T05:42:53.185093 (delta: 0.061654)         elapsed: 369.942853 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-12T05:42:53.340748 (delta: 0.155595)         elapsed: 370.098508 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-12T05:42:53.441497 (delta: 0.100693)         elapsed: 370.199257 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-c8bffd58b-xd282 -n aman-busybox", "delta": "0:00:39.573268", "end": "2019-09-12 05:43:33.248802", "rc": 0, "start": "2019-09-12 05:42:53.675534", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-c8bffd58b-xd282\" deleted", "stdout_lines": ["pod \"app-busybox-c8bffd58b-xd282\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-12T05:43:33.391387 (delta: 39.949833)         elapsed: 410.149147 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox", "delta": "0:00:01.368340", "end": "2019-09-12 05:43:35.058401", "rc": 0, "start": "2019-09-12 05:43:33.690061", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS    RESTARTS   AGE\napp-busybox-c8bffd58b-xjbl5   1/1     Running   0          41s", "stdout_lines": ["NAME                          READY   STATUS    RESTARTS   AGE", "app-busybox-c8bffd58b-xjbl5   1/1     Running   0          41s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-12T05:43:35.197511 (delta: 1.806024)         elapsed: 411.955271 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n aman-busybox -l app=busybox -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.221461", "end": "2019-09-12 05:43:36.730697", "rc": 0, "start": "2019-09-12 05:43:35.509236", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-c8bffd58b-xjbl5", "stdout_lines": ["app-busybox-c8bffd58b-xjbl5"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-12T05:43:36.791098 (delta: 1.593491)         elapsed: 413.548858 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-c8bffd58b-xjbl5\")].status.phase}'", "delta": "0:00:01.364270", "end": "2019-09-12 05:43:38.428779", "rc": 0, "start": "2019-09-12 05:43:37.064509", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-12T05:43:38.542409 (delta: 1.751256)         elapsed: 415.300169 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n aman-busybox -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-c8bffd58b-xjbl5\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.382051", "end": "2019-09-12 05:43:40.234531", "rc": 0, "start": "2019-09-12 05:43:38.852480", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T05:42:59Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T05:42:59Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-12T05:43:40.319379 (delta: 1.776898)         elapsed: 417.077139 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-c8bffd58b-xjbl5 -n aman-busybox -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.920317", "end": "2019-09-12 05:43:42.517701", "failed_when_result": false, "rc": 0, "start": "2019-09-12 05:43:40.597384", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-12T05:43:42.586661 (delta: 2.267211)         elapsed: 419.344421 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-c8bffd58b-xjbl5 -n aman-busybox -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.750877", "end": "2019-09-12 05:43:44.583607", "failed_when_result": false, "rc": 0, "start": "2019-09-12 05:43:42.832730", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-12T05:43:44.769471 (delta: 2.182756)         elapsed: 421.527231 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-12T05:43:44.926681 (delta: 0.157106)         elapsed: 421.684441 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-12T05:43:44.991510 (delta: 0.064769)         elapsed: 421.74927 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:150
2019-09-12T05:43:45.053162 (delta: 0.061592)         elapsed: 421.810922 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:161
2019-09-12T05:43:45.137230 (delta: 0.084014)         elapsed: 421.89499 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-12T05:43:45.253960 (delta: 0.116655)         elapsed: 422.01172 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-12T05:43:45.310470 (delta: 0.056455)         elapsed: 422.06823 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-12T05:43:45.384697 (delta: 0.074175)         elapsed: 422.142457 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-12T05:43:45.459662 (delta: 0.074896)         elapsed: 422.217422 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cd521ba3834fdc7ebdaaaf2b9d1245702cd7227c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "40fdc05ee57c44d3b9159f71bf44c775", "mode": "0644", "owner": "root", "size": 460, "src": "/root/.ansible/tmp/ansible-tmp-1568267025.56-88930848979412/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-12T05:43:48.373548 (delta: 2.913815)         elapsed: 425.131308 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.164387", "end": "2019-09-12 05:43:49.881913", "rc": 0, "start": "2019-09-12 05:43:48.717526", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-12T05:43:49.947102 (delta: 1.57349)         elapsed: 426.704862 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.492218", "end": "2019-09-12 05:43:51.775727", "failed_when_result": false, "rc": 0, "start": "2019-09-12 05:43:50.283509", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=58   changed=38   unreachable=0    failed=0   

2019-09-12T05:43:51.882403 (delta: 1.93523)         elapsed: 428.640163 ******* 









## Logs for data consistency check against percona --->
 

config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Jul  9 2019, 16:51:35) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************
2019-09-12T07:34:00.754997 (delta: 0.073677)         elapsed: 0.073677 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2019-09-12T07:34:00.771086 (delta: 0.016027)         elapsed: 0.089766 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2019-09-12T07:34:10.226053 (delta: 9.454945)         elapsed: 9.544733 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2019-09-12T07:34:10.352400 (delta: 0.126274)         elapsed: 9.67108 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-124 --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:02.241170", "end": "2019-09-12 07:34:13.075982", "rc": 0, "start": "2019-09-12 07:34:10.834812", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2019-09-12T07:34:13.200527 (delta: 2.848025)         elapsed: 12.519207 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.359727", "end": "2019-09-12 07:34:15.074109", "rc": 0, "start": "2019-09-12 07:34:13.714382", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2019-09-12T07:34:15.168897 (delta: 1.968269)         elapsed: 14.487577 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2019-09-12T07:34:15.362586 (delta: 0.193608)         elapsed: 14.681266 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2019-09-12T07:34:15.562527 (delta: 0.199843)         elapsed: 14.881207 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-124 --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.263728", "end": "2019-09-12 07:34:17.229655", "rc": 0, "start": "2019-09-12 07:34:15.965927", "stderr": "", "stderr_lines": [], "stdout": "pvc-2775a78b-d52f-11e9-92b9-00505698550d", "stdout_lines": ["pvc-2775a78b-d52f-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2019-09-12T07:34:17.362510 (delta: 1.799843)         elapsed: 16.68119 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-2775a78b-d52f-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.310256", "end": "2019-09-12 07:34:19.082499", "rc": 0, "start": "2019-09-12 07:34:17.772243", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2019-09-12T07:34:19.179135 (delta: 1.816524)         elapsed: 18.497815 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:48
2019-09-12T07:34:19.366516 (delta: 0.187261)         elapsed: 18.685196 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "137781b9db9e90483410f27628fcbde087b091e6", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "596bdd1088ab2ad5ab78689e89933c03", "mode": "0644", "owner": "root", "size": 63, "src": "/root/.ansible/tmp/ansible-tmp-1568273659.42-106932663370547/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:53
2019-09-12T07:34:20.189386 (delta: 0.822815)         elapsed: 19.508066 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1568273660.25-7453497665905/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2019-09-12T07:34:20.714651 (delta: 0.525211)         elapsed: 20.033331 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2019-09-12T07:34:20.819070 (delta: 0.104352)         elapsed: 20.13775 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_controller_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2019-09-12T07:34:20.921364 (delta: 0.102232)         elapsed: 20.240044 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_controller_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2019-09-12T07:34:21.029224 (delta: 0.107799)         elapsed: 20.347904 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2019-09-12T07:34:21.137582 (delta: 0.108275)         elapsed: 20.456262 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-12T07:34:21.233546 (delta: 0.095883)         elapsed: 20.552226 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-12T07:34:21.328892 (delta: 0.095247)         elapsed: 20.647572 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2019-09-12T07:34:21.465505 (delta: 0.136545)         elapsed: 20.784185 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-12T07:34:21.596308 (delta: 0.130697)         elapsed: 20.914988 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8e0841832a793354ba03dd5c3707b4054aa649aa", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6fbd50533272587f60314e2251a3eb41", "mode": "0644", "owner": "root", "size": 465, "src": "/root/.ansible/tmp/ansible-tmp-1568273661.67-148441321444750/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-12T07:34:22.166288 (delta: 0.56992)         elapsed: 21.484968 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.155411", "end": "2019-09-12 07:34:23.528244", "rc": 0, "start": "2019-09-12 07:34:22.372833", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-12T07:34:23.596717 (delta: 1.430372)         elapsed: 22.915397 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.615431", "end": "2019-09-12 07:34:25.434851", "failed_when_result": false, "rc": 0, "start": "2019-09-12 07:34:23.819420", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-12T07:34:25.621496 (delta: 2.024717)         elapsed: 24.940176 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-12T07:34:25.782015 (delta: 0.160379)         elapsed: 25.100695 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-12T07:34:25.888980 (delta: 0.106853)         elapsed: 25.20766 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2019-09-12T07:34:25.967205 (delta: 0.078165)         elapsed: 25.285885 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : percona-124", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2019-09-12T07:34:26.103671 (delta: 0.136389)         elapsed: 25.422351 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-12T07:34:26.255335 (delta: 0.151578)         elapsed: 25.574015 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona-124 -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.322311", "end": "2019-09-12 07:34:27.892122", "rc": 0, "start": "2019-09-12 07:34:26.569811", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T07:30:38Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T07:30:38Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-12T07:34:27.977775 (delta: 1.722356)         elapsed: 27.296455 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124 -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.322438", "end": "2019-09-12 07:34:29.605011", "rc": 0, "start": "2019-09-12 07:34:28.282573", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2019-09-12T07:34:29.750127 (delta: 1.772248)         elapsed: 29.068807 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-124 -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.257000", "end": "2019-09-12 07:34:31.515938", "rc": 0, "start": "2019-09-12 07:34:30.258938", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-8vczs", "stdout_lines": ["percona-7685f6f58-8vczs"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2019-09-12T07:34:31.590148 (delta: 1.839914)         elapsed: 30.908828 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-12T07:34:31.860867 (delta: 0.270641)         elapsed: 31.179547 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-8vczs -n percona-124 -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:01.648872", "end": "2019-09-12 07:34:33.763316", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2019-09-12 07:34:32.114444", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-8vczs -n percona-124 -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:01.638845", "end": "2019-09-12 07:34:35.903163", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2019-09-12 07:34:34.264318", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-8vczs -n percona-124 -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:01.530439", "end": "2019-09-12 07:34:37.703913", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2019-09-12 07:34:36.173474", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-12T07:34:37.854375 (delta: 5.993451)         elapsed: 37.173055 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-12T07:34:37.924589 (delta: 0.070105)         elapsed: 37.243269 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-12T07:34:37.984022 (delta: 0.05937)         elapsed: 37.302702 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-12T07:34:38.054948 (delta: 0.070855)         elapsed: 37.373628 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-12T07:34:38.130641 (delta: 0.075627)         elapsed: 37.449321 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-12T07:34:38.301650 (delta: 0.170935)         elapsed: 37.62033 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-12T07:34:38.387631 (delta: 0.085917)         elapsed: 37.706311 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-12T07:34:38.485140 (delta: 0.097436)         elapsed: 37.80382 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-12T07:34:38.619425 (delta: 0.134102)         elapsed: 37.938105 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:85
2019-09-12T07:34:38.787127 (delta: 0.167602)         elapsed: 38.105807 ******* 
included: /chaoslib/openebs/jiva_controller_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:1
2019-09-12T07:34:38.999279 (delta: 0.212029)         elapsed: 38.317959 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n percona-124", "delta": "0:00:01.571465", "end": "2019-09-12 07:34:40.845601", "rc": 0, "start": "2019-09-12 07:34:39.274136", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:9
2019-09-12T07:34:40.909216 (delta: 1.909875)         elapsed: 40.227896 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n percona-124 | sort | uniq", "delta": "0:00:01.341369", "end": "2019-09-12 07:35:04.236102", "rc": 0, "start": "2019-09-12 07:35:02.894733", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:21
2019-09-12T07:35:04.406852 (delta: 23.497555)         elapsed: 63.725532 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n percona-124 --no-headers", "delta": "0:00:01.399397", "end": "2019-09-12 07:35:06.192716", "rc": 0, "start": "2019-09-12 07:35:04.793319", "stderr": "", "stderr_lines": [], "stdout": "pvc-2775a78b-d52f-11e9-92b9-00505698550d", "stdout_lines": ["pvc-2775a78b-d52f-11e9-92b9-00505698550d"]}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:30
2019-09-12T07:35:06.290740 (delta: 1.883784)         elapsed: 65.60942 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller -n percona-124 --no-headers | grep pvc-2775a78b-d52f-11e9-92b9-00505698550d | awk '{print $1}'", "delta": "0:00:01.356045", "end": "2019-09-12 07:35:08.087908", "rc": 0, "start": "2019-09-12 07:35:06.731863", "stderr": "", "stderr_lines": [], "stdout": "pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd", "stdout_lines": ["pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd"]}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:39
2019-09-12T07:35:08.156671 (delta: 1.865844)         elapsed: 67.475351 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-con"}, "changed": false}

TASK [Get the node on which the jiva controller is scheduled] ******************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:44
2019-09-12T07:35:08.265096 (delta: 0.108365)         elapsed: 67.583776 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd -n percona-124 --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.319751", "end": "2019-09-12 07:35:09.970043", "rc": 0, "start": "2019-09-12 07:35:08.650292", "stderr": "", "stderr_lines": [], "stdout": "node1-1554817485.mayalabs.io", "stdout_lines": ["node1-1554817485.mayalabs.io"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:52
2019-09-12T07:35:10.092832 (delta: 1.827648)         elapsed: 69.411512 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n percona-124 -o=jsonpath='{.items[0].spec.clusterIP}'", "delta": "0:00:01.437801", "end": "2019-09-12 07:35:11.828227", "failed_when_result": false, "rc": 0, "start": "2019-09-12 07:35:10.390426", "stderr": "", "stderr_lines": [], "stdout": "172.24.97.78", "stdout_lines": ["172.24.97.78"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:61
2019-09-12T07:35:11.918429 (delta: 1.825497)         elapsed: 71.237109 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd -n percona-124 -c pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:24.849463", "end": "2019-09-12 07:35:36.982091", "rc": 0, "start": "2019-09-12 07:35:12.132628", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:7 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:8 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1322 kB]\nGet:10 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [942 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [986 kB]\nGet:13 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:14 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [582 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]\nGet:18 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6114 B]\nFetched 16.0 MB in 10s (1464 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 1s (168 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5294 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 586 kB of archives.\nAfter this operation, 1809 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 586 kB in 2s (280 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5306 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...", "stdout_lines": ["Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:7 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:8 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1322 kB]", "Get:10 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [942 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [986 kB]", "Get:13 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:14 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [582 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]", "Get:18 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6114 B]", "Fetched 16.0 MB in 10s (1464 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 1s (168 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5294 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 23 not upgraded.", "Need to get 586 kB of archives.", "After this operation, 1809 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 586 kB in 2s (280 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5306 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ..."]}

TASK [Getting the ReplicaCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:68
2019-09-12T07:35:37.125574 (delta: 25.207078)         elapsed: 96.444254 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd -n percona-124 -c pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-con curl http://\"172.24.97.78\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.851743", "end": "2019-09-12 07:35:39.384386", "rc": 0, "start": "2019-09-12 07:35:37.532643", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   898  100   898    0     0   163k      0 --:--:-- --:--:-- --:--:--  219k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   898  100   898    0     0   163k      0 --:--:-- --:--:-- --:--:--  219k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Identify the pumba pod that co-exists with jiva controller] **************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:76
2019-09-12T07:35:39.506949 (delta: 2.381277)         elapsed: 98.825629 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n percona-124 -o jsonpath='{.items[?(@.spec.nodeName==''\"node1-1554817485.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.308462", "end": "2019-09-12 07:35:41.219548", "rc": 0, "start": "2019-09-12 07:35:39.911086", "stderr": "", "stderr_lines": [], "stdout": "pumba-l24j5", "stdout_lines": ["pumba-l24j5"]}

TASK [Inject egress delay of 240000ms on jiva controller for 240s] *************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:84
2019-09-12T07:35:41.340746 (delta: 1.833701)         elapsed: 100.659426 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-l24j5 -n percona-124 -- pumba netem --interface eth0 --duration 240s delay --time 240000 re2:k8s_pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-co", "delta": "0:04:03.699148", "end": "2019-09-12 07:39:45.336507", "rc": 0, "start": "2019-09-12 07:35:41.637359", "stderr": "time=\"2019-09-12T07:35:43Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-09-12T07:35:44Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e for 4m0s\" \ntime=\"2019-09-12T07:35:44Z\" level=info msg=\"Start netem for container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" \ntime=\"2019-09-12T07:39:45Z\" level=info msg=\"Stopping netem on container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e\" \ntime=\"2019-09-12T07:39:45Z\" level=info msg=\"Stop netem for container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e on 'eth0'\" ", "stderr_lines": ["time=\"2019-09-12T07:35:43Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-09-12T07:35:44Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e for 4m0s\" ", "time=\"2019-09-12T07:35:44Z\" level=info msg=\"Start netem for container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" ", "time=\"2019-09-12T07:39:45Z\" level=info msg=\"Stopping netem on container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e\" ", "time=\"2019-09-12T07:39:45Z\" level=info msg=\"Stop netem for container a97477e12a5bb0489d805157c562086acc46591a7675e408a4c4af329d078f3e on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Verifying the Replica getting disconnected] ******************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:92
2019-09-12T07:39:45.464328 (delta: 244.123467)         elapsed: 344.783008 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd -n percona-124 -c pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-con curl http://\"172.24.97.78\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.522724", "end": "2019-09-12 07:39:47.325491", "rc": 0, "start": "2019-09-12 07:39:45.802767", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   517  100   517    0     0   120k      0 --:--:-- --:--:-- --:--:--  168k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   517  100   517    0     0   120k      0 --:--:-- --:--:-- --:--:--  168k"], "stdout": "0", "stdout_lines": ["0"]}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:103
2019-09-12T07:39:47.497201 (delta: 2.032747)         elapsed: 346.815881 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n percona-124", "delta": "0:00:01.511222", "end": "2019-09-12 07:39:49.314032", "rc": 0, "start": "2019-09-12 07:39:47.802810", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:109
2019-09-12T07:39:49.466996 (delta: 1.969632)         elapsed: 348.785676 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n percona-124", "delta": "0:00:01.377568", "end": "2019-09-12 07:39:51.116883", "rc": 0, "start": "2019-09-12 07:39:49.739315", "stderr": "", "stderr_lines": [], "stdout": "pumba-l24j5   0/1   Terminating   0     5m\npumba-lmwss   0/1   Terminating   0     5m\npumba-nrxwz   0/1   Terminating   0     5m", "stdout_lines": ["pumba-l24j5   0/1   Terminating   0     5m", "pumba-lmwss   0/1   Terminating   0     5m", "pumba-nrxwz   0/1   Terminating   0     5m"]}

TASK [Verifying the replicas post network recovery] ****************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:119
2019-09-12T07:39:51.220097 (delta: 1.752997)         elapsed: 350.538777 ****** 
FAILED - RETRYING: Verifying the replicas post network recovery (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl exec -it pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd -n percona-124 -c pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-con curl http://\"172.24.97.78\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.554719", "end": "2019-09-12 07:40:10.339620", "rc": 0, "start": "2019-09-12 07:40:08.784901", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   898  100   898    0     0   418k      0 --:--:-- --:--:-- --:--:--  876k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   898  100   898    0     0   418k      0 --:--:-- --:--:-- --:--:--  876k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:93
2019-09-12T07:40:10.482634 (delta: 19.262463)         elapsed: 369.801314 ***** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-12T07:40:10.715468 (delta: 0.23273)         elapsed: 370.034148 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
FAILED - RETRYING: Get the container status of application. (131 retries left).
FAILED - RETRYING: Get the container status of application. (130 retries left).
FAILED - RETRYING: Get the container status of application. (129 retries left).
FAILED - RETRYING: Get the container status of application. (128 retries left).
FAILED - RETRYING: Get the container status of application. (127 retries left).
FAILED - RETRYING: Get the container status of application. (126 retries left).
changed: [127.0.0.1] => {"attempts": 26, "changed": true, "cmd": "kubectl get pod -n percona-124 -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.269503", "end": "2019-09-12 07:41:44.347075", "rc": 0, "start": "2019-09-12 07:41:43.077572", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T07:41:43Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T07:41:43Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-12T07:41:44.470589 (delta: 93.755015)         elapsed: 463.789269 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124 -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.276364", "end": "2019-09-12 07:41:46.111861", "rc": 0, "start": "2019-09-12 07:41:44.835497", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Delete the application pod] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:102
2019-09-12T07:41:46.252083 (delta: 1.781395)         elapsed: 465.570763 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7685f6f58-8vczs -n percona-124", "delta": "0:00:03.100851", "end": "2019-09-12 07:41:49.672167", "rc": 0, "start": "2019-09-12 07:41:46.571316", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7685f6f58-8vczs\" deleted", "stdout_lines": ["pod \"percona-7685f6f58-8vczs\" deleted"]}

TASK [Check whether the application pod is deleted] ****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:108
2019-09-12T07:41:49.815111 (delta: 3.562932)         elapsed: 469.133791 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124", "delta": "0:00:01.411982", "end": "2019-09-12 07:41:51.519740", "rc": 0, "start": "2019-09-12 07:41:50.107758", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY   STATUS              RESTARTS   AGE\npercona-7685f6f58-4ml9h                                          0/1     ContainerCreating   0          3s\npvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd   2/2     Running             0          11m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-66wxv    1/1     Running             2          11m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-n4s2v    1/1     Running             3          11m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-w2vrh    1/1     Running             3          11m", "stdout_lines": ["NAME                                                             READY   STATUS              RESTARTS   AGE", "percona-7685f6f58-4ml9h                                          0/1     ContainerCreating   0          3s", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd   2/2     Running             0          11m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-66wxv    1/1     Running             2          11m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-n4s2v    1/1     Running             3          11m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-w2vrh    1/1     Running             3          11m"]}

TASK [Check the application pod is rescheduled] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:117
2019-09-12T07:41:51.625406 (delta: 1.81016)         elapsed: 470.944086 ******* 
FAILED - RETRYING: Check the application pod is rescheduled (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona-124 -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.496715", "end": "2019-09-12 07:42:05.074809", "rc": 0, "start": "2019-09-12 07:42:03.578094", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the rescheduled  application pod name] *******************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:128
2019-09-12T07:42:05.167649 (delta: 13.542165)         elapsed: 484.486329 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-124 -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.133183", "end": "2019-09-12 07:42:06.778429", "rc": 0, "start": "2019-09-12 07:42:05.645246", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-4ml9h", "stdout_lines": ["percona-7685f6f58-4ml9h"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:136
2019-09-12T07:42:06.849975 (delta: 1.682251)         elapsed: 486.168655 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:139
2019-09-12T07:42:06.934437 (delta: 0.084402)         elapsed: 486.253117 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-12T07:42:07.165561 (delta: 0.231047)         elapsed: 486.484241 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-12T07:42:07.265251 (delta: 0.099631)         elapsed: 486.583931 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7685f6f58-4ml9h -n percona-124", "delta": "0:00:06.703391", "end": "2019-09-12 07:42:14.263526", "rc": 0, "start": "2019-09-12 07:42:07.560135", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7685f6f58-4ml9h\" deleted", "stdout_lines": ["pod \"percona-7685f6f58-4ml9h\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-12T07:42:14.417607 (delta: 7.152232)         elapsed: 493.736287 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124", "delta": "0:00:01.332823", "end": "2019-09-12 07:42:16.104142", "rc": 0, "start": "2019-09-12 07:42:14.771319", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY   STATUS    RESTARTS   AGE\npercona-7685f6f58-5279n                                          1/1     Running   0          8s\npvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd   2/2     Running   0          12m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-66wxv    1/1     Running   2          11m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-n4s2v    1/1     Running   3          11m\npvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-w2vrh    1/1     Running   3          11m", "stdout_lines": ["NAME                                                             READY   STATUS    RESTARTS   AGE", "percona-7685f6f58-5279n                                          1/1     Running   0          8s", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-ctrl-65f8c996df-hlttd   2/2     Running   0          12m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-66wxv    1/1     Running   2          11m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-n4s2v    1/1     Running   3          11m", "pvc-2775a78b-d52f-11e9-92b9-00505698550d-rep-7bcc5b879c-w2vrh    1/1     Running   3          11m"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-12T07:42:16.190506 (delta: 1.772792)         elapsed: 495.509186 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-124 -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.361930", "end": "2019-09-12 07:42:17.897959", "rc": 0, "start": "2019-09-12 07:42:16.536029", "stderr": "", "stderr_lines": [], "stdout": "percona-7685f6f58-5279n", "stdout_lines": ["percona-7685f6f58-5279n"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-12T07:42:17.976346 (delta: 1.785769)         elapsed: 497.295026 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124 -o jsonpath='{.items[?(@.metadata.name==\"percona-7685f6f58-5279n\")].status.phase}'", "delta": "0:00:01.470987", "end": "2019-09-12 07:42:19.789737", "rc": 0, "start": "2019-09-12 07:42:18.318750", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-12T07:42:19.888987 (delta: 1.912543)         elapsed: 499.207667 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-124 -o jsonpath='{.items[?(@.metadata.name==\"percona-7685f6f58-5279n\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.384143", "end": "2019-09-12 07:42:21.553120", "rc": 0, "start": "2019-09-12 07:42:20.168977", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-12T07:42:11Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-12T07:42:11Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-12T07:42:21.633385 (delta: 1.744248)         elapsed: 500.952065 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-5279n -n percona-124 -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:01.681919", "end": "2019-09-12 07:42:23.715419", "failed_when_result": false, "rc": 0, "start": "2019-09-12 07:42:22.033500", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-12T07:42:23.811865 (delta: 2.178406)         elapsed: 503.130545 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7685f6f58-5279n -n percona-124 -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:01.605816", "end": "2019-09-12 07:42:25.652681", "failed_when_result": false, "rc": 0, "start": "2019-09-12 07:42:24.046865", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-12T07:42:25.813538 (delta: 2.001611)         elapsed: 505.132218 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-12T07:42:25.936450 (delta: 0.122821)         elapsed: 505.25513 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:150
2019-09-12T07:42:26.049994 (delta: 0.113455)         elapsed: 505.368674 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:161
2019-09-12T07:42:26.222753 (delta: 0.172654)         elapsed: 505.541433 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-12T07:42:26.430193 (delta: 0.207339)         elapsed: 505.748873 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-12T07:42:26.501854 (delta: 0.071542)         elapsed: 505.820534 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-12T07:42:26.573495 (delta: 0.071556)         elapsed: 505.892175 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-12T07:42:26.664343 (delta: 0.090783)         elapsed: 505.983023 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "da39158cfc759d88d401b1d85578ee3c603fa5c5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "799e965c7dabea0a387c5483269ef64f", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1568274146.74-21459621935328/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-12T07:42:29.435741 (delta: 2.771306)         elapsed: 508.754421 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.348587", "end": "2019-09-12 07:42:31.079592", "rc": 0, "start": "2019-09-12 07:42:29.731005", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-12T07:42:31.145561 (delta: 1.709765)         elapsed: 510.464241 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.463880", "end": "2019-09-12 07:42:32.851638", "failed_when_result": false, "rc": 0, "start": "2019-09-12 07:42:31.387758", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=62   changed=43   unreachable=0    failed=0   

2019-09-12T07:42:32.904970 (delta: 1.759352)         elapsed: 512.22365 ******* 
