### PR TITLE
[Refactor] pod_failure_by_litmus to use ansible k8s module

### DIFF
--- a/build/ansible-runner/Dockerfile
+++ b/build/ansible-runner/Dockerfile
@@ -9,8 +9,8 @@ RUN rm -rf /var/lib/apt/lists/* && \
     apt-get install -y python-minimal python-pip netcat iproute2 jq sshpass \
     curl openssh-client
 
-#Installing ansible
-RUN pip install ansible==2.7.3
+#Installing ansible and dependencies for k8s module
+RUN pip install ansible==2.7.3 openshift jmespath
 
 RUN touch /mnt/parameters.yml
 

--- a/chaoslib/litmus/kill_random_pod.yml
+++ b/chaoslib/litmus/kill_random_pod.yml
@@ -29,9 +29,6 @@
   register: result
   when: "c_force == 'false' or c_force == ''" 
 
-- debug:
-    var: result
-
 - name: Wait for the interval timer
   pause:
     seconds: "{{c_interval}}"

--- a/chaoslib/litmus/kill_random_pod.yml
+++ b/chaoslib/litmus/kill_random_pod.yml
@@ -1,0 +1,37 @@
+- name: Get a list of all pods from given namespace
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ a_ns }}"
+    label_selectors:
+      - "{{a_label}}"
+  register: pod_list
+
+- name: Select a random pod to kill
+  set_fact:
+    a_pod_to_kill: "{{ pod_list.resources | random | json_query('metadata.name') }}"
+
+- debug:
+    msg: "Killing pod {{a_pod_to_kill}}"
+
+- name: Force Kill application pod
+  shell: |
+    kubectl delete pod -n {{ a_ns }} --force --grace-period=0 --wait=false {{a_pod_to_kill}}
+  args:
+    executable: /bin/bash
+  register: result
+  when: "c_force == 'true'"
+
+- name: Kill application pod
+  shell: |
+    kubectl delete pod -n {{ a_ns }} --grace-period=0 --wait=false {{a_pod_to_kill}}
+  args:
+    executable: /bin/bash
+  register: result
+  when: "c_force == 'false' or c_force == ''" 
+
+- debug:
+    var: result
+
+- name: Wait for the interval timer
+  pause:
+    seconds: "{{c_interval}}"

--- a/chaoslib/litmus/pod_failure_by_litmus.yml
+++ b/chaoslib/litmus/pod_failure_by_litmus.yml
@@ -7,22 +7,7 @@
     chaos_iterations: 1
   when: "chaos_iterations == '0'" 
 
-- name: Kill application pods randomly for the specified duration
-  shell: |
-    kubectl get pods -l {{ a_label }} -n {{ a_ns }} --no-headers -o custom-columns=:metadata.name | shuf -n 1 | xargs kubectl delete pod -n {{ a_ns }} --force --grace-period=0 --wait=false
-    sleep {{ c_interval }}
-  args:
-    executable: /bin/bash
-  register: result
+- name: Kill random pod
+  include: kill_random_pod.yml
   with_sequence: start=1 end={{ chaos_iterations }}
-  when: "c_force == 'true'"
-
-- name: Kill application pods randomly for the specified duration
-  shell: |
-    kubectl get pods -l {{ a_label }} -n {{ a_ns }} --no-headers -o custom-columns=:metadata.name | shuf -n 1 | xargs kubectl delete pod -n {{ a_ns }}
-    sleep {{ c_interval }}
-  args:
-    executable: /bin/bash
-  register: result
-  with_sequence: start=1 end={{ chaos_iterations }}
-  when: "c_force == 'false' or c_force == ''" 
+  


### PR DESCRIPTION
Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Many of of the ansible modules are using shell commands using kubectl to access kubernetes resources. This PR would be contributing towards #808 and #703 in converting them to k8s and k8s_facts module provided by ansible

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [x] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
Could not change the kill_pod task to k8s module, as the module doesn't support --grace-period parameter. Also I have moved the pod kill logic to separate file as ansible doesn't support looping over blocks.
Tested locally in minikube by invoking the following playbook with various parameters

```yaml
- hosts: localhost
  connection: local
  gather_facts: no

  vars:
    c_experiment: "pod-delete"
    c_duration: "15"
    c_interval: "5"
    c_force: "false"
    a_ns: "default"
    a_label: "run=myserver"
  
  tasks:
    - include_tasks: "./pod_failure_by_litmus.yml"
      vars:
        c_svc_acc: "litmus"
```