### PR TITLE
refactor[yaml]: Added openebs-jiva-xfs storage class with xfs file system

### DIFF
--- a/providers/cstor-storage-policies/jiva-xfs-sc.j2
+++ b/providers/cstor-storage-policies/jiva-xfs-sc.j2
@@ -2,9 +2,9 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: openebs-cstor-xfs
+  name: openebs-jiva-xfs
   annotations:
-    openebs.io/cas-type: cstor
+    openebs.io/cas-type: jiva
     cas.openebs.io/config: |
       - name: StoragePoolClaim
         value: "{{ pool_name }}"

--- a/providers/cstor-storage-policies/test.yml
+++ b/providers/cstor-storage-policies/test.yml
@@ -22,6 +22,7 @@
             dest: "{{ item.dest }}"
           with_items:
              - { src: cstor-xfs-sc.j2,dest: cstor-xfs-sc.yml }
+             - { src: jiva-xfs-sc.j2,dest: jiva-xfs-sc.yml }
              - { src: cstor-volume-monitor-sc.j2,dest: cstor-volume-monitor-sc.yml }
              - { src: cstor-disk-standalone.j2,dest: cstor-disk-standalone.yml }
              - { src: local-pv-hostpath.j2,dest: local-pv-hostpath.yml }
@@ -47,6 +48,7 @@
               retries: 5
               with_items:
                 - openebs-cstor-xfs
+                - openebs-jiva-xfs
                 - openebs-cstor-volume-monitor
                 - cstor-disk-standalone
                 - openebs-jiva-standalone
@@ -76,6 +78,7 @@
               retries: 5
               with_items:
                 - openebs-cstor-xfs
+                - openebs-jiva-xfs
                 - openebs-cstor-volume-monitor
                 - local-pv-hostpath
                 - cstor-disk-standalone

--- a/providers/cstor-storage-policies/test_vars.yml
+++ b/providers/cstor-storage-policies/test_vars.yml
@@ -7,6 +7,7 @@ lu_workers: "{{ lookup('env','LU_WORKER') }}"
 zvol_workers: "{{ lookup('env','ZVOL_WORKER') }}"
 storage_policies:
   - cstor-xfs-sc.yml
+  - jiva-xfs-sc.yml
   - cstor-volume-monitor-sc.yml
   - cstor-disk-standalone.yml
   - jiva-standalone.yml


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

**What this PR does**:
1. added openebs-jiva-xfs storage class with xfs file system

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
