### PR TITLE
refactor(yaml): updated task to check pool pod status

### DIFF
--- a/providers/openebs/installers/operator/master/litmusbook/test.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/test.yaml
@@ -289,11 +289,11 @@
                   retries: 120
 
                 - name: Confirm if sparse pool is running in all the nodes
-                  shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="cstor-sparse-pool")].status.phase}'
+                  shell: kubectl get pods -n {{ namespace }} -l openebs.io/storage-pool-claim==cstor-sparse-pool -o custom-columns=:status.phase --no-headers  
                   args:
                     executable: /bin/bash
                   register: sparse_pool_count
-                  until: (sparse_pool_count.stdout)|int == (maxpool_count.stdout)|int
+                  until: "(sparse_pool_count.stdout_lines)|length == (maxpool_count.stdout)|int  and 'Running' in sparse_pool_count.stdout"
                   delay: 5
                   retries: 120  
 

--- a/providers/openebs/installers/operator/master/litmusbook/test.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/test.yaml
@@ -288,14 +288,23 @@
                   delay: 5
                   retries: 120
 
-                - name: Confirm if sparse pool is running in all the nodes
+                - name: Confirm if sparse pool is created in all the nodes
                   shell: kubectl get pods -n {{ namespace }} -l openebs.io/storage-pool-claim==cstor-sparse-pool -o custom-columns=:status.phase --no-headers  
                   args:
                     executable: /bin/bash
                   register: sparse_pool_count
-                  until: "(sparse_pool_count.stdout_lines)|length == (maxpool_count.stdout)|int  and 'Running' in sparse_pool_count.stdout"
+                  until: "(sparse_pool_count.stdout_lines)|length == (maxpool_count.stdout)|int"
                   delay: 5
                   retries: 120  
+
+                - name: Confirm if sparse pool is running in all the nodes
+                  shell: kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-sparse-pool -o custom-columns=:.status.phase --no-headers|uniq
+                  args:
+                    executable: /bin/bash
+                  register: sparse_pool_count
+                  until: "sparse_pool_count.stdout == 'Running'"
+                  delay: 5
+                  retries: 120 
 
               when: lookup('env','INSTALL_DEFAULT_CSP') == "true"
 


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
updated the task to check pool pod status in openebs deployer litmusbook
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
 config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yaml ************************************************************
1 plays in ./providers/openebs/installers/operator/master/litmusbook/test.yaml

PLAY [localhost] ***************************************************************
2019-09-13T14:58:01.481338 (delta: 0.064346)         elapsed: 0.064346 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:4
2019-09-13T14:58:01.497827 (delta: 0.016418)         elapsed: 0.080835 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:15
2019-09-13T14:58:11.071927 (delta: 9.574074)         elapsed: 9.654935 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-13T14:58:11.294476 (delta: 0.222504)         elapsed: 9.877484 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-13T14:58:11.409734 (delta: 0.115198)         elapsed: 9.992742 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:18
2019-09-13T14:58:11.552965 (delta: 0.14314)         elapsed: 10.135973 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-13T14:58:11.842887 (delta: 0.289833)         elapsed: 10.425895 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "a1237ef08ce94e87de39be97e2675d791da608ec", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "fc9d410c1786af4bbaee8758a12235dd", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1568386691.97-260580658935405/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-13T14:58:13.096188 (delta: 1.253211)         elapsed: 11.679196 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.044748", "end": "2019-09-13 14:58:14.726565", "rc": 0, "start": "2019-09-13 14:58:13.681817", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-13T14:58:14.836172 (delta: 1.73992)         elapsed: 13.41918 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.695866", "end": "2019-09-13 14:58:16.898851", "failed_when_result": false, "rc": 0, "start": "2019-09-13 14:58:15.202985", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-provision configured", "stdout_lines": ["litmusresult.litmus.io/openebs-provision configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-13T14:58:17.050598 (delta: 2.214357)         elapsed: 15.633606 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-13T14:58:17.183595 (delta: 0.13291)         elapsed: 15.766603 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-13T14:58:17.321232 (delta: 0.137545)         elapsed: 15.90424 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating pod security policy, cluster role and clusterrolebinding] *******
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:30
2019-09-13T14:58:17.454641 (delta: 0.133298)         elapsed: 16.037649 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"openebs_psp.yaml\"", "delta": "0:00:01.584889", "end": "2019-09-13 14:58:19.504307", "failed_when_result": false, "rc": 0, "start": "2019-09-13 14:58:17.919418", "stderr": "", "stderr_lines": [], "stdout": "podsecuritypolicy.extensions/privileged unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-psp unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged", "stdout_lines": ["podsecuritypolicy.extensions/privileged unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-psp unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged"]}

TASK [Downloading openebs-operator.yaml] ***************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:37
2019-09-13T14:58:19.658104 (delta: 2.203375)         elapsed: 18.241112 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "f74090195ee6070b9d8852dc73ff9c7cfbaf8025", "dest": "/providers/openebs/installers/operator/master/litmusbook/openebs-operator.yaml", "gid": 0, "group": "root", "md5sum": "ecb1feff7b60817334e5cd9c24c18591", "mode": "0644", "msg": "OK (30147 bytes)", "owner": "root", "size": 30147, "src": "/root/.ansible/tmp/ansible-tmp-1568386699.79-186431952733237/tmpHTTgMJ", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [Downloading openebs-storageclasses.yaml] *********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:47
2019-09-13T14:58:26.225702 (delta: 6.567506)         elapsed: 24.80871 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "a8aa0d7e36752b07b7061449384b341a34ad4c45", "dest": "/providers/openebs/installers/operator/master/litmusbook/storageclass.yaml", "gid": 0, "group": "root", "md5sum": "325c4aac8f18d22423932a4ad93137af", "mode": "0644", "msg": "OK (661 bytes)", "owner": "root", "size": 661, "src": "/root/.ansible/tmp/ansible-tmp-1568386706.36-120873108467202/tmpEE264m", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [Downloading openebs cspc-operator.yaml] **********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:57
2019-09-13T14:58:27.289951 (delta: 1.064153)         elapsed: 25.872959 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "50463fb7d0f1dd64b7363c1e3b74a3fa1f323068", "dest": "/providers/openebs/installers/operator/master/litmusbook/cspc-operator.yaml", "gid": 0, "group": "root", "md5sum": "eb55c661bca090ca5f9dd27571b3cef4", "mode": "0644", "msg": "OK (2145 bytes)", "owner": "root", "size": 2145, "src": "/root/.ansible/tmp/ansible-tmp-1568386707.42-36982892968860/tmpSCU1WQ", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/cspc-operator.yaml"}

TASK [Change CSPC operator image] **********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:67
2019-09-13T14:58:28.363165 (delta: 1.073121)         elapsed: 26.946173 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change OPENEBS_IO_CSPI_MGMT image] ***************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:74
2019-09-13T14:58:28.521563 (delta: 0.158306)         elapsed: 27.104571 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change OPENEBS_IO_CSTOR_POOL image] **************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:81
2019-09-13T14:58:28.678431 (delta: 0.156777)         elapsed: 27.261439 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change OPENEBS_IO_CSTOR_POOL_EXPORTER image] *****************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:88
2019-09-13T14:58:28.836521 (delta: 0.157988)         elapsed: 27.419529 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:96
2019-09-13T14:58:28.995099 (delta: 0.158479)         elapsed: 27.578107 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Change the value of sparse file count in operator YAML] ******************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:103
2019-09-13T14:58:29.746087 (delta: 0.750895)         elapsed: 28.329095 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the Node Disk manager Image] **************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:110
2019-09-13T14:58:30.151958 (delta: 0.405818)         elapsed: 28.734966 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the Node Disk operator Image] *************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:117
2019-09-13T14:58:30.254263 (delta: 0.102251)         elapsed: 28.837271 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:124
2019-09-13T14:58:30.382592 (delta: 0.128257)         elapsed: 28.9656 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Applying openebs operator] ***********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:132
2019-09-13T14:58:30.738426 (delta: 0.355753)         elapsed: 29.321434 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f openebs-operator.yaml", "delta": "0:00:03.888833", "end": "2019-09-13 14:58:34.928898", "rc": 0, "start": "2019-09-13 14:58:31.040065", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs created\nserviceaccount/openebs-maya-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-maya-operator created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator created\ndeployment.apps/maya-apiserver created\nservice/maya-apiserver-service created\ndeployment.apps/openebs-provisioner created\ndeployment.apps/openebs-snapshot-operator created\nconfigmap/openebs-ndm-config created\ndaemonset.extensions/openebs-ndm created\ndeployment.apps/openebs-ndm-operator created\nsecret/admission-server-certs created\nservice/admission-server-svc created\ndeployment.apps/openebs-admission-server created\nvalidatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg created\ndeployment.apps/openebs-localpv-provisioner created", "stdout_lines": ["namespace/openebs created", "serviceaccount/openebs-maya-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-maya-operator created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator created", "deployment.apps/maya-apiserver created", "service/maya-apiserver-service created", "deployment.apps/openebs-provisioner created", "deployment.apps/openebs-snapshot-operator created", "configmap/openebs-ndm-config created", "daemonset.extensions/openebs-ndm created", "deployment.apps/openebs-ndm-operator created", "secret/admission-server-certs created", "service/admission-server-svc created", "deployment.apps/openebs-admission-server created", "validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg created", "deployment.apps/openebs-localpv-provisioner created"]}

TASK [Applying storageclasses] *************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:137
2019-09-13T14:58:35.106765 (delta: 4.368279)         elapsed: 33.689773 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f storageclass.yaml", "delta": "0:00:01.651665", "end": "2019-09-13 14:58:37.183939", "rc": 0, "start": "2019-09-13 14:58:35.532274", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-standard unchanged\nstorageclass.storage.k8s.io/openebs-standalone unchanged\nstorageclass.storage.k8s.io/openebs-mongodb unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-standard unchanged", "storageclass.storage.k8s.io/openebs-standalone unchanged", "storageclass.storage.k8s.io/openebs-mongodb unchanged"]}

TASK [Applying cspc operator] **************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:142
2019-09-13T14:58:37.324175 (delta: 2.217293)         elapsed: 35.907183 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f cspc-operator.yaml", "delta": "0:00:01.658110", "end": "2019-09-13 14:58:39.307841", "rc": 0, "start": "2019-09-13 14:58:37.649731", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.openebs.io created\ndeployment.apps/cspc-operator created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.openebs.io created", "deployment.apps/cspc-operator created"]}

TASK [Updating maya api server image] ******************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:147
2019-09-13T14:58:39.451443 (delta: 2.127164)         elapsed: 38.034451 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva controller image] **********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:153
2019-09-13T14:58:39.612542 (delta: 0.161007)         elapsed: 38.19555 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica image] *************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:159
2019-09-13T14:58:39.781927 (delta: 0.169291)         elapsed: 38.364935 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica count] *************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:165
2019-09-13T14:58:39.964939 (delta: 0.182919)         elapsed: 38.547947 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor target image] *************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:171
2019-09-13T14:58:40.157801 (delta: 0.19276)         elapsed: 38.740809 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool image] ***************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:177
2019-09-13T14:58:40.319927 (delta: 0.162029)         elapsed: 38.902935 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool management image] ****************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:183
2019-09-13T14:58:40.498449 (delta: 0.178426)         elapsed: 39.081457 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume management image] **************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:189
2019-09-13T14:58:40.675319 (delta: 0.176773)         elapsed: 39.258327 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:195
2019-09-13T14:58:40.833335 (delta: 0.157887)         elapsed: 39.416343 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:201
2019-09-13T14:58:40.992172 (delta: 0.158704)         elapsed: 39.57518 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting all pods in openebs namespace] ********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:207
2019-09-13T14:58:41.178461 (delta: 0.186194)         elapsed: 39.761469 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po --all -n openebs", "delta": "0:00:34.688558", "end": "2019-09-13 14:59:16.085754", "rc": 0, "start": "2019-09-13 14:58:41.397196", "stderr": "", "stderr_lines": [], "stdout": "pod \"cspc-operator-644b644654-p8fsc\" deleted\npod \"maya-apiserver-7cf6b7f98f-ncpv8\" deleted\npod \"openebs-admission-server-6c8bcd75dc-9tdfc\" deleted\npod \"openebs-localpv-provisioner-7fcb5db7b4-pg4h4\" deleted\npod \"openebs-ndm-72qlz\" deleted\npod \"openebs-ndm-mvbk6\" deleted\npod \"openebs-ndm-operator-7cd777946d-st6hd\" deleted\npod \"openebs-ndm-vw2bs\" deleted\npod \"openebs-provisioner-5695f8d98f-njktq\" deleted\npod \"openebs-snapshot-operator-7ddb4c97d-52jm7\" deleted", "stdout_lines": ["pod \"cspc-operator-644b644654-p8fsc\" deleted", "pod \"maya-apiserver-7cf6b7f98f-ncpv8\" deleted", "pod \"openebs-admission-server-6c8bcd75dc-9tdfc\" deleted", "pod \"openebs-localpv-provisioner-7fcb5db7b4-pg4h4\" deleted", "pod \"openebs-ndm-72qlz\" deleted", "pod \"openebs-ndm-mvbk6\" deleted", "pod \"openebs-ndm-operator-7cd777946d-st6hd\" deleted", "pod \"openebs-ndm-vw2bs\" deleted", "pod \"openebs-provisioner-5695f8d98f-njktq\" deleted", "pod \"openebs-snapshot-operator-7ddb4c97d-52jm7\" deleted"]}

TASK [Verify that rolling update of maya-apiserver is completed] ***************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:212
2019-09-13T14:59:16.236220 (delta: 35.057684)         elapsed: 74.819228 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver | wc -l", "delta": "0:00:01.315276", "end": "2019-09-13 14:59:17.997321", "rc": 0, "start": "2019-09-13 14:59:16.682045", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking Maya-API-Server container status] *******************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:223
2019-09-13T14:59:18.136923 (delta: 1.900602)         elapsed: 76.719931 ******* 
FAILED - RETRYING: Checking Maya-API-Server container status (120 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (119 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (118 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (117 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (116 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (115 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (114 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (113 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver -o jsonpath='{.items[?(@.status.containerStatuses[*].name==\"maya-apiserver\")].status.containerStatuses[*].ready}'", "delta": "0:00:01.306120", "end": "2019-09-13 15:00:12.477665", "rc": 0, "start": "2019-09-13 15:00:11.171545", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Checking OpenEBS-provisioner is running] *********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:232
2019-09-13T15:00:12.610092 (delta: 54.473081)         elapsed: 131.1931 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-provisioner\")].status.phase}'", "delta": "0:00:01.175919", "end": "2019-09-13 15:00:14.152773", "rc": 0, "start": "2019-09-13 15:00:12.976854", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS-admission-server is running] ****************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:239
2019-09-13T15:00:14.231515 (delta: 1.621325)         elapsed: 132.814523 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.app==\"admission-webhook\")].status.phase}'", "delta": "0:00:01.285737", "end": "2019-09-13 15:00:15.729016", "rc": 0, "start": "2019-09-13 15:00:14.443279", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get maya-apiserver pod name] *********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:246
2019-09-13T15:00:15.805491 (delta: 1.573919)         elapsed: 134.388499 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs --no-headers --selector=name=maya-apiserver -o custom-columns=:metadata.name", "delta": "0:00:01.459329", "end": "2019-09-13 15:00:17.546579", "rc": 0, "start": "2019-09-13 15:00:16.087250", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-7cf6b7f98f-rtfsm", "stdout_lines": ["maya-apiserver-7cf6b7f98f-rtfsm"]}

TASK [Create fact for pod name] ************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:255
2019-09-13T15:00:17.683979 (delta: 1.878436)         elapsed: 136.266987 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "maya-apiserver-7cf6b7f98f-rtfsm"}, "changed": false}

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:259
2019-09-13T15:00:17.810566 (delta: 0.12653)         elapsed: 136.393574 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-snapshot-operator\")].status.phase}'", "delta": "0:00:01.341272", "end": "2019-09-13 15:00:19.407164", "rc": 0, "start": "2019-09-13 15:00:18.065892", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:266
2019-09-13T15:00:19.559482 (delta: 1.748847)         elapsed: 138.14249 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:01.280053", "end": "2019-09-13 15:00:21.224505", "rc": 0, "start": "2019-09-13 15:00:19.944452", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Confirm that maya-cli is available in the maya-apiserver pod] ************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:273
2019-09-13T15:00:21.345788 (delta: 1.786199)         elapsed: 139.928796 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec maya-apiserver-7cf6b7f98f-rtfsm -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:02.529774", "end": "2019-09-13 15:00:24.221071", "failed_when_result": false, "rc": 0, "start": "2019-09-13 15:00:21.691297", "stderr": "", "stderr_lines": [], "stdout": "Version: 1.3.0-unreleased\nGit commit: 0a45491fd5a12371bee0d14eb882e19e8197ce2d\nGO Version: go1.11.2\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://172.23.6.79:5656\nm-apiserver status:  running", "stdout_lines": ["Version: 1.3.0-unreleased", "Git commit: 0a45491fd5a12371bee0d14eb882e19e8197ce2d", "GO Version: go1.11.2", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://172.23.6.79:5656", "m-apiserver status:  running"]}

TASK [Get the maxpool count of storage pool claim.] ****************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:282
2019-09-13T15:00:24.380186 (delta: 3.034326)         elapsed: 142.963194 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get spc -o=jsonpath='{.items[?(@.metadata.name==\"cstor-sparse-pool\")].spec.maxPools}'", "delta": "0:00:01.170328", "end": "2019-09-13 15:00:25.894639", "rc": 0, "start": "2019-09-13 15:00:24.724311", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if sparse pool is running in all the nodes] **********************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:291
2019-09-13T15:00:25.996531 (delta: 1.61625)         elapsed: 144.579539 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim==cstor-sparse-pool -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.373916", "end": "2019-09-13 15:00:27.722190", "rc": 0, "start": "2019-09-13 15:00:26.348274", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:303
2019-09-13T15:00:27.881806 (delta: 1.885205)         elapsed: 146.464814 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node --no-headers | grep -v \"master\" | wc -l", "delta": "0:00:01.149961", "end": "2019-09-13 15:00:29.274817", "rc": 0, "start": "2019-09-13 15:00:28.124856", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:309
2019-09-13T15:00:29.392574 (delta: 1.510671)         elapsed: 147.975582 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-ndm\")].status.phase}'| grep Running | wc -w", "delta": "0:00:01.349869", "end": "2019-09-13 15:00:31.105146", "rc": 0, "start": "2019-09-13 15:00:29.755277", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the number of nodes] *********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:321
2019-09-13T15:00:31.277261 (delta: 1.884609)         elapsed: 149.860269 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:327
2019-09-13T15:00:31.363985 (delta: 0.086626)         elapsed: 149.946993 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm CAS Templates are deployed] **************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:338
2019-09-13T15:00:31.443878 (delta: 0.079836)         elapsed: 150.026886 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get castemplate -n openebs", "delta": "0:00:01.294965", "end": "2019-09-13 15:00:32.995293", "rc": 0, "start": "2019-09-13 15:00:31.700328", "stderr": "", "stderr_lines": [], "stdout": "NAME                                  CREATED AT\ncas-volume-stats-default-1.1.0        8d\ncas-volume-stats-default-1.2.0        8d\ncas-volume-stats-default-1.3.0        2h\ncstor-pool-create-default-1.1.0       8d\ncstor-pool-create-default-1.2.0       8d\ncstor-pool-create-default-1.3.0       2h\ncstor-snapshot-create-default-1.1.0   8d\ncstor-snapshot-create-default-1.2.0   8d\ncstor-snapshot-create-default-1.3.0   2h\ncstor-snapshot-delete-default-1.1.0   8d\ncstor-snapshot-delete-default-1.2.0   8d\ncstor-snapshot-delete-default-1.3.0   2h\ncstor-volume-create-default-1.1.0     8d\ncstor-volume-create-default-1.2.0     8d\ncstor-volume-create-default-1.3.0     2h\ncstor-volume-delete-default-1.1.0     8d\ncstor-volume-delete-default-1.2.0     8d\ncstor-volume-delete-default-1.3.0     2h\ncstor-volume-list-default-1.1.0       8d\ncstor-volume-list-default-1.2.0       8d\ncstor-volume-list-default-1.3.0       2h\ncstor-volume-read-default-1.1.0       8d\ncstor-volume-read-default-1.2.0       8d\ncstor-volume-read-default-1.3.0       2h\njiva-snapshot-create-default-1.1.0    8d\njiva-snapshot-create-default-1.2.0    8d\njiva-snapshot-create-default-1.3.0    2h\njiva-volume-create-default-1.1.0      8d\njiva-volume-create-default-1.2.0      8d\njiva-volume-create-default-1.3.0      2h\njiva-volume-delete-default-0.6.0      8d\njiva-volume-delete-default-1.1.0      8d\njiva-volume-delete-default-1.2.0      8d\njiva-volume-delete-default-1.3.0      2h\njiva-volume-list-default-0.6.0        8d\njiva-volume-list-default-1.1.0        8d\njiva-volume-list-default-1.2.0        8d\njiva-volume-list-default-1.3.0        2h\njiva-volume-read-default-0.6.0        8d\njiva-volume-read-default-1.1.0        8d\njiva-volume-read-default-1.2.0        8d\njiva-volume-read-default-1.3.0        2h\nstorage-pool-list-default-1.1.0       8d\nstorage-pool-list-default-1.2.0       8d\nstorage-pool-list-default-1.3.0       2h\nstorage-pool-read-default-1.1.0       8d\nstorage-pool-read-default-1.2.0       8d\nstorage-pool-read-default-1.3.0       2h", "stdout_lines": ["NAME                                  CREATED AT", "cas-volume-stats-default-1.1.0        8d", "cas-volume-stats-default-1.2.0        8d", "cas-volume-stats-default-1.3.0        2h", "cstor-pool-create-default-1.1.0       8d", "cstor-pool-create-default-1.2.0       8d", "cstor-pool-create-default-1.3.0       2h", "cstor-snapshot-create-default-1.1.0   8d", "cstor-snapshot-create-default-1.2.0   8d", "cstor-snapshot-create-default-1.3.0   2h", "cstor-snapshot-delete-default-1.1.0   8d", "cstor-snapshot-delete-default-1.2.0   8d", "cstor-snapshot-delete-default-1.3.0   2h", "cstor-volume-create-default-1.1.0     8d", "cstor-volume-create-default-1.2.0     8d", "cstor-volume-create-default-1.3.0     2h", "cstor-volume-delete-default-1.1.0     8d", "cstor-volume-delete-default-1.2.0     8d", "cstor-volume-delete-default-1.3.0     2h", "cstor-volume-list-default-1.1.0       8d", "cstor-volume-list-default-1.2.0       8d", "cstor-volume-list-default-1.3.0       2h", "cstor-volume-read-default-1.1.0       8d", "cstor-volume-read-default-1.2.0       8d", "cstor-volume-read-default-1.3.0       2h", "jiva-snapshot-create-default-1.1.0    8d", "jiva-snapshot-create-default-1.2.0    8d", "jiva-snapshot-create-default-1.3.0    2h", "jiva-volume-create-default-1.1.0      8d", "jiva-volume-create-default-1.2.0      8d", "jiva-volume-create-default-1.3.0      2h", "jiva-volume-delete-default-0.6.0      8d", "jiva-volume-delete-default-1.1.0      8d", "jiva-volume-delete-default-1.2.0      8d", "jiva-volume-delete-default-1.3.0      2h", "jiva-volume-list-default-0.6.0        8d", "jiva-volume-list-default-1.1.0        8d", "jiva-volume-list-default-1.2.0        8d", "jiva-volume-list-default-1.3.0        2h", "jiva-volume-read-default-0.6.0        8d", "jiva-volume-read-default-1.1.0        8d", "jiva-volume-read-default-1.2.0        8d", "jiva-volume-read-default-1.3.0        2h", "storage-pool-list-default-1.1.0       8d", "storage-pool-list-default-1.2.0       8d", "storage-pool-list-default-1.3.0       2h", "storage-pool-read-default-1.1.0       8d", "storage-pool-read-default-1.2.0       8d", "storage-pool-read-default-1.3.0       2h"]}

TASK [Cleaning cspc operator] **************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:353
2019-09-13T15:00:33.128729 (delta: 1.684791)         elapsed: 151.711737 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Cleaning openebs operator] ***********************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:359
2019-09-13T15:00:33.242282 (delta: 0.113491)         elapsed: 151.82529 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm pods has been deleted] *******************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:365
2019-09-13T15:00:33.372237 (delta: 0.129888)         elapsed: 151.955245 ****** 
skipping: [127.0.0.1] => (item=maya-apiserver)  => {"changed": false, "item": "maya-apiserver", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-provisioner)  => {"changed": false, "item": "openebs-provisioner", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-snapshot-operator)  => {"changed": false, "item": "openebs-snapshot-operator", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-ndm-operator)  => {"changed": false, "item": "openebs-ndm-operator", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-admission-server)  => {"changed": false, "item": "openebs-admission-server", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-localpv-provisioner)  => {"changed": false, "item": "openebs-localpv-provisioner", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-ndm)  => {"changed": false, "item": "openebs-ndm", "skip_reason": "Conditional result was False"}

TASK [Confirm that namespace has been deleted] *********************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:382
2019-09-13T15:00:33.645548 (delta: 0.273231)         elapsed: 152.228556 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:393
2019-09-13T15:00:33.751460 (delta: 0.105751)         elapsed: 152.334468 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /providers/openebs/installers/operator/master/litmusbook/test.yaml:401
2019-09-13T15:00:33.863093 (delta: 0.111579)         elapsed: 152.446101 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-13T15:00:34.063316 (delta: 0.200155)         elapsed: 152.646324 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-13T15:00:34.128184 (delta: 0.064798)         elapsed: 152.711192 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-13T15:00:34.195164 (delta: 0.066929)         elapsed: 152.778172 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-13T15:00:34.266286 (delta: 0.071067)         elapsed: 152.849294 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "02518eb12431f2da50c030038aebba86fa10ee95", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "633e5a8c18da78bb93fcc5b52d5bf057", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1568386834.36-225726946272375/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-13T15:00:36.808229 (delta: 2.541886)         elapsed: 155.391237 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.063080", "end": "2019-09-13 15:00:38.111064", "rc": 0, "start": "2019-09-13 15:00:37.047984", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-13T15:00:38.193618 (delta: 1.385336)         elapsed: 156.776626 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.537418", "end": "2019-09-13 15:00:39.993935", "failed_when_result": false, "rc": 0, "start": "2019-09-13 15:00:38.456517", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-provision configured", "stdout_lines": ["litmusresult.litmus.io/openebs-provision configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=36   changed=29   unreachable=0    failed=0   

2019-09-13T15:00:40.073807 (delta: 1.880102)         elapsed: 158.656815 ****** 
```