### PR TITLE
refactor(yaml): Updated target_network_delay litmusbook to check the data consistency

### DIFF
--- a/experiments/chaos/openebs_target_network_delay/README.md
+++ b/experiments/chaos/openebs_target_network_delay/README.md
@@ -59,19 +59,21 @@ This scenario validates the behaviour of application and OpenEBS persistent volu
 After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
 ​
 Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
-​
-    parameters.yml: |
+```
+​    parameters.yml: |
       blocksize: 4k
       blockcount: 1024
       testfile: difiletest
+```
 It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
 ​
 For percona-mysql, the following parameters are to be injected into configmap.
-​
-parameters.yml: |
-  dbuser: root
-  dbpassword: k8sDem0
-  dbname: tdb
+​```
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+```
 The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
 ​
 Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.

--- a/experiments/chaos/openebs_target_network_delay/README.md
+++ b/experiments/chaos/openebs_target_network_delay/README.md
@@ -49,3 +49,34 @@
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+
+
+​
+### Procedure
+​
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+​
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+​
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+​
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+​
+For percona-mysql, the following parameters are to be injected into configmap.
+​
+parameters.yml: |
+  dbuser: root
+  dbpassword: k8sDem0
+  dbname: tdb
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+​
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
+
+
+
+

--- a/experiments/chaos/openebs_target_network_delay/README.md
+++ b/experiments/chaos/openebs_target_network_delay/README.md
@@ -51,34 +51,26 @@
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
 
 
-​
-### Procedure
+​### Procedure
 ​
 This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
 ​
 After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
-​
+
 Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
-```
-​    parameters.yml: |
+
+    parameters.yml: |
       blocksize: 4k
       blockcount: 1024
       testfile: difiletest
-```
+
 It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
-​
+
 For percona-mysql, the following parameters are to be injected into configmap.
-```
+
     parameters.yml: |
       dbuser: root
       dbpassword: k8sDem0
       dbname: tdb
-```
-The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
-​
-Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
 
-
-
-
-
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.

--- a/experiments/chaos/openebs_target_network_delay/README.md
+++ b/experiments/chaos/openebs_target_network_delay/README.md
@@ -68,7 +68,7 @@ Based on the value of env DATA_PERSISTENCE, the corresponding data consistency u
 It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
 ​
 For percona-mysql, the following parameters are to be injected into configmap.
-​```
+```
     parameters.yml: |
       dbuser: root
       dbpassword: k8sDem0

--- a/experiments/chaos/openebs_target_network_delay/README.md
+++ b/experiments/chaos/openebs_target_network_delay/README.md
@@ -50,8 +50,7 @@
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
 
-
-​### Procedure
+### Procedure
 ​
 This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
 ​

--- a/experiments/chaos/openebs_target_network_delay/data_persistence.j2
+++ b/experiments/chaos/openebs_target_network_delay/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_target_network_delay/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_network_delay/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: target-network-delay
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -45,8 +54,16 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
-          - name: DATA_PERSISTENCY
+          - name: DATA_PERSISTENCE
             value: ""   
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_target_network_delay/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: target-network-delay

--- a/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/experiments/chaos/openebs_target_network_delay/test.yml
@@ -4,6 +4,7 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
@@ -16,6 +17,9 @@
         - include_tasks: /utils/fcm/create_testname.yml  
 
         - include: test_prerequisites.yml
+
+        - include_vars:
+            file: data_persistence.yml
   
         - include_vars:
             file: chaosutil.yml
@@ -23,6 +27,11 @@
         - name: Record the chaos util path
           set_fact: 
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''    
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
@@ -61,16 +70,13 @@
             executable: /bin/bash
           register: app_pod_name    
 
-        - name: Create some test data in the mysql database
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+        - name: Create some test data
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'LOAD'
             ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'   
-          when: data_persistance != ''    
+            pod_name: "{{ app_pod_name.stdout }}"  
+          when: data_persistence != ''    
 
         ## STORAGE FAULT INJECTION 
 
@@ -94,16 +100,13 @@
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
     
-        - name: Verify mysql data persistence  
+        - name: Verify application data persistence  
           include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: 'tdb'
-          when: data_persistance != ''      
+          when: data_persistence != ''      
           
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/experiments/chaos/openebs_target_network_delay/test.yml
@@ -101,7 +101,7 @@
           when: liveness_label != ''
     
         - name: Verify application data persistence  
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"

--- a/experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
@@ -50,3 +50,7 @@
     src: chaosutil.j2
     dest: chaosutil.yml
 
+- name: Identify the data consistency util to be invoked
+  template:
+    src: data_persistence.j2
+    dest: data_persistence.yml

--- a/experiments/chaos/openebs_target_network_delay/test_vars.yml
+++ b/experiments/chaos/openebs_target_network_delay/test_vars.yml
@@ -7,5 +7,5 @@ c_duration: "{{ lookup('env','CHAOS_DURATION') }}"
 operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

1. Updated the target_network_delay litmusbook to check the data consistency.

**Special notes for your reviewer**:
Logs for data consistency check against percona --->

```
config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_delay/test.yml

PLAY [localhost] ***************************************************************
2019-09-16T11:57:44.376782 (delta: 0.068344)         elapsed: 0.068344 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:2
2019-09-16T11:57:44.393796 (delta: 0.016957)         elapsed: 0.085358 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:13
2019-09-16T11:57:54.003988 (delta: 9.610168)         elapsed: 9.69555 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:17
2019-09-16T11:57:54.144744 (delta: 0.140671)         elapsed: 9.836306 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-16T11:57:54.329087 (delta: 0.184248)         elapsed: 10.020649 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-16T11:57:54.408143 (delta: 0.078959)         elapsed: 10.099705 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:2
2019-09-16T11:57:54.476235 (delta: 0.068039)         elapsed: 10.167797 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc mypercona -n percona-test --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.370703", "end": "2019-09-16 11:57:56.263181", "rc": 0, "start": "2019-09-16 11:57:54.892478", "stderr": "", "stderr_lines": [], "stdout": "openebs-sparse-sc-statefulset", "stdout_lines": ["openebs-sparse-sc-statefulset"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:10
2019-09-16T11:57:56.405102 (delta: 1.928813)         elapsed: 12.096664 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-sparse-sc-statefulset --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.213484", "end": "2019-09-16 11:57:58.002306", "rc": 0, "start": "2019-09-16 11:57:56.788822", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:18
2019-09-16T11:57:58.062011 (delta: 1.656808)         elapsed: 13.753573 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-sparse-sc-statefulset"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:22
2019-09-16T11:57:58.158435 (delta: 0.09637)         elapsed: 13.849997 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:27
2019-09-16T11:57:58.254316 (delta: 0.095818)         elapsed: 13.945878 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc mypercona -n percona-test --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.417257", "end": "2019-09-16 11:57:59.980051", "rc": 0, "start": "2019-09-16 11:57:58.562794", "stderr": "", "stderr_lines": [], "stdout": "pvc-52a8f342-d878-11e9-92b9-00505698550d", "stdout_lines": ["pvc-52a8f342-d878-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:35
2019-09-16T11:58:00.081320 (delta: 1.826942)         elapsed: 15.772882 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-52a8f342-d878-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.540967", "end": "2019-09-16 11:58:02.048631", "rc": 0, "start": "2019-09-16 11:58:00.507664", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:43
2019-09-16T11:58:02.108516 (delta: 2.027118)         elapsed: 17.800078 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:48
2019-09-16T11:58:02.203017 (delta: 0.094438)         elapsed: 17.894579 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1568635082.26-262275218084306/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:53
2019-09-16T11:58:03.065439 (delta: 0.862363)         elapsed: 18.757001 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1568635083.16-72513270896643/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:21
2019-09-16T11:58:03.764978 (delta: 0.699473)         elapsed: 19.45654 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:24
2019-09-16T11:58:03.900801 (delta: 0.13575)         elapsed: 19.592363 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:27
2019-09-16T11:58:04.050525 (delta: 0.149644)         elapsed: 19.742087 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:31
2019-09-16T11:58:04.224578 (delta: 0.17396)         elapsed: 19.91614 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:38
2019-09-16T11:58:04.392266 (delta: 0.16759)         elapsed: 20.083828 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-16T11:58:04.528163 (delta: 0.13584)         elapsed: 20.219725 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d033ea974d5ef085c993c50e7a6f965c34548b8d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "847944374d12ae8e25882f4315d7c96c", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1568635084.6-73322624218110/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-16T11:58:05.058703 (delta: 0.530477)         elapsed: 20.750265 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.212636", "end": "2019-09-16 11:58:06.677960", "rc": 0, "start": "2019-09-16 11:58:05.465324", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-16T11:58:06.746966 (delta: 1.688202)         elapsed: 22.438528 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.591318", "end": "2019-09-16 11:58:08.572845", "failed_when_result": false, "rc": 0, "start": "2019-09-16 11:58:06.981527", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-16T11:58:08.725583 (delta: 1.97856)         elapsed: 24.417145 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-16T11:58:08.798670 (delta: 0.073028)         elapsed: 24.490232 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-16T11:58:08.868897 (delta: 0.070171)         elapsed: 24.560459 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:45
2019-09-16T11:58:08.932211 (delta: 0.063248)         elapsed: 24.623773 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : percona-test", 
        "Label        : name=perconatest", 
        "PVC          : mypercona", 
        "StorageClass : openebs-sparse-sc-statefulset"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:56
2019-09-16T11:58:09.097204 (delta: 0.164934)         elapsed: 24.788766 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-16T11:58:09.271572 (delta: 0.174282)         elapsed: 24.963134 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona-test -l name=\"perconatest\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.305845", "end": "2019-09-16 11:58:10.845527", "rc": 0, "start": "2019-09-16 11:58:09.539682", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T11:52:39Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T11:52:39Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-16T11:58:10.954194 (delta: 1.682563)         elapsed: 26.645756 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-test -o jsonpath='{.items[?(@.metadata.labels.name==\"perconatest\")].status.phase}'", "delta": "0:00:01.238165", "end": "2019-09-16 11:58:12.482825", "rc": 0, "start": "2019-09-16 11:58:11.244660", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:65
2019-09-16T11:58:12.570611 (delta: 1.616318)         elapsed: 28.262173 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-test -l name=perconatest --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.224434", "end": "2019-09-16 11:58:14.080431", "rc": 0, "start": "2019-09-16 11:58:12.855997", "stderr": "", "stderr_lines": [], "stdout": "percona-7dd9b46b64-t49b9", "stdout_lines": ["percona-7dd9b46b64-t49b9"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:73
2019-09-16T11:58:14.141498 (delta: 1.570821)         elapsed: 29.83306 ******** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-16T11:58:14.305707 (delta: 0.164155)         elapsed: 29.997269 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-7dd9b46b64-t49b9 -n percona-test -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:01.340333", "end": "2019-09-16 11:58:15.913502", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2019-09-16 11:58:14.573169", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-7dd9b46b64-t49b9 -n percona-test -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:02.609028", "end": "2019-09-16 11:58:18.962937", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2019-09-16 11:58:16.353909", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-7dd9b46b64-t49b9 -n percona-test -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:01.556718", "end": "2019-09-16 11:58:20.909394", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2019-09-16 11:58:19.352676", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-16T11:58:20.974991 (delta: 6.669223)         elapsed: 36.666553 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-16T11:58:21.028721 (delta: 0.05368)         elapsed: 36.720283 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-16T11:58:21.082309 (delta: 0.053533)         elapsed: 36.773871 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-16T11:58:21.139047 (delta: 0.056688)         elapsed: 36.830609 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-16T11:58:21.195437 (delta: 0.056332)         elapsed: 36.886999 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-16T11:58:21.253850 (delta: 0.058361)         elapsed: 36.945412 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-16T11:58:21.305957 (delta: 0.052059)         elapsed: 36.997519 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-16T11:58:21.377602 (delta: 0.071587)         elapsed: 37.069164 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-16T11:58:21.440752 (delta: 0.063093)         elapsed: 37.132314 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:83
2019-09-16T11:58:21.502398 (delta: 0.061592)         elapsed: 37.19396 ******** 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-09-16T11:58:21.651838 (delta: 0.149364)         elapsed: 37.3434 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n percona-test", "delta": "0:00:01.701092", "end": "2019-09-16 11:58:23.609189", "rc": 0, "start": "2019-09-16 11:58:21.908097", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-09-16T11:58:23.739493 (delta: 2.087593)         elapsed: 39.431055 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n percona-test | sort | uniq", "delta": "0:00:01.357493", "end": "2019-09-16 11:58:46.875547", "rc": 0, "start": "2019-09-16 11:58:45.518054", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-09-16T11:58:46.940235 (delta: 23.200686)         elapsed: 62.631797 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc mypercona -o custom-columns=:spec.volumeName -n percona-test --no-headers", "delta": "0:00:01.260422", "end": "2019-09-16 11:58:48.403614", "rc": 0, "start": "2019-09-16 11:58:47.143192", "stderr": "", "stderr_lines": [], "stdout": "pvc-52a8f342-d878-11e9-92b9-00505698550d", "stdout_lines": ["pvc-52a8f342-d878-11e9-92b9-00505698550d"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-09-16T11:58:48.484855 (delta: 1.544563)         elapsed: 64.176417 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-52a8f342-d878-11e9-92b9-00505698550d | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.099618", "end": "2019-09-16 11:58:49.864967", "rc": 0, "start": "2019-09-16 11:58:48.765349", "stderr": "", "stderr_lines": [], "stdout": "pvc-52a8f342-d878-11e9-92b9-00505698550d-target-785d578b5682ttl", "stdout_lines": ["pvc-52a8f342-d878-11e9-92b9-00505698550d-target-785d578b5682ttl"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-09-16T11:58:49.931723 (delta: 1.446782)         elapsed: 65.623285 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-52a8f342-d878-11e9-92b9-00505698550d"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-09-16T11:58:50.039097 (delta: 0.107309)         elapsed: 65.730659 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-52a8f342-d878-11e9-92b9-00505698550d-target-785d578b5682ttl -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.113002", "end": "2019-09-16 11:58:51.478943", "rc": 0, "start": "2019-09-16 11:58:50.365941", "stderr": "", "stderr_lines": [], "stdout": "node1-1554817485.mayalabs.io", "stdout_lines": ["node1-1554817485.mayalabs.io"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-09-16T11:58:51.556721 (delta: 1.517566)         elapsed: 67.248283 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n percona-test -o jsonpath='{.items[?(@.spec.nodeName==''\"node1-1554817485.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.194832", "end": "2019-09-16 11:58:53.025349", "rc": 0, "start": "2019-09-16 11:58:51.830517", "stderr": "", "stderr_lines": [], "stdout": "pumba-pj4pp", "stdout_lines": ["pumba-pj4pp"]}

TASK [Inject egress delay of 60000ms on cstor target for 60s] ******************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-09-16T11:58:53.097903 (delta: 1.541114)         elapsed: 68.789465 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-pj4pp -n percona-test -- pumba netem --interface eth0 --duration 60s delay --time 60000 re2:k8s_cstor-istgt_pvc-52a8f342-d878-11e9-92b9-00505698550d", "delta": "0:01:04.196820", "end": "2019-09-16 11:59:57.504111", "rc": 0, "start": "2019-09-16 11:58:53.307291", "stderr": "time=\"2019-09-16T11:58:55Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-09-16T11:58:56Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 for 1m0s\" \ntime=\"2019-09-16T11:58:56Z\" level=info msg=\"Start netem for container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2019-09-16T11:59:57Z\" level=info msg=\"Stopping netem on container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215\" \ntime=\"2019-09-16T11:59:57Z\" level=info msg=\"Stop netem for container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 on 'eth0'\" ", "stderr_lines": ["time=\"2019-09-16T11:58:55Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-09-16T11:58:56Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 for 1m0s\" ", "time=\"2019-09-16T11:58:56Z\" level=info msg=\"Start netem for container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2019-09-16T11:59:57Z\" level=info msg=\"Stopping netem on container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215\" ", "time=\"2019-09-16T11:59:57Z\" level=info msg=\"Stop netem for container 445964755fa83f4890a6dceed1ad0a1d102bc385e6cf3538e6659615e9830215 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-09-16T11:59:57.620380 (delta: 64.522424)         elapsed: 133.311942 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-09-16T12:00:08.312076 (delta: 10.691548)         elapsed: 144.003638 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n percona-test", "delta": "0:00:01.445172", "end": "2019-09-16 12:00:10.000785", "rc": 0, "start": "2019-09-16 12:00:08.555613", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-09-16T12:00:10.110337 (delta: 1.798204)         elapsed: 145.801899 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n percona-test", "delta": "0:00:01.133275", "end": "2019-09-16 12:00:11.531704", "rc": 0, "start": "2019-09-16 12:00:10.398429", "stderr": "", "stderr_lines": [], "stdout": "pumba-8fdnw   0/1   Terminating   0     1m\npumba-pj4pp   0/1   Terminating   0     1m\npumba-sz6kh   0/1   Terminating   0     1m", "stdout_lines": ["pumba-8fdnw   0/1   Terminating   0     1m", "pumba-pj4pp   0/1   Terminating   0     1m", "pumba-sz6kh   0/1   Terminating   0     1m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:91
2019-09-16T12:00:11.597184 (delta: 1.486707)         elapsed: 147.288746 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-16T12:00:11.701302 (delta: 0.104058)         elapsed: 147.392864 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona-test -l name=\"perconatest\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.123262", "end": "2019-09-16 12:00:13.026958", "rc": 0, "start": "2019-09-16 12:00:11.903696", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T11:52:39Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T11:52:39Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-16T12:00:13.116061 (delta: 1.414701)         elapsed: 148.807623 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-test -o jsonpath='{.items[?(@.metadata.labels.name==\"perconatest\")].status.phase}'", "delta": "0:00:01.424247", "end": "2019-09-16 12:00:14.844795", "rc": 0, "start": "2019-09-16 12:00:13.420548", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:100
2019-09-16T12:00:14.957511 (delta: 1.841374)         elapsed: 150.649073 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:103
2019-09-16T12:00:15.029650 (delta: 0.072046)         elapsed: 150.721212 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-09-16T12:00:15.170607 (delta: 0.140892)         elapsed: 150.862169 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-09-16T12:00:15.261698 (delta: 0.091027)         elapsed: 150.95326 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7dd9b46b64-t49b9 -n percona-test", "delta": "0:00:11.366512", "end": "2019-09-16 12:00:26.832522", "rc": 0, "start": "2019-09-16 12:00:15.466010", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7dd9b46b64-t49b9\" deleted", "stdout_lines": ["pod \"percona-7dd9b46b64-t49b9\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-09-16T12:00:26.903664 (delta: 11.641901)         elapsed: 162.595226 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-test", "delta": "0:00:01.150468", "end": "2019-09-16 12:00:28.262053", "rc": 0, "start": "2019-09-16 12:00:27.111585", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\npercona-7dd9b46b64-qtmms   1/1     Running   0          12s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "percona-7dd9b46b64-qtmms   1/1     Running   0          12s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-09-16T12:00:28.356198 (delta: 1.452465)         elapsed: 164.04776 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-test -l name=perconatest -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.441703", "end": "2019-09-16 12:00:30.082432", "rc": 0, "start": "2019-09-16 12:00:28.640729", "stderr": "", "stderr_lines": [], "stdout": "percona-7dd9b46b64-qtmms", "stdout_lines": ["percona-7dd9b46b64-qtmms"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-09-16T12:00:30.145384 (delta: 1.78912)         elapsed: 165.836946 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-test -o jsonpath='{.items[?(@.metadata.name==\"percona-7dd9b46b64-qtmms\")].status.phase}'", "delta": "0:00:01.394215", "end": "2019-09-16 12:00:31.756050", "rc": 0, "start": "2019-09-16 12:00:30.361835", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-09-16T12:00:31.827651 (delta: 1.682168)         elapsed: 167.519213 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-test -o jsonpath='{.items[?(@.metadata.name==\"percona-7dd9b46b64-qtmms\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.108725", "end": "2019-09-16 12:00:33.152519", "rc": 0, "start": "2019-09-16 12:00:32.043794", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T12:00:23Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T12:00:23Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-09-16T12:00:33.228507 (delta: 1.400793)         elapsed: 168.920069 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7dd9b46b64-qtmms -n percona-test -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:01.389311", "end": "2019-09-16 12:00:34.875960", "failed_when_result": false, "rc": 0, "start": "2019-09-16 12:00:33.486649", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-09-16T12:00:34.987218 (delta: 1.758644)         elapsed: 170.67878 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7dd9b46b64-qtmms -n percona-test -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:01.370039", "end": "2019-09-16 12:00:36.562031", "failed_when_result": false, "rc": 0, "start": "2019-09-16 12:00:35.191992", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-09-16T12:00:36.633564 (delta: 1.646285)         elapsed: 172.325126 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-09-16T12:00:36.692584 (delta: 0.058956)         elapsed: 172.384146 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:111
2019-09-16T12:00:36.749707 (delta: 0.057062)         elapsed: 172.441269 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:122
2019-09-16T12:00:36.844104 (delta: 0.094339)         elapsed: 172.535666 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-16T12:00:36.963524 (delta: 0.119356)         elapsed: 172.655086 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-16T12:00:37.025521 (delta: 0.061935)         elapsed: 172.717083 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-16T12:00:37.092131 (delta: 0.066551)         elapsed: 172.783693 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-16T12:00:37.155297 (delta: 0.063107)         elapsed: 172.846859 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e7f0f790b1fb82156ee809c231d7445cd5cd07b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "89296e59cc89d49e5b7cbb6d0f0c8848", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1568635237.27-217821174093994/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-16T12:00:39.665152 (delta: 2.509799)         elapsed: 175.356714 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.100979", "end": "2019-09-16 12:00:41.017202", "rc": 0, "start": "2019-09-16 12:00:39.916223", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-16T12:00:41.082767 (delta: 1.417557)         elapsed: 176.774329 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.578198", "end": "2019-09-16 12:00:42.874156", "failed_when_result": false, "rc": 0, "start": "2019-09-16 12:00:41.295958", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=34   unreachable=0    failed=0   

2019-09-16T12:00:42.941048 (delta: 1.858227)         elapsed: 178.63261 ******* 
```
Logs for data consistency check against busybox--->
```
config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_delay/test.yml

PLAY [localhost] ***************************************************************
2019-09-16T10:50:49.193212 (delta: 0.066547)         elapsed: 0.066547 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:2
2019-09-16T10:50:49.209346 (delta: 0.016068)         elapsed: 0.082681 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:13
2019-09-16T10:50:58.908778 (delta: 9.69941)         elapsed: 9.782113 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:17
2019-09-16T10:50:59.030351 (delta: 0.12151)         elapsed: 9.903686 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-09-16T10:50:59.215042 (delta: 0.184548)         elapsed: 10.088377 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-09-16T10:50:59.290148 (delta: 0.07501)         elapsed: 10.163483 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:2
2019-09-16T10:50:59.386211 (delta: 0.095978)         elapsed: 10.259546 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n bb-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.257133", "end": "2019-09-16 10:51:01.167835", "rc": 0, "start": "2019-09-16 10:50:59.910702", "stderr": "", "stderr_lines": [], "stdout": "openebs-sparse-sc-statefulset", "stdout_lines": ["openebs-sparse-sc-statefulset"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:10
2019-09-16T10:51:01.237511 (delta: 1.851221)         elapsed: 12.110846 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-sparse-sc-statefulset --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.384899", "end": "2019-09-16 10:51:02.948776", "rc": 0, "start": "2019-09-16 10:51:01.563877", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:18
2019-09-16T10:51:03.013194 (delta: 1.775629)         elapsed: 13.886529 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-sparse-sc-statefulset"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:22
2019-09-16T10:51:03.148281 (delta: 0.135035)         elapsed: 14.021616 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:27
2019-09-16T10:51:03.328028 (delta: 0.179662)         elapsed: 14.201363 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n bb-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.257970", "end": "2019-09-16 10:51:04.848844", "rc": 0, "start": "2019-09-16 10:51:03.590874", "stderr": "", "stderr_lines": [], "stdout": "pvc-b0421b29-d484-11e9-92b9-00505698550d", "stdout_lines": ["pvc-b0421b29-d484-11e9-92b9-00505698550d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:35
2019-09-16T10:51:05.004048 (delta: 1.675907)         elapsed: 15.877383 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-b0421b29-d484-11e9-92b9-00505698550d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.228145", "end": "2019-09-16 10:51:06.487870", "rc": 0, "start": "2019-09-16 10:51:05.259725", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:43
2019-09-16T10:51:06.601124 (delta: 1.597016)         elapsed: 17.474459 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:48
2019-09-16T10:51:06.791321 (delta: 0.190114)         elapsed: 17.664656 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1568631066.9-50916560775216/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:53
2019-09-16T10:51:07.804584 (delta: 1.007974)         elapsed: 18.677919 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1568631067.86-104364085364554/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:21
2019-09-16T10:51:08.267723 (delta: 0.463064)         elapsed: 19.141058 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:24
2019-09-16T10:51:08.361169 (delta: 0.093385)         elapsed: 19.234504 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:27
2019-09-16T10:51:08.461804 (delta: 0.100574)         elapsed: 19.335139 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:31
2019-09-16T10:51:08.582047 (delta: 0.120173)         elapsed: 19.455382 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:38
2019-09-16T10:51:08.736586 (delta: 0.154468)         elapsed: 19.609921 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-16T10:51:08.859943 (delta: 0.123294)         elapsed: 19.733278 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d033ea974d5ef085c993c50e7a6f965c34548b8d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "847944374d12ae8e25882f4315d7c96c", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1568631068.92-145046998771480/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-16T10:51:09.426503 (delta: 0.5665)         elapsed: 20.299838 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.302688", "end": "2019-09-16 10:51:10.990980", "rc": 0, "start": "2019-09-16 10:51:09.688292", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-16T10:51:11.147290 (delta: 1.720709)         elapsed: 22.020625 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.178623", "end": "2019-09-16 10:51:13.666861", "failed_when_result": false, "rc": 0, "start": "2019-09-16 10:51:11.488238", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-16T10:51:13.742560 (delta: 2.595199)         elapsed: 24.615895 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-16T10:51:13.801887 (delta: 0.05927)         elapsed: 24.675222 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-16T10:51:13.865959 (delta: 0.064013)         elapsed: 24.739294 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:45
2019-09-16T10:51:13.944626 (delta: 0.078605)         elapsed: 24.817961 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : bb-ns", 
        "Label        : app=bb", 
        "PVC          : openebs-busybox", 
        "StorageClass : openebs-sparse-sc-statefulset"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:56
2019-09-16T10:51:14.134740 (delta: 0.19002)         elapsed: 25.008075 ******** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-16T10:51:14.306636 (delta: 0.17181)         elapsed: 25.179971 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n bb-ns -l app=\"bb\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.362351", "end": "2019-09-16 10:51:16.130435", "rc": 0, "start": "2019-09-16 10:51:14.768084", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T10:18:56Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T10:18:56Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-16T10:51:16.223728 (delta: 1.917013)         elapsed: 27.097063 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"bb\")].status.phase}'", "delta": "0:00:01.281074", "end": "2019-09-16 10:51:17.986387", "rc": 0, "start": "2019-09-16 10:51:16.705313", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:65
2019-09-16T10:51:18.074520 (delta: 1.8507)         elapsed: 28.947855 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n bb-ns -l app=bb --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.256434", "end": "2019-09-16 10:51:19.636984", "rc": 0, "start": "2019-09-16 10:51:18.380550", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-6f765cf76d-gv6gs", "stdout_lines": ["app-busybox-6f765cf76d-gv6gs"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:73
2019-09-16T10:51:19.733592 (delta: 1.659006)         elapsed: 30.606927 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-16T10:51:19.920120 (delta: 0.186469)         elapsed: 30.793455 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-6f765cf76d-gv6gs -n bb-ns -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:01.495469", "end": "2019-09-16 10:51:21.703090", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-09-16 10:51:20.207621", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.035392 seconds, 113.0MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.035392 seconds, 113.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-6f765cf76d-gv6gs -n bb-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:01.459786", "end": "2019-09-16 10:51:23.378701", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-09-16 10:51:21.918915", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-16T10:51:23.450994 (delta: 3.530806)         elapsed: 34.324329 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-16T10:51:23.524171 (delta: 0.073103)         elapsed: 34.397506 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-16T10:51:23.600811 (delta: 0.076573)         elapsed: 34.474146 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-16T10:51:23.660661 (delta: 0.059766)         elapsed: 34.533996 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-16T10:51:23.717197 (delta: 0.056477)         elapsed: 34.590532 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-16T10:51:23.772076 (delta: 0.054824)         elapsed: 34.645411 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-16T10:51:23.827521 (delta: 0.055389)         elapsed: 34.700856 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-16T10:51:23.882764 (delta: 0.055191)         elapsed: 34.756099 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-16T10:51:23.937378 (delta: 0.054559)         elapsed: 34.810713 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-16T10:51:24.003164 (delta: 0.065714)         elapsed: 34.876499 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:83
2019-09-16T10:51:24.085601 (delta: 0.08238)         elapsed: 34.958936 ******** 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-09-16T10:51:24.279235 (delta: 0.193568)         elapsed: 35.15257 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n bb-ns", "delta": "0:00:01.633195", "end": "2019-09-16 10:51:26.262174", "rc": 0, "start": "2019-09-16 10:51:24.628979", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-09-16T10:51:26.326852 (delta: 2.047543)         elapsed: 37.200187 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n bb-ns | sort | uniq", "delta": "0:00:01.294003", "end": "2019-09-16 10:51:49.403200", "rc": 0, "start": "2019-09-16 10:51:48.109197", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-09-16T10:51:49.469158 (delta: 23.142255)         elapsed: 60.342493 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n bb-ns --no-headers", "delta": "0:00:01.174146", "end": "2019-09-16 10:51:50.863546", "rc": 0, "start": "2019-09-16 10:51:49.689400", "stderr": "", "stderr_lines": [], "stdout": "pvc-b0421b29-d484-11e9-92b9-00505698550d", "stdout_lines": ["pvc-b0421b29-d484-11e9-92b9-00505698550d"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-09-16T10:51:50.968687 (delta: 1.499473)         elapsed: 61.842022 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-b0421b29-d484-11e9-92b9-00505698550d | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.369497", "end": "2019-09-16 10:51:52.653961", "rc": 0, "start": "2019-09-16 10:51:51.284464", "stderr": "", "stderr_lines": [], "stdout": "pvc-b0421b29-d484-11e9-92b9-00505698550d-target-9f5f87f8f-mp2fr", "stdout_lines": ["pvc-b0421b29-d484-11e9-92b9-00505698550d-target-9f5f87f8f-mp2fr"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-09-16T10:51:52.714095 (delta: 1.745326)         elapsed: 63.58743 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-b0421b29-d484-11e9-92b9-00505698550d"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-09-16T10:51:52.851821 (delta: 0.137672)         elapsed: 63.725156 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-b0421b29-d484-11e9-92b9-00505698550d-target-9f5f87f8f-mp2fr -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.361499", "end": "2019-09-16 10:51:54.436868", "rc": 0, "start": "2019-09-16 10:51:53.075369", "stderr": "", "stderr_lines": [], "stdout": "node2-1554817485.mayalabs.io", "stdout_lines": ["node2-1554817485.mayalabs.io"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-09-16T10:51:54.509949 (delta: 1.658065)         elapsed: 65.383284 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n bb-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"node2-1554817485.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.175516", "end": "2019-09-16 10:51:55.905181", "rc": 0, "start": "2019-09-16 10:51:54.729665", "stderr": "", "stderr_lines": [], "stdout": "pumba-q4ngc", "stdout_lines": ["pumba-q4ngc"]}

TASK [Inject egress delay of 60000ms on cstor target for 60s] ******************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-09-16T10:51:56.049190 (delta: 1.539177)         elapsed: 66.922525 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-q4ngc -n bb-ns -- pumba netem --interface eth0 --duration 60s delay --time 60000 re2:k8s_cstor-istgt_pvc-b0421b29-d484-11e9-92b9-00505698550d", "delta": "0:01:03.291615", "end": "2019-09-16 10:52:59.622945", "rc": 0, "start": "2019-09-16 10:51:56.331330", "stderr": "time=\"2019-09-16T10:51:57Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-09-16T10:51:58Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 for 1m0s\" \ntime=\"2019-09-16T10:51:58Z\" level=info msg=\"Start netem for container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2019-09-16T10:52:59Z\" level=info msg=\"Stopping netem on container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05\" \ntime=\"2019-09-16T10:52:59Z\" level=info msg=\"Stop netem for container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 on 'eth0'\" ", "stderr_lines": ["time=\"2019-09-16T10:51:57Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-09-16T10:51:58Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 for 1m0s\" ", "time=\"2019-09-16T10:51:58Z\" level=info msg=\"Start netem for container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2019-09-16T10:52:59Z\" level=info msg=\"Stopping netem on container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05\" ", "time=\"2019-09-16T10:52:59Z\" level=info msg=\"Stop netem for container b2c5b34d0976dc0f3b64e9c3a7a00917e59eeb00f72fac0c401754b019bc4a05 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-09-16T10:52:59.757151 (delta: 63.707862)         elapsed: 130.630486 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-09-16T10:53:10.401332 (delta: 10.644076)         elapsed: 141.274667 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n bb-ns", "delta": "0:00:01.244077", "end": "2019-09-16 10:53:11.900812", "rc": 0, "start": "2019-09-16 10:53:10.656735", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-09-16T10:53:11.992444 (delta: 1.590962)         elapsed: 142.865779 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n bb-ns", "delta": "0:00:01.216951", "end": "2019-09-16 10:53:13.478490", "rc": 0, "start": "2019-09-16 10:53:12.261539", "stderr": "", "stderr_lines": [], "stdout": "pumba-hm7pf   0/1   Terminating   0     1m\npumba-l84p5   0/1   Terminating   0     1m\npumba-q4ngc   0/1   Terminating   0     1m", "stdout_lines": ["pumba-hm7pf   0/1   Terminating   0     1m", "pumba-l84p5   0/1   Terminating   0     1m", "pumba-q4ngc   0/1   Terminating   0     1m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:91
2019-09-16T10:53:13.638706 (delta: 1.646174)         elapsed: 144.512041 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-09-16T10:53:13.799147 (delta: 0.160337)         elapsed: 144.672482 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n bb-ns -l app=\"bb\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.199479", "end": "2019-09-16 10:53:15.266169", "rc": 0, "start": "2019-09-16 10:53:14.066690", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T10:18:56Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T10:18:56Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-09-16T10:53:15.341702 (delta: 1.542494)         elapsed: 146.215037 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"bb\")].status.phase}'", "delta": "0:00:01.368950", "end": "2019-09-16 10:53:16.995668", "rc": 0, "start": "2019-09-16 10:53:15.626718", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:100
2019-09-16T10:53:17.092688 (delta: 1.75093)         elapsed: 147.966023 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:103
2019-09-16T10:53:17.222162 (delta: 0.129398)         elapsed: 148.095497 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-09-16T10:53:17.572069 (delta: 0.349804)         elapsed: 148.445404 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-09-16T10:53:17.670340 (delta: 0.098169)         elapsed: 148.543675 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-6f765cf76d-gv6gs -n bb-ns", "delta": "0:00:42.294599", "end": "2019-09-16 10:54:00.274224", "rc": 0, "start": "2019-09-16 10:53:17.979625", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-6f765cf76d-gv6gs\" deleted", "stdout_lines": ["pod \"app-busybox-6f765cf76d-gv6gs\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-09-16T10:54:00.333474 (delta: 42.663076)         elapsed: 191.206809 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb-ns", "delta": "0:00:01.360152", "end": "2019-09-16 10:54:02.027434", "rc": 0, "start": "2019-09-16 10:54:00.667282", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\napp-busybox-6f765cf76d-qlcgf   1/1     Running   0          43s", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "app-busybox-6f765cf76d-qlcgf   1/1     Running   0          43s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-09-16T10:54:02.150588 (delta: 1.817056)         elapsed: 193.023923 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n bb-ns -l app=bb -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.128798", "end": "2019-09-16 10:54:03.549676", "rc": 0, "start": "2019-09-16 10:54:02.420878", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-6f765cf76d-qlcgf", "stdout_lines": ["app-busybox-6f765cf76d-qlcgf"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-09-16T10:54:03.646796 (delta: 1.496119)         elapsed: 194.520131 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-6f765cf76d-qlcgf\")].status.phase}'", "delta": "0:00:01.253587", "end": "2019-09-16 10:54:05.259895", "rc": 0, "start": "2019-09-16 10:54:04.006308", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-09-16T10:54:05.390295 (delta: 1.743406)         elapsed: 196.26363 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-6f765cf76d-qlcgf\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.238090", "end": "2019-09-16 10:54:07.087895", "rc": 0, "start": "2019-09-16 10:54:05.849805", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-09-16T10:53:22Z]]", "stdout_lines": ["map[running:map[startedAt:2019-09-16T10:53:22Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-09-16T10:54:07.212321 (delta: 1.821853)         elapsed: 198.085656 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-6f765cf76d-qlcgf -n bb-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.702697", "end": "2019-09-16 10:54:09.215541", "failed_when_result": false, "rc": 0, "start": "2019-09-16 10:54:07.512844", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-09-16T10:54:09.358309 (delta: 2.145839)         elapsed: 200.231644 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-6f765cf76d-qlcgf -n bb-ns -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.511682", "end": "2019-09-16 10:54:11.213179", "failed_when_result": false, "rc": 0, "start": "2019-09-16 10:54:09.701497", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-09-16T10:54:11.354138 (delta: 1.995686)         elapsed: 202.227473 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-09-16T10:54:11.477979 (delta: 0.12374)         elapsed: 202.351314 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-09-16T10:54:11.543101 (delta: 0.065017)         elapsed: 202.416436 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:111
2019-09-16T10:54:11.602035 (delta: 0.058875)         elapsed: 202.47537 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:122
2019-09-16T10:54:11.741255 (delta: 0.13916)         elapsed: 202.61459 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-09-16T10:54:11.939151 (delta: 0.197823)         elapsed: 202.812486 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-09-16T10:54:12.051219 (delta: 0.111984)         elapsed: 202.924554 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-09-16T10:54:12.149769 (delta: 0.098464)         elapsed: 203.023104 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-09-16T10:54:12.251190 (delta: 0.101335)         elapsed: 203.124525 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e7f0f790b1fb82156ee809c231d7445cd5cd07b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "89296e59cc89d49e5b7cbb6d0f0c8848", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1568631252.39-123171850522351/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-09-16T10:54:14.901642 (delta: 2.65035)         elapsed: 205.774977 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.150420", "end": "2019-09-16 10:54:16.269267", "rc": 0, "start": "2019-09-16 10:54:15.118847", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-09-16T10:54:16.331024 (delta: 1.429328)         elapsed: 207.204359 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.453595", "end": "2019-09-16 10:54:18.084874", "failed_when_result": false, "rc": 0, "start": "2019-09-16 10:54:16.631279", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=34   unreachable=0    failed=0   

2019-09-16T10:54:18.160866 (delta: 1.829786)         elapsed: 209.034201 ****** 

```
