### PR TITLE
refactor[yaml]: Updated pool_failure and pool_network litmusbook to check data consistency

### DIFF
--- a/experiments/chaos/openebs_pool_failure/README.md
+++ b/experiments/chaos/openebs_pool_failure/README.md
@@ -72,4 +72,4 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery (enabled, disabled) |

--- a/experiments/chaos/openebs_pool_failure/README.md
+++ b/experiments/chaos/openebs_pool_failure/README.md
@@ -25,6 +25,30 @@
 
 - `cstor_pool_kill.yml`,`pod_failure_by_sigkill.yaml`
 
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on storage pool. The litmus experiment fails the specified pool and thereby losing the access to volumes being created on it.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
 ## Litmusbook Environment Variables
 
 ### Application
@@ -49,30 +73,3 @@
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
-
-
-### Procedure
-
-This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
-
-After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
-
-Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
-
-    parameters.yml: |
-      blocksize: 4k
-      blockcount: 1024
-      testfile: difiletest
-
-It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
-
-For percona-mysql, the following parameters are to be injected into configmap.
-
-    parameters.yml: |
-      dbuser: root
-      dbpassword: k8sDem0
-      dbname: tdb
-
-The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
-
-

--- a/experiments/chaos/openebs_pool_failure/README.md
+++ b/experiments/chaos/openebs_pool_failure/README.md
@@ -72,5 +72,4 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery |
-|                          for busybox value: "busybox" and for percona value: "mysql" |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery. To check against busybox set value: "busybox" and for percona, set value: "mysql"|

--- a/experiments/chaos/openebs_pool_failure/README.md
+++ b/experiments/chaos/openebs_pool_failure/README.md
@@ -72,4 +72,5 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery |
+|                          for busybox value: "busybox" and for percona value: "mysql" |

--- a/experiments/chaos/openebs_pool_failure/README.md
+++ b/experiments/chaos/openebs_pool_failure/README.md
@@ -50,3 +50,29 @@
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
 
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
+

--- a/experiments/chaos/openebs_pool_failure/data_persistence.j2
+++ b/experiments/chaos/openebs_pool_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_pool_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_pool_failure/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pool-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -47,8 +56,8 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
-          - name: DATA_PERSISTENCY
-            value: "enable"  
+          - name: DATA_PERSISTENCE
+            value: ""  
 
           - name: CHAOS_TYPE
             value: "pool-kill"
@@ -58,3 +67,11 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_pool_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: pool-failure   

--- a/experiments/chaos/openebs_pool_failure/test.yml
+++ b/experiments/chaos/openebs_pool_failure/test.yml
@@ -4,38 +4,23 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
 
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name 
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
 
-        - name: Generate unique string for use in dbname
-          shell: echo $(mktemp) | cut -d '.' -f 2
-          args:
-            executable: /bin/bash
-          register: uniqstr
-
-        - name: Create some test data in the mysql database
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
-          vars:
-            status: 'LOAD'
-            ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: "tdb{{ uniqstr.stdout }}"
-          when: data_persistance != '' 
+        - include_vars:
+            file: data_persistence.yml
 
         - name: Record the chaos util path
           set_fact:
@@ -46,6 +31,11 @@
           set_fact:
             chaos_util_path: "/chaoslib/openebs/cstor_pool_delete.yml"
           when: chaos_type == "pool-delete"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
@@ -75,6 +65,22 @@
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: 5
             retries: 60
+        
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name 
+
+        - name: Create some test data 
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''  
 
         ## STORAGE FAULT INJECTION 
 
@@ -95,29 +101,30 @@
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: 5
             retries: 60
-
-
-        - name: Verify mysql data persistence  
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+ 
+        - name: Verify application data persistence  
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: "tdb{{ uniqstr.stdout }}"
-          when: data_persistance != '' 
+          when: data_persistence != '' 
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: new_app_pod  
 
         - name: Verify successful database delete
-          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+          include: "{{ data_consistency_util_path }}"
           vars:
             status: 'DELETE'
             ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
-            dbuser: 'root'
-            dbpassword: 'k8sDem0'
-            dbname: "tdb{{ uniqstr.stdout }}"
-          when: data_persistance != '' 
+            pod_name: "{{ new_app_pod.stdout }}"
+          when: data_persistence != '' 
 
           # Check application liveness post chaos
         - include_tasks: /utils/k8s/application_liveness_check.yml
@@ -135,3 +142,4 @@
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:
             status: 'EOT'
+            chaostype: "{{ test_name }}"

--- a/experiments/chaos/openebs_pool_failure/test_vars.yml
+++ b/experiments/chaos/openebs_pool_failure/test_vars.yml
@@ -3,7 +3,7 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
-data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 operator_ns: openebs
 chaos_type: "{{ lookup('env','CHAOS_TYPE') }}" 

--- a/experiments/chaos/openebs_pool_network/README.md
+++ b/experiments/chaos/openebs_pool_network/README.md
@@ -73,4 +73,4 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery (enabled, disabled) |

--- a/experiments/chaos/openebs_pool_network/README.md
+++ b/experiments/chaos/openebs_pool_network/README.md
@@ -73,5 +73,4 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery |
-|                          for busybox value: "busybox" and for percona value: "mysql" |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery. To check against busybox set value: "busybox" and for percona, set value: "mysql"|

--- a/experiments/chaos/openebs_pool_network/README.md
+++ b/experiments/chaos/openebs_pool_network/README.md
@@ -73,4 +73,5 @@ The configmap data will be utilised by litmus experiments as its variables while
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery |
+|                          for busybox value: "busybox" and for percona value: "mysql" |

--- a/experiments/chaos/openebs_pool_network/README.md
+++ b/experiments/chaos/openebs_pool_network/README.md
@@ -51,3 +51,28 @@
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
 
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+

--- a/experiments/chaos/openebs_pool_network/README.md
+++ b/experiments/chaos/openebs_pool_network/README.md
@@ -25,6 +25,30 @@
 
 - `cstor_pool_network.yml`
 
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on storage pool network. The litmus experiment fails the specified pool due to injected network delay and thereby losing the access to volumes being created on it.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
 ## Litmusbook Environment Variables
 
 ### Application
@@ -50,29 +74,3 @@
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
-
-
-### Procedure
-
-This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
-
-After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
-
-Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
-
-    parameters.yml: |
-      blocksize: 4k
-      blockcount: 1024
-      testfile: difiletest
-
-It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
-
-For percona-mysql, the following parameters are to be injected into configmap.
-
-    parameters.yml: |
-      dbuser: root
-      dbpassword: k8sDem0
-      dbname: tdb
-
-The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
-

--- a/experiments/chaos/openebs_pool_network/data_persistence.j2
+++ b/experiments/chaos/openebs_pool_network/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/openebs_pool_network/run_litmus_test.yml
+++ b/experiments/chaos/openebs_pool_network/run_litmus_test.yml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pool-network
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -48,5 +57,16 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
+          - name: DATA_PERSISTENCE
+            value: ""
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_pool_network/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: pool-network  

--- a/experiments/chaos/openebs_pool_network/test.yml
+++ b/experiments/chaos/openebs_pool_network/test.yml
@@ -4,13 +4,28 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
 
           ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
+
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+       
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
 
         ## RECORD START OF THE TEST IN LITMUS RESULT CR
         - include_tasks: /utils/fcm/create_testname.yml 
@@ -41,7 +56,23 @@
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: '2'
             retries: '60'
-  
+
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name 
+
+        - name: Create some test data 
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''  
+        
         ## STORAGE FAULT INJECTION 
 
         - include: "/chaoslib/openebs/cstor_pool_network.yml"
@@ -52,7 +83,6 @@
             chaos_duration: "{{ lookup('env','CHAOS_DURATION') }}"
             pvc_name: "{{ pvc }}"
           
-
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
@@ -63,12 +93,17 @@
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: '2'
             retries: '60'
-          
-         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+          
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
-
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_pool_network/test_vars.yml
+++ b/experiments/chaos/openebs_pool_network/test_vars.yml
@@ -7,3 +7,4 @@ pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 operator_ns: openebs
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -104,7 +104,7 @@
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
-            pod_name: "{{ new_pod_name.stdout }}"
+            pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
         - set_fact:


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

##
1. Added data consistency check in openebs_pool_failure litmusbook.
2. Added data consistency check in openebs_pool_network litmusbook.
3. Resolved typo in target_network_loss litmusbook.
    -  new_pod_name variable changed to app_pod_name.

##

1. [openebs pool failure logs against busybox.txt](https://github.com/litmuschaos/litmus/files/3629653/openebs.pool.failure.logs.against.busybox.txt)
2. [openebs_pool_failure logs against percona.txt](https://github.com/litmuschaos/litmus/files/3629656/openebs_pool_failure.logs.against.percona.txt)
3. [openebs_pool_network logs against busybox.txt](https://github.com/litmuschaos/litmus/files/3629657/openebs_pool_network.logs.against.busybox.txt)
4. [openebs_pool_network logs against percona.txt](https://github.com/litmuschaos/litmus/files/3629658/openebs_pool_network.logs.against.percona.txt)



