### PR TITLE
Refactored Litmus Book - Changed the kubectl command used in shell module to k8s , k8s_facts module 

### DIFF
--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -1,4 +1,3 @@
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -49,4 +48,3 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/percona/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]
-     

--- a/utils/fcm/update_litmus_result_resource.yml
+++ b/utils/fcm/update_litmus_result_resource.yml
@@ -15,11 +15,11 @@
      shell: cat litmus-result.yaml
 
    - name: Apply the litmus result CR
-     shell: kubectl apply -f litmus-result.yaml
-     args:
-       executable: /bin/bash
+     k8s:
+       state: present
+       src: litmus-result.yaml
      register: lr_status
-     failed_when: "lr_status.rc != 0"
+     failed_when: "lr_status is failed"
 
   when: status == "SOT"
 
@@ -39,10 +39,11 @@
      shell: cat litmus-result.yaml
 
    - name: Apply the litmus result CR
-     shell: kubectl apply -f litmus-result.yaml
-     args:
-       executable: /bin/bash
+     k8s:
+       state: present
+       src: litmus-result.yaml
+       merge_type: merge
      register: lr_status
-     failed_when: "lr_status.rc != 0"
+     failed_when: "lr_status is failed"
 
   when: status == "EOT"

--- a/utils/k8s/create_ns.yml
+++ b/utils/k8s/create_ns.yml
@@ -1,18 +1,20 @@
 ---
 - name: Obtain list of existing namespaces
-  shell: >
-    kubectl get ns 
-    --no-headers 
-    -o custom-columns=:metadata.name
-  args: 
-    executable: /bin/bash
+  k8s_facts:
+    kind: Namespace
   register: ns_list
+ 
+- debug: 
+    msg: "{{item.metadata.name}}"
+  with_items: "{{ns_list.resources}}"
 
 - name: Create test specific namespace.
-  shell: kubectl create ns {{ app_ns }}
-  args:
-    executable: /bin/bash
-  when: app_ns != 'litmus' and app_ns not in ns_list.stdout_lines
+  k8s:
+    kind: Namespace
+    name: "{{ app_ns }}"
+    state: present
+  when: app_ns != 'litmus' and app_ns not in item.metadata.name
+  with_items: "{{ ns_list.resources }}"
 
 - include_tasks: /utils/k8s/status_testns.yml
 

--- a/utils/k8s/deploy_single_app.yml
+++ b/utils/k8s/deploy_single_app.yml
@@ -2,7 +2,12 @@
 #Deploying application on k8's cluster and cross checking whether the
 #application is deployed successfully.
 - name: Deploying {{ application_name }}
-  shell: kubectl apply -f {{ application_deployment }} -n {{ app_ns }}
+  k8s:
+    state: present
+    src: "{{ application_deployment }}"
+    namespace: "{{ app_ns }}"
+    merge_type: merge  
+  register: result
 
 - include_tasks: /utils/k8s/status_app_pod.yml
   when: check_app_pod == 'yes'

--- a/utils/k8s/deprovision_deployment.yml
+++ b/utils/k8s/deprovision_deployment.yml
@@ -1,5 +1,4 @@
 ---
-
 # This Utility task file can delete the application and its underlying resources such as pvc and service from K8s cluster
 # This accepts application namespace, application label and application manifest file as input parameters.
 # The parameters used are
@@ -10,37 +9,52 @@
 - block:
 
     - name: Check if the application to be deleted is running.
-      shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers -o custom-columns=:status.phase
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: Pod
+        label_selectors:
+          - "{{ app_label }}"
+        namespace: "{{ app_ns }}"
       register: result
-      until: "'Running' in result.stdout"
+      until: "result.resources.0.status.phase == 'Running'"
       delay: 5
       retries: 60
     
     - name: Obtaining the PVC name using application label.
-      shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:..claimName --no-headers
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: Pod
+        namespace: "{{ app_ns }}"
+        label_selectors:
+          - "{{ app_label }}"
       register: pvc_name
-    
+
+    - debug:
+        msg: "{{ item.spec.volumes.0.persistentVolumeClaim.claimName }}"
+      with_items: "{{ pvc_name.resources }}" 
+
     - name: Obtaining the PV name from PVC name.
-      shell: kubectl get pvc {{ pvc_name.stdout }} -n {{ app_ns }} -o custom-columns=:spec.volumeName --no-headers
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: PersistentVolumeClaim
+        name: "{{ pvc_name.resources.0.spec.volumes.0.persistentVolumeClaim.claimName }}"
+        namespace: "{{ app_ns }}"
       register: pv_name
+    - debug:
+        msg: "{{ item.spec.volumeName  }}"
+      with_items: "{{ pv_name.resources }}"
 
     - name: Check for presence & value of cas type annotation
-      shell: >
-        kubectl get pv {{ pv_name.stdout }} --no-headers
-        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: PersistentVolume
+        name: "{{ pv_name.resources.0.spec.volumeName }}"
       register: openebs_stg_engine
+
+    - debug: 
+        msg: "{{ item.metadata.annotations['openebs.io/cas-type'] }}"
+      with_items: "{{ openebs_stg_engine.resources }}"
+
 
     - name: Record the storage engine name
       set_fact:
-        stg_engine: "{{ openebs_stg_engine.stdout }}"
+        stg_engine: "{{ openebs_stg_engine.resources.0.metadata.annotations['openebs.io/cas-type'] }}"
     
     ## Replacing the item names in the respective deployer spec file.
     - name: Replace the PVC name in application deployer spec.
@@ -77,11 +91,11 @@
         executable: /bin/bash
     
     - name: Check if the PVC is deleted.
-      shell: kubectl get pvc -n {{ app_ns }} --no-headers
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: PersistentVolumeClaim
+        namespace: "{{ app_ns }}"
       register: resource_list
-      until: "app_pvc not in resource_list.stdout"
+      until: resource_list.resources | length < 1
       delay: 5
       retries: 120
     
@@ -90,22 +104,24 @@
         - block:
 
             - name: Check if the ctrl-pod is deleted.
-              shell: >
-                 kubectl get pods -n {{ app_ns }}
-                 -l openebs.io/controller=jiva-controller --no-headers
-              args:
-                executable: /bin/bash
+              k8s_facts:
+                kind: Pod
+                namespace: "{{ app_ns }}"
+                label_selectors:
+                  - "openebs.io/controller=jiva-controller" 
               register: ctrl_status
-              until: "'No resources found' in ctrl_status.stderr"
+              until: "ctrl_status.resources | length < 1"
               delay: 5
               retries: 15
 
             - name: Check if the  replica-pod is deleted.
-              shell: kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica
-              args:
-                executable: /bin/bash
+              k8s_facts:
+                kind: Pod
+                namespace: "{{ app_ns }}"
+                label_selectors:
+                  - "openebs.io/replica=jiva-replica"
               register: rep_status
-              until: "'No resources found' in rep_status.stderr"
+              until: "rep_status.resources | length < 1"
               delay: 5
               retries: 15
 
@@ -114,22 +130,25 @@
         - block:
 
             - name: Check if the target pod is deleted.
-              shell: >
-                  kubectl get pods -l openebs.io/target=cstor-target  -n {{ operator_ns }} --no-headers
-              args:
-                executable: /bin/bash
+              k8s_facts:
+                kind: Pod
+                label_selectors:
+                  - "openebs.io/target=cstor-target"
+                  - "pv_name.resources.0.spec.volumName"
+                namespace: "{{ operator_ns }}"        
               register: target_status
-              until: " pv_name.stdout  not  in target_status.stdout"
+              until: " target_status.resources | length < 1"
               delay: 5
               retries: 20
 
             - name: Check status of the pool deployments from cvr
-              shell: >
-                  kubectl get cvr -n {{ operator_ns }} --no-headers
-              args:
-                executable:  /bin/bash
+              k8s_facts:
+                kind: CStorVolumeReplica
+                namespace: "{{ operator_ns }}"
+                label_selectors:
+                  - "pv_name.resources.0.spec.volumName"
               register: cvr_status
-              until: " pv_name.stdout not in cvr_status.stdout"
+              until: " cvr_status.resources | length < 1 "
               delay: 5
               retries: 20
 
@@ -138,13 +157,14 @@
       when: storage_class is defined    
 
 - name: Delete the namespace.
-  shell: kubectl delete ns {{ app_ns }}
-  args:
-    executable: /bin/bash
+  k8s:
+    state: absent
+    kind: Namespace
+    name: "{{ app_ns }}"
 
 - name: Check if the PV is deleted.
-  shell: kubectl get pv {{ pv_name.stdout }}
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: PersistentVolume
+    name: "pv_name.resources.0.spec.volumName" 
   register: pv_result
-  failed_when: "pv_name.stdout in pv_result.stdout"
+  failed_when: "pv_result.resources | length > 1"

--- a/utils/k8s/deprovision_deployment.yml
+++ b/utils/k8s/deprovision_deployment.yml
@@ -37,14 +37,18 @@
         name: "{{ pvc_name.resources.0.spec.volumes.0.persistentVolumeClaim.claimName }}"
         namespace: "{{ app_ns }}"
       register: pv_name
+
     - debug:
         msg: "{{ item.spec.volumeName  }}"
       with_items: "{{ pv_name.resources }}"
 
+    - set_fact:
+        pvname: "{{ pv_name.resources.0.spec.volumeName }}"
+
     - name: Check for presence & value of cas type annotation
       k8s_facts:
         kind: PersistentVolume
-        name: "{{ pv_name.resources.0.spec.volumeName }}"
+        name: "{{ pvname}}"
       register: openebs_stg_engine
 
     - debug: 
@@ -54,7 +58,8 @@
 
     - name: Record the storage engine name
       set_fact:
-        stg_engine: "{{ openebs_stg_engine.resources.0.metadata.annotations['openebs.io/cas-type'] }}"
+        stg_engine: "{{ item.metadata.annotations['openebs.io/cas-type'] }}"
+      with_items: "{{  openebs_stg_engine.resources }}"
     
     ## Replacing the item names in the respective deployer spec file.
     - name: Replace the PVC name in application deployer spec.
@@ -94,6 +99,8 @@
       k8s_facts:
         kind: PersistentVolumeClaim
         namespace: "{{ app_ns }}"
+        label_selectors:
+          - "{{ app_label }}"
       register: resource_list
       until: resource_list.resources | length < 1
       delay: 5
@@ -134,7 +141,7 @@
                 kind: Pod
                 label_selectors:
                   - "openebs.io/target=cstor-target"
-                  - "pv_name.resources.0.spec.volumName"
+                  - "{{ pvname }}"
                 namespace: "{{ operator_ns }}"        
               register: target_status
               until: " target_status.resources | length < 1"
@@ -146,7 +153,7 @@
                 kind: CStorVolumeReplica
                 namespace: "{{ operator_ns }}"
                 label_selectors:
-                  - "pv_name.resources.0.spec.volumName"
+                  - "{{ pvname }}"
               register: cvr_status
               until: " cvr_status.resources | length < 1 "
               delay: 5
@@ -165,6 +172,9 @@
 - name: Check if the PV is deleted.
   k8s_facts:
     kind: PersistentVolume
-    name: "pv_name.resources.0.spec.volumName" 
+    name: "{{ pvname }}"
+    label_selectors:
+      - "{{ app_label }}"
   register: pv_result
   failed_when: "pv_result.resources | length > 1"
+  

--- a/utils/k8s/fetch_app_pod.yml
+++ b/utils/k8s/fetch_app_pod.yml
@@ -1,6 +1,12 @@
 ---
 #Fetching the details of the application pod
 - name: Getting the {{ application_name }} POD name
-  shell: kubectl get po -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ app_ns }}" 
+    label_selectors:
+      - "{{ app_label }}"
   register: pod_name
-
+- debug:
+    msg: "{{ item.metadata.name }}"
+  with_items: "{{ pod_name.resources }}"

--- a/utils/k8s/pre_create_app_deploy.yml
+++ b/utils/k8s/pre_create_app_deploy.yml
@@ -1,9 +1,9 @@
 ---
 - block:
     - name: Check whether the provider storageclass is applied
-      shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
-      args:
-        executable: /bin/bash
+      k8s_facts:
+        kind: StorageClass
+        name: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
       register: result
 
     - name: Replace the pvc placeholder with provider

--- a/utils/k8s/status_app_pod.yml
+++ b/utils/k8s/status_app_pod.yml
@@ -16,4 +16,3 @@
   until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
   delay: '{{ delay }}'
   retries: '{{ retries }}'
-

--- a/utils/k8s/status_testns.yml
+++ b/utils/k8s/status_testns.yml
@@ -1,10 +1,10 @@
 ---
 - name: Checking the status  of test specific namespace.
-  shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: Namespace
+    name: "{{ app_ns }}"
   register: npstatus
-  until: "'Active' in npstatus.stdout"
+  until: "'Active' in npstatus.resources.0.status.phase"
   delay: 30
   retries: 10
 

--- a/utils/scm/applications/mysql/check_db_connection.yml
+++ b/utils/scm/applications/mysql/check_db_connection.yml
@@ -1,6 +1,6 @@
-##Check if the database is ready for connection, upper bound wait time: 900s 
+#Check if the database is ready for connection, upper bound wait time: 900s 
 - name: Check if db is ready for connections
-  shell: kubectl logs {{ pod_name.stdout }} -n {{ app_ns }} | grep 'ready for connections' | wc -l
+  shell: kubectl logs {{ pod_name.resources.0.metadata.name }} -n {{ app_ns }} | grep 'ready for connections' | wc -l
   register: initcheck
   until: initcheck.stdout == "2"
   delay: 5

--- a/utils/scm/openebs/check_replica_count.yml
+++ b/utils/scm/openebs/check_replica_count.yml
@@ -1,19 +1,33 @@
 ---
 - block:
    - name: Obtain the number of replicas.
-     shell: kubectl get statefulset -n {{ app_ns }} --no-headers -l "{{app_label}}" -o custom-columns=:spec.replicas
-     args:
-       executable: /bin/bash
+     k8s_facts:
+       kind: StatefulSet
+       namespace: "{{ app_ns }}"
+       label_selectors:
+         - "{{ app_label }}"
      register: rep_count
-     until: "rep_count.rc == 0"
+     until: "rep_count is succeeded "
      delay: 60
      retries: 15
 
+   - debug:
+       msg: "{{ item.spec.replicas }}"
+     with_items: "{{ rep_count.resources }}"
+    
+
    - name: Obtain the ready replica count and compare with the replica count.
-     shell: kubectl get statefulset -n {{ app_ns }} -l "{{app_label}}" --no-headers -o custom-columns=:..readyReplicas
-     args:
-       executable: /bin/bash
+     k8s_facts: 
+       kind: StatefulSet 
+       namespace: "{{ app_ns }}"
+       label_selectors:
+         - "{{ app_label }}"
      register: ready_rep
-     until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+
+   - debug:
+       msg: "{{ item.status.currentReplicas }}"
+     with_items: "{{ ready_rep.resources }}"
+
+     until: "ready_rep is succeeded and ready_rep.resources.0.status.updatedReplicas |int == rep_count.resources.0.spec.replicas |int"
      delay: 60
      retries: 30

--- a/utils/scm/openebs/check_replica_count.yml
+++ b/utils/scm/openebs/check_replica_count.yml
@@ -23,10 +23,6 @@
        label_selectors:
          - "{{ app_label }}"
      register: ready_rep
-
-   - debug:
-       msg: "{{ item.status.currentReplicas }}"
-     with_items: "{{ ready_rep.resources }}"
-     until: "ready_rep is succeeded and ready_rep.resources.0.status.updatedReplicas |int == rep_count.resources.0.spec.replicas |int"
+     until: "ready_rep is succeeded and ready_rep.resources.0.status.readyReplicas |int == rep_count.resources.0.spec.replicas |int"
      delay: 60
      retries: 30

--- a/utils/scm/openebs/check_replica_count.yml
+++ b/utils/scm/openebs/check_replica_count.yml
@@ -15,7 +15,9 @@
        msg: "{{ item.spec.replicas }}"
      with_items: "{{ rep_count.resources }}"
     
-
+   - pause:
+       seconds: 30
+   
    - name: Obtain the ready replica count and compare with the replica count.
      k8s_facts: 
        kind: StatefulSet 

--- a/utils/scm/openebs/check_replica_count.yml
+++ b/utils/scm/openebs/check_replica_count.yml
@@ -27,7 +27,6 @@
    - debug:
        msg: "{{ item.status.currentReplicas }}"
      with_items: "{{ ready_rep.resources }}"
-
      until: "ready_rep is succeeded and ready_rep.resources.0.status.updatedReplicas |int == rep_count.resources.0.spec.replicas |int"
      delay: 60
      retries: 30

--- a/utils/scm/openebs/target_affinity_check.yml
+++ b/utils/scm/openebs/target_affinity_check.yml
@@ -1,32 +1,41 @@
 - name: Obtain node where app pod resides
-  shell: >
-    kubectl get pods -l {{ app_label }} -n {{ app_ns }}
-    --no-headers -o custom-columns=:spec.nodeName
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: Pod
+    label_selectors:
+      - "{{ app_label }}"
+    namespace: "{{ app_ns }}"
   register: app_node
 
+- debug:
+    msg: "{{ item.spec.nodeName }}"
+  with_items: "{{ app_node.resources }}"
+
+
 - name: Derive PV from application PVC
-  shell: >
-    kubectl get pvc {{ app_pvc }}
-    -o custom-columns=:spec.volumeName -n {{ app_ns }}
-    --no-headers
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: PersistentVolumeClaim 
+    name: "{{ app_pvc }}"
+    namespace: "{{ app_ns }}"
   register: pv
 
+- debug:
+    msg: "{{ item.spec.volumeName }}"
+  with_items: "{{ pv.resources }}"
+
 - name: Derive storage engine from PV
-  shell: >
-    kubectl get pv {{ pv.stdout }} --no-headers
-    -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: PersistentVolume
+    name: "{{ pv.resources.0.spec.volumeName }}"
   register: stg_engine
+
+- debug:
+    msg: "{{ item.metadata.annotations['openebs.io/cas-type']}}"
+  with_items: "{{ stg_engine.resources }}"
 
 - set_fact: 
     target_ns: "{{ app_ns }}"
     target_label: "openebs.io/controller=jiva-controller"
-  when: stg_engine.stdout == 'jiva'
+  when: stg_engine.resources.0.metadata.annotations['openebs.io/cas-type'] == 'jiva'
 
 
 ## TODO: Account for the case where cstor target can reside in app_ns
@@ -35,19 +44,18 @@
 - set_fact:
     target_ns: "{{ operator_ns }}"
     target_label: "openebs.io/target=cstor-target"
-  when: stg_engine.stdout == 'cstor' and target_in_app_ns is undefined
+  when: stg_engine.resources.0.metadata.annotations['openebs.io/cas-type'] == 'cstor' and target_in_app_ns is undefined
 
 - name: Obtain the node where PV target pod resides
-  shell: >
-    kubectl get pod -n {{ target_ns }} 
-    -l {{ target_label }}
-    -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].spec.nodeName}' 
-  args:
-    executable: /bin/bash
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ target_ns }}"
+    label_selectors:
+      - "{{ target_label }}"
+      - "openebs.io/persistent-volume={{ pv.resources.0.spec.volumeName }}"
   register: target_node
 
 - name: Verify whether the app & target pod co-exist on same node
   debug: 
     msg: "App and Target affinity is maintained"
-  failed_when: target_node.stdout != app_node.stdout
-  
+  failed_when: target_node.resources.0.spec.nodeName != app_node.resources.0.spec.nodeName


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

CHANGES:
Changed the kubectl command used in `shell` module to `k8s,k8s_facts` module in the following utils.
/utils/fcm/update_litmus_result_resource.yml
/utils/k8s/pre_create_app_deploy.yml
/utils/k8s/create_ns.yml
/utils/k8s/deploy_single_app.yml
/utils/scm/openebs/check_replica_count.yml
/utils/k8s/fetch_app_pod.yml
/utils/scm/applications/mysql/check_db_connection.yml
/utils/scm/openebs/target_affinity_check.yml
/utils/k8s/deprovision_deployment.yml
/utils/k8s/status_testns.yml

TESTS:
After changing, following test were performed:

i.) In Percona  - `Provision [deployment]`
ii.) In Percona  - `Deprovision [deployment]`
iii.) In Busybox  - `Provision [statefulset]`
iv.) In Busybox - `Deprovision [statefulset]`
[Test_logs.txt](https://github.com/litmuschaos/litmus/files/3616290/Test_logs.txt)



The logs of all the 4 tests has been uploaded please review in case you need it .



TO DO:
1. In util - k8s/deprovision_deployment.yml 
Task name - Delete the application deployment
 is left in shell module as by using k8s module the pvc get struct in terminating state 

2. The util  status_app_pod.yml is left in shell module because of this issue - https://github.com/litmuschaos/litmus/issues/734

 




