### PR TITLE
refactor[ctrl-kill]: Modified the controller pod kill util to get the replica status

### DIFF
--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -85,7 +85,7 @@
   args:
     executable: /bin/bash
   register: rstatus_after
-  until: "((rstatus_after.stdout_lines|unique)|length) == 1 and 'RW' in rstatus_after.stdout"
+  until: "rstatus_after.stdout_lines == rstatus_before.stdout_lines and 'RW' in rstatus_after.stdout"
   retries: 30
   delay: 10
 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Changed the until condition to get the status of replica in controller kill util

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
[root@master-1558702621 openebs_target_failure]# kubectl logs -f openebs-target-failure-mlh6t-9jdk5 -n litmus
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_failure/test.yml

PLAY [localhost] ***************************************************************
2019-09-14T07:38:14.240693 (delta: 0.070093)         elapsed: 0.070093 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:2
2019-09-14T07:38:14.256113 (delta: 0.015364)         elapsed: 0.085513 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:13
2019-09-14T07:38:22.908113 (delta: 8.651977)         elapsed: 8.737513 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:2
2019-09-14T07:38:23.010847 (delta: 0.102666)         elapsed: 8.840247 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-jiva -n app-busybox-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.339021", "end": "2019-09-14 07:38:24.927995", "rc": 0, "start": "2019-09-14 07:38:23.588974", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:10
2019-09-14T07:38:25.055458 (delta: 2.044528)         elapsed: 10.884858 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.167984", "end": "2019-09-14 07:38:26.628188", "rc": 0, "start": "2019-09-14 07:38:25.460204", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:18
2019-09-14T07:38:26.758317 (delta: 1.702764)         elapsed: 12.587717 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:22
2019-09-14T07:38:26.982767 (delta: 0.224321)         elapsed: 12.812167 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:27
2019-09-14T07:38:27.079150 (delta: 0.096314)         elapsed: 12.90855 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-jiva -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.227896", "end": "2019-09-14 07:38:28.531124", "rc": 0, "start": "2019-09-14 07:38:27.303228", "stderr": "", "stderr_lines": [], "stdout": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3", "stdout_lines": ["pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:35
2019-09-14T07:38:28.656878 (delta: 1.577672)         elapsed: 14.486278 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:02.455072", "end": "2019-09-14 07:38:31.461193", "rc": 0, "start": "2019-09-14 07:38:29.006121", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:43
2019-09-14T07:38:31.630800 (delta: 2.973823)         elapsed: 17.4602 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:48
2019-09-14T07:38:31.850191 (delta: 0.219289)         elapsed: 17.679591 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0a937ecd6003ce4df11f7c11f2ebeb488057b745", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "3eb3f96848fe3277080f1436959c01f6", "mode": "0644", "owner": "root", "size": 61, "src": "/root/.ansible/tmp/ansible-tmp-1568446711.95-109685603973747/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_failure/test_prerequisites.yml:53
2019-09-14T07:38:32.825422 (delta: 0.975136)         elapsed: 18.654822 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1568446712.9-244153768213591/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:18
2019-09-14T07:38:33.460609 (delta: 0.635076)         elapsed: 19.290009 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:21
2019-09-14T07:38:33.628993 (delta: 0.16832)         elapsed: 19.458393 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_controller_pod_failure.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:24
2019-09-14T07:38:33.836907 (delta: 0.207813)         elapsed: 19.666307 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_controller_pod_failure.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_failure/test.yml:28
2019-09-14T07:38:34.046539 (delta: 0.209534)         elapsed: 19.875939 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:34
2019-09-14T07:38:34.284059 (delta: 0.237414)         elapsed: 20.113459 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-14T07:38:34.391015 (delta: 0.106895)         elapsed: 20.220415 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-14T07:38:34.477810 (delta: 0.08674)         elapsed: 20.30721 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:36
2019-09-14T07:38:34.602826 (delta: 0.124951)         elapsed: 20.432226 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-14T07:38:34.826639 (delta: 0.223733)         elapsed: 20.656039 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ad277ff7e49d85df2af3406b90605d31dafb534", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "fc86d91307b2a01f2e5914ce76c0caf3", "mode": "0644", "owner": "root", "size": 458, "src": "/root/.ansible/tmp/ansible-tmp-1568446714.93-259120596959783/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-14T07:38:35.503501 (delta: 0.676764)         elapsed: 21.332901 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.026278", "end": "2019-09-14 07:38:36.901537", "rc": 0, "start": "2019-09-14 07:38:35.875259", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-14T07:38:37.004876 (delta: 1.501289)         elapsed: 22.834276 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.644566", "end": "2019-09-14 07:38:38.955848", "failed_when_result": false, "rc": 0, "start": "2019-09-14 07:38:37.311282", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-14T07:38:39.040926 (delta: 2.035945)         elapsed: 24.870326 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-14T07:38:39.103986 (delta: 0.063007)         elapsed: 24.933386 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-14T07:38:39.183441 (delta: 0.079404)         elapsed: 25.012841 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_failure/test.yml:43
2019-09-14T07:38:39.275976 (delta: 0.092483)         elapsed: 25.105376 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace           : app-busybox-ns", 
        "Target Namespace    : openebs", 
        "Label               : app=busybox-sts", 
        "PVC                 : openebs-busybox-jiva", 
        "StorageClass        : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_failure/test.yml:55
2019-09-14T07:38:39.552504 (delta: 0.276424)         elapsed: 25.381904 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-14T07:38:39.745278 (delta: 0.192719)         elapsed: 25.574678 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.219214", "end": "2019-09-14 07:38:41.323560", "rc": 0, "start": "2019-09-14 07:38:40.104346", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-14T06:17:42Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-14T06:17:42Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-14T07:38:41.484846 (delta: 1.739517)         elapsed: 27.314246 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.388032", "end": "2019-09-14 07:38:43.176842", "rc": 0, "start": "2019-09-14 07:38:41.788810", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:64
2019-09-14T07:38:43.308842 (delta: 1.823909)         elapsed: 29.138242 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.350438", "end": "2019-09-14 07:38:44.894942", "rc": 0, "start": "2019-09-14 07:38:43.544504", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-6c47496f68-fvc4h", "stdout_lines": ["app-busybox-6c47496f68-fvc4h"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:72
2019-09-14T07:38:45.016766 (delta: 1.707827)         elapsed: 30.846166 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-14T07:38:45.307165 (delta: 0.290305)         elapsed: 31.136565 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/newfile bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-6c47496f68-fvc4h -n app-busybox-ns -- sh -c \"dd if=/dev/urandom of=/busybox/newfile bs=4k count=1024\"", "delta": "0:00:01.609001", "end": "2019-09-14 07:38:47.318258", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/newfile bs=4k count=1024", "rc": 0, "start": "2019-09-14 07:38:45.709257", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.035045 seconds, 114.1MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.035045 seconds, 114.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/newfile > /busybox/newfile-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-6c47496f68-fvc4h -n app-busybox-ns -- sh -c \"md5sum /busybox/newfile > /busybox/newfile-pre-chaos-md5\"", "delta": "0:00:01.739666", "end": "2019-09-14 07:38:49.475073", "failed_when_result": false, "item": "md5sum /busybox/newfile > /busybox/newfile-pre-chaos-md5", "rc": 0, "start": "2019-09-14 07:38:47.735407", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-14T07:38:49.630705 (delta: 4.323489)         elapsed: 35.460105 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-14T07:38:49.784608 (delta: 0.153808)         elapsed: 35.614008 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-14T07:38:49.920051 (delta: 0.135337)         elapsed: 35.749451 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-14T07:38:50.100982 (delta: 0.18083)         elapsed: 35.930382 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-14T07:38:50.167794 (delta: 0.066704)         elapsed: 35.997194 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-14T07:38:50.245282 (delta: 0.077433)         elapsed: 36.074682 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-14T07:38:50.370045 (delta: 0.124648)         elapsed: 36.199445 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-14T07:38:50.538356 (delta: 0.168214)         elapsed: 36.367756 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-14T07:38:50.682472 (delta: 0.143983)         elapsed: 36.511872 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-14T07:38:50.830228 (delta: 0.147631)         elapsed: 36.659628 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:82
2019-09-14T07:38:50.916952 (delta: 0.086618)         elapsed: 36.746352 ******* 
included: /chaoslib/openebs/jiva_controller_pod_failure.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:1
2019-09-14T07:38:51.108081 (delta: 0.191073)         elapsed: 36.937481 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-jiva -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.223274", "end": "2019-09-14 07:38:52.615311", "rc": 0, "start": "2019-09-14 07:38:51.392037", "stderr": "", "stderr_lines": [], "stdout": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3", "stdout_lines": ["pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3"]}

TASK [Record the jiva controller deployment of the PV] *************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:10
2019-09-14T07:38:52.761669 (delta: 1.653528)         elapsed: 38.591069 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_deploy": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl"}, "changed": false}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:15
2019-09-14T07:38:52.980313 (delta: 0.218541)         elapsed: 38.809713 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-con"}, "changed": false}

TASK [Get the resourceVersion of the target deploy before fault injection] *****
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:20
2019-09-14T07:38:53.166937 (delta: 0.186485)         elapsed: 38.996337 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl -n app-busybox-ns -o=custom-columns=NAME:\".metadata.resourceVersion\" --no-headers", "delta": "0:00:01.190093", "end": "2019-09-14 07:38:54.690827", "rc": 0, "start": "2019-09-14 07:38:53.500734", "stderr": "", "stderr_lines": [], "stdout": "3196202", "stdout_lines": ["3196202"]}

TASK [Get jiva controller pod belonging to the PV] *****************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:28
2019-09-14T07:38:54.805933 (delta: 1.63894)         elapsed: 40.635333 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n app-busybox-ns -o jsonpath=\"{.items[?(@.metadata.labels.openebs\\\\.io/persistent-volume==\\\"pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3\\\")].metadata.name}\"", "delta": "0:00:01.272095", "end": "2019-09-14 07:38:56.501726", "rc": 0, "start": "2019-09-14 07:38:55.229631", "stderr": "", "stderr_lines": [], "stdout": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg", "stdout_lines": ["pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:36
2019-09-14T07:38:56.647335 (delta: 1.841319)         elapsed: 42.476735 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n app-busybox-ns -o=jsonpath='{.items[0].spec.clusterIP}'", "delta": "0:00:01.166092", "end": "2019-09-14 07:38:58.193348", "failed_when_result": false, "rc": 0, "start": "2019-09-14 07:38:57.027256", "stderr": "", "stderr_lines": [], "stdout": "172.24.70.77", "stdout_lines": ["172.24.70.77"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:45
2019-09-14T07:38:58.275912 (delta: 1.628414)         elapsed: 44.105312 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg -n app-busybox-ns -c pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq\"", "delta": "0:00:12.858492", "end": "2019-09-14 07:39:11.402227", "rc": 0, "start": "2019-09-14 07:38:58.543735", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nFetched 325 kB in 7s (42.9 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\njq is already the newest version (1.5+dfsg-1ubuntu0.1).\n0 upgraded, 0 newly installed, 0 to remove and 23 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Fetched 325 kB in 7s (42.9 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "jq is already the newest version (1.5+dfsg-1ubuntu0.1).", "0 upgraded, 0 newly installed, 0 to remove and 23 not upgraded."]}

TASK [Getting the Replicastatus before killing controller] *********************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:52
2019-09-14T07:39:11.505189 (delta: 13.229218)         elapsed: 57.334589 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg -n app-busybox-ns -c pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-con curl http://\"172.24.70.77\":9501/v1/replicas | jq -r '.data[].mode'", "delta": "0:00:01.583568", "end": "2019-09-14 07:39:13.445008", "rc": 0, "start": "2019-09-14 07:39:11.861440", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1459  100  1459    0     0   260k      0 --:--:-- --:--:-- --:--:--  356k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1459  100  1459    0     0   260k      0 --:--:-- --:--:-- --:--:--  356k"], "stdout": "RW\nRW\nRW", "stdout_lines": ["RW", "RW", "RW"]}

TASK [Kill the jiva controller pod] ********************************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:60
2019-09-14T07:39:13.591218 (delta: 2.085929)         elapsed: 59.420618 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg -n app-busybox-ns", "delta": "0:00:03.724231", "end": "2019-09-14 07:39:17.586487", "rc": 0, "start": "2019-09-14 07:39:13.862256", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg\" deleted", "stdout_lines": ["pod \"pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-pdwwg\" deleted"]}

TASK [Get jiva controller pod belonging to the PV] *****************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:66
2019-09-14T07:39:17.755163 (delta: 4.163857)         elapsed: 63.584563 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n app-busybox-ns -o jsonpath=\"{.items[?(@.metadata.labels.openebs\\\\.io/persistent-volume==\\\"pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3\\\")].metadata.name}\"", "delta": "0:00:01.275249", "end": "2019-09-14 07:39:19.413028", "rc": 0, "start": "2019-09-14 07:39:18.137779", "stderr": "", "stderr_lines": [], "stdout": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh", "stdout_lines": ["pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:74
2019-09-14T07:39:19.524924 (delta: 1.769653)         elapsed: 65.354324 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh -n app-busybox-ns -c pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq\"", "delta": "0:00:22.171098", "end": "2019-09-14 07:39:42.163953", "rc": 0, "start": "2019-09-14 07:39:19.992855", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [942 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:6 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [582 kB]\nGet:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6114 B]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1322 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [986 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]\nFetched 16.0 MB in 10s (1560 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 6s (36.5 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5294 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...", "stdout_lines": ["Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [942 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:6 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [582 kB]", "Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6114 B]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1322 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [986 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]", "Fetched 16.0 MB in 10s (1560 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 6s (36.5 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5294 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ..."]}

TASK [Getting the Replicastatus after killing the controller] ******************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:81
2019-09-14T07:39:42.266013 (delta: 22.740993)         elapsed: 88.095413 ****** 
FAILED - RETRYING: Getting the Replicastatus after killing the controller (30 retries left).
FAILED - RETRYING: Getting the Replicastatus after killing the controller (29 retries left).
FAILED - RETRYING: Getting the Replicastatus after killing the controller (28 retries left).
FAILED - RETRYING: Getting the Replicastatus after killing the controller (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl exec -it pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh -n app-busybox-ns -c pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-con curl http://\"172.24.70.77\":9501/v1/replicas | jq -r '.data[].mode'", "delta": "0:00:01.640668", "end": "2019-09-14 07:40:31.614268", "rc": 0, "start": "2019-09-14 07:40:29.973600", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1459  100  1459    0     0   426k      0 --:--:-- --:--:-- --:--:--  712k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1459  100  1459    0     0   426k      0 --:--:-- --:--:-- --:--:--  712k"], "stdout": "RW\nRW\nRW", "stdout_lines": ["RW", "RW", "RW"]}

TASK [Get the resourceVersion of the target deploy after fault injection] ******
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:92
2019-09-14T07:40:31.770458 (delta: 49.504387)         elapsed: 137.599858 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl -n app-busybox-ns -o=custom-columns=NAME:\".metadata.resourceVersion\" --no-headers", "delta": "0:00:01.286027", "end": "2019-09-14 07:40:33.507965", "rc": 0, "start": "2019-09-14 07:40:32.221938", "stderr": "", "stderr_lines": [], "stdout": "3215897", "stdout_lines": ["3215897"]}

TASK [Compare resourceVersions of target deployment] ***************************
task path: /chaoslib/openebs/jiva_controller_pod_failure.yaml:100
2019-09-14T07:40:33.652333 (delta: 1.881773)         elapsed: 139.481733 ****** 
ok: [127.0.0.1] => {
    "msg": "Verified target pods were restarted by fault injection"
}

TASK [Wait (soak) for I/O on pools] ********************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:89
2019-09-14T07:40:33.864779 (delta: 0.212287)         elapsed: 139.694179 ****** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 360, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_failure/test.yml:93
2019-09-14T07:46:34.707154 (delta: 360.842278)         elapsed: 500.536554 **** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-14T07:46:34.861550 (delta: 0.15428)         elapsed: 500.69095 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.220156", "end": "2019-09-14 07:46:36.362140", "rc": 0, "start": "2019-09-14 07:46:35.141984", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-14T06:17:42Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-14T06:17:42Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-14T07:46:36.520947 (delta: 1.659337)         elapsed: 502.350347 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.179650", "end": "2019-09-14 07:46:38.052940", "rc": 0, "start": "2019-09-14 07:46:36.873290", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:103
2019-09-14T07:46:38.199896 (delta: 1.678827)         elapsed: 504.029296 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:106
2019-09-14T07:46:38.349929 (delta: 0.149937)         elapsed: 504.179329 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.074934", "end": "2019-09-14 07:46:39.669627", "rc": 0, "start": "2019-09-14 07:46:38.594693", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-6c47496f68-fvc4h", "stdout_lines": ["app-busybox-6c47496f68-fvc4h"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:114
2019-09-14T07:46:39.790060 (delta: 1.440037)         elapsed: 505.61946 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-14T07:46:40.067252 (delta: 0.277112)         elapsed: 505.896652 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/newfile bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/newfile bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/newfile > /busybox/newfile-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/newfile > /busybox/newfile-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-14T07:46:40.163388 (delta: 0.09608)         elapsed: 505.992788 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-6c47496f68-fvc4h -n app-busybox-ns", "delta": "0:00:32.818017", "end": "2019-09-14 07:47:13.365475", "rc": 0, "start": "2019-09-14 07:46:40.547458", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-6c47496f68-fvc4h\" deleted", "stdout_lines": ["pod \"app-busybox-6c47496f68-fvc4h\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-14T07:47:13.496776 (delta: 33.333334)         elapsed: 539.326176 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns", "delta": "0:00:01.200315", "end": "2019-09-14 07:47:15.039639", "rc": 0, "start": "2019-09-14 07:47:13.839324", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY   STATUS      RESTARTS   AGE\napp-busybox-6c47496f68-7hjn7                                     1/1     Running     0          34s\nbusybox-liveness-q9xn2-ct6wr                                     0/1     Completed   0          2h\npvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh   2/2     Running     0          8m\npvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-7h89k    1/1     Running     4          2h\npvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-dbrzt    1/1     Running     4          2h\npvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-zhftz    1/1     Running     4          2h", "stdout_lines": ["NAME                                                             READY   STATUS      RESTARTS   AGE", "app-busybox-6c47496f68-7hjn7                                     1/1     Running     0          34s", "busybox-liveness-q9xn2-ct6wr                                     0/1     Completed   0          2h", "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-ctrl-5d8875c6c4-x7fzh   2/2     Running     0          8m", "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-7h89k    1/1     Running     4          2h", "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-dbrzt    1/1     Running     4          2h", "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3-rep-6465dbc97d-zhftz    1/1     Running     4          2h"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-14T07:47:15.184225 (delta: 1.68736)         elapsed: 541.013625 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.204664", "end": "2019-09-14 07:47:16.647832", "rc": 0, "start": "2019-09-14 07:47:15.443168", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-6c47496f68-7hjn7", "stdout_lines": ["app-busybox-6c47496f68-7hjn7"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-14T07:47:16.775450 (delta: 1.591126)         elapsed: 542.60485 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-6c47496f68-7hjn7\")].status.phase}'", "delta": "0:00:01.198345", "end": "2019-09-14 07:47:18.210092", "rc": 0, "start": "2019-09-14 07:47:17.011747", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-14T07:47:18.339642 (delta: 1.564137)         elapsed: 544.169042 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-6c47496f68-7hjn7\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.279241", "end": "2019-09-14 07:47:20.052985", "rc": 0, "start": "2019-09-14 07:47:18.773744", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-14T07:46:44Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-14T07:46:44Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-14T07:47:20.176700 (delta: 1.836961)         elapsed: 546.0061 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-6c47496f68-7hjn7 -n app-busybox-ns -- sh -c \"md5sum /busybox/newfile > /busybox/newfile-post-chaos-md5\"", "delta": "0:00:01.439061", "end": "2019-09-14 07:47:22.071530", "failed_when_result": false, "rc": 0, "start": "2019-09-14 07:47:20.632469", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-14T07:47:22.227605 (delta: 2.05081)         elapsed: 548.057005 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-6c47496f68-7hjn7 -n app-busybox-ns -- sh -c \"diff /busybox/newfile-pre-chaos-md5 /busybox/newfile-post-chaos-md5\"", "delta": "0:00:01.758155", "end": "2019-09-14 07:47:24.245319", "failed_when_result": false, "rc": 0, "start": "2019-09-14 07:47:22.487164", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-14T07:47:24.412149 (delta: 2.184448)         elapsed: 550.241549 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-14T07:47:24.547948 (delta: 0.135704)         elapsed: 550.377348 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-14T07:47:24.694460 (delta: 0.146412)         elapsed: 550.52386 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:123
2019-09-14T07:47:24.835611 (delta: 0.141045)         elapsed: 550.665011 ****** 
included: /utils/scm/openebs/target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
task path: /utils/scm/openebs/target_affinity_check.yml:1
2019-09-14T07:47:25.061770 (delta: 0.226021)         elapsed: 550.89117 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=busybox-sts -n app-busybox-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.359399", "end": "2019-09-14 07:47:26.693816", "rc": 0, "start": "2019-09-14 07:47:25.334417", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Derive PV from application PVC] ******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:9
2019-09-14T07:47:26.818287 (delta: 1.756457)         elapsed: 552.647687 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox-jiva -o custom-columns=:spec.volumeName -n app-busybox-ns --no-headers", "delta": "0:00:01.157500", "end": "2019-09-14 07:47:28.285844", "rc": 0, "start": "2019-09-14 07:47:27.128344", "stderr": "", "stderr_lines": [], "stdout": "pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3", "stdout_lines": ["pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3"]}

TASK [Derive storage engine from PV] *******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:18
2019-09-14T07:47:28.355519 (delta: 1.537068)         elapsed: 554.184919 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.066782", "end": "2019-09-14 07:47:29.621805", "rc": 0, "start": "2019-09-14 07:47:28.555023", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:26
2019-09-14T07:47:29.698503 (delta: 1.342917)         elapsed: 555.527903 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"target_label": "openebs.io/controller=jiva-controller", "target_ns": "app-busybox-ns"}, "changed": false}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:35
2019-09-14T07:47:29.809399 (delta: 0.110832)         elapsed: 555.638799 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the node where PV target pod resides] *****************************
task path: /utils/scm/openebs/target_affinity_check.yml:40
2019-09-14T07:47:29.883287 (delta: 0.07383)         elapsed: 555.712687 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l openebs.io/controller=jiva-controller -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume==\"pvc-5ae7639e-d6b2-11e9-8eaa-0050569846e3\")].spec.nodeName}'", "delta": "0:00:01.278263", "end": "2019-09-14 07:47:31.360860", "rc": 0, "start": "2019-09-14 07:47:30.082597", "stderr": "", "stderr_lines": [], "stdout": "node2-1558702621.mayalabs.io", "stdout_lines": ["node2-1558702621.mayalabs.io"]}

TASK [Verify whether the app & target pod co-exist on same node] ***************
task path: /utils/scm/openebs/target_affinity_check.yml:49
2019-09-14T07:47:31.428112 (delta: 1.544769)         elapsed: 557.257512 ****** 
ok: [127.0.0.1] => {
    "msg": "App and Target affinity is maintained"
}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:132
2019-09-14T07:47:31.531848 (delta: 0.10368)         elapsed: 557.361248 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:138
2019-09-14T07:47:31.610756 (delta: 0.078838)         elapsed: 557.440156 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_failure/test.yml:149
2019-09-14T07:47:31.737969 (delta: 0.127157)         elapsed: 557.567369 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-14T07:47:31.884792 (delta: 0.146758)         elapsed: 557.714192 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-14T07:47:31.952895 (delta: 0.068044)         elapsed: 557.782295 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-14T07:47:32.018726 (delta: 0.065775)         elapsed: 557.848126 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-14T07:47:32.085628 (delta: 0.066844)         elapsed: 557.915028 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "1451b2509d937a30ce4400c2f2b35190478a883f", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5cf26c64ecfc0556a34702cbafb39a3a", "mode": "0644", "owner": "root", "size": 456, "src": "/root/.ansible/tmp/ansible-tmp-1568447252.15-56220219715251/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-14T07:47:34.625234 (delta: 2.539549)         elapsed: 560.454634 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.110874", "end": "2019-09-14 07:47:35.935142", "rc": 0, "start": "2019-09-14 07:47:34.824268", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-14T07:47:36.004983 (delta: 1.379694)         elapsed: 561.834383 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.291609", "end": "2019-09-14 07:47:37.528082", "failed_when_result": false, "rc": 0, "start": "2019-09-14 07:47:36.236473", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=66   changed=41   unreachable=0    failed=0   

2019-09-14T07:47:37.579856 (delta: 1.57482)         elapsed: 563.409256 ******* 
=============================================================================== 
```
