### PR TITLE
(feat)experiment: add generic network chaos experiments on k8s pods

### DIFF
--- a/chaoslib/pumba/network_chaos/induce_latency.yml
+++ b/chaoslib/pumba/network_chaos/induce_latency.yml
@@ -1,0 +1,7 @@
+- name: Inject egress delay of {{n_latency}}ms on app pod for {{ c_duration }}ms 
+  shell: > 
+    kubectl exec {{ pumba_pod.stdout }} -n {{ a_ns }} 
+    -- pumba netem --interface {{ n_interface }} --duration {{ c_duration }}ms delay
+    --time {{ n_latency }} re2:k8s_{{ c_container }}_{{ app_pod.stdout }}
+  args:
+    executable: /bin/bash

--- a/chaoslib/pumba/network_chaos/induce_packet_loss.yml
+++ b/chaoslib/pumba/network_chaos/induce_packet_loss.yml
@@ -1,0 +1,7 @@
+- name: Inject {{n_packet_loss}}% packet loss on app pod for {{ c_duration }}ms 
+  shell: > 
+    kubectl exec {{ pumba_pod.stdout }} -n {{ a_ns }} 
+    -- pumba netem --interface {{ n_interface }} --duration {{ c_duration }}ms  
+    loss --percent {{ n_packet_loss }} re2:k8s_{{ c_container }}_{{ app_pod.stdout }}
+  args:
+    executable: /bin/bash

--- a/chaoslib/pumba/network_chaos/network_chaos.yml
+++ b/chaoslib/pumba/network_chaos/network_chaos.yml
@@ -1,0 +1,92 @@
+---
+- block: 
+    - name: Setup pumba chaos infrastructure
+      shell: >
+        kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n {{ a_ns }}
+      args: 
+        executable: /bin/bash
+      register: pumb_deploy_result
+
+    - name: Confirm that the pumba ds is running on all nodes
+      shell: >
+        kubectl get pod -l app=pumba
+        --no-headers -o custom-columns=:status.phase
+        -n {{ a_ns }} | sort | uniq
+      args:
+        executable: /bin/bash
+      register: result
+      until: "result.stdout == 'Running'"
+      delay: 1
+      retries: 60
+      ignore_errors: true
+
+    - name: Select the app pod
+      shell: >
+        kubectl get pod -l {{ a_label }} -n {{ a_ns }}
+        -o=custom-columns=:metadata.name --no-headers
+        | shuf | head -1 
+      args:
+        executable: /bin/bash
+      register: app_pod
+
+    - name: Identify the application node
+      shell: >
+        kubectl get pod {{ app_pod.stdout }} -n {{ a_ns }}
+        --no-headers -o custom-columns=:spec.nodeName
+      args:
+        executable: /bin/bash
+      register: app_node
+
+    - name: Identify the pumba pod that co-exists with app pod
+      shell: >
+        kubectl get pods -l app=pumba -n {{ a_ns }} 
+        -o jsonpath='{.items[?(@.spec.nodeName==''"{{ app_node.stdout }}"'')].metadata.name}'
+      args:
+        executable: /bin/bash
+      register: pumba_pod 
+
+    - include_tasks: /chaoslib/pumba/network_chaos/induce_latency.yml
+      when: "n_latency is defined"
+
+    - include_tasks: /chaoslib/pumba/network_chaos/induce_packet_loss.yml
+      when: "n_packet_loss is defined"
+     
+    - name: Tear down pumba infrastructure
+      shell: >
+        kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ a_ns }} 
+      args:
+        executable: /bin/bash
+
+    - name: Confirm that the pumba ds is deleted successfully
+      shell: >
+        kubectl get pods -l app=pumba --no-headers -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' not in result.stdout"
+      delay: 20
+      retries: 15
+
+  rescue: 
+
+    - block: 
+
+        - name: Tear down pumba infrastructure, if setup
+          shell: >
+            kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ a_ns }} 
+          args:
+            executable: /bin/bash
+        
+        - name: Confirm that the pumba ds is deleted successfully
+          shell: >
+            kubectl get pods -l app=pumba --no-headers -n {{ a_ns }}
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' not in result.stdout"
+          delay: 20
+          retries: 15
+
+      when: "pumb_deploy_result.rc == 0"
+
+

--- a/experiments/generic/pod_network_latency/README.md
+++ b/experiments/generic/pod_network_latency/README.md
@@ -1,0 +1,57 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | K8s Platform |
+| ----- | ------------------------------------------------------------ | ------------ |
+| Chaos | Inject network latency into application pod                  | Any          |
+
+## Entry-Criteria
+
+- Application pods are healthy before chaos injection
+
+## Exit-Criteria
+
+- Application pods are healthy post chaos injection
+
+## Pre-Requisites
+
+- Application subjected to chaos must have `tc` network traffic shaping tool installed
+
+## Notes
+
+- Typically used as a disruptive test, to cause flaky access to application replica by injecting network delay using pumba.
+- The application pod should be healthy once chaos is stopped. Service-requests should be served despite chaos
+
+## Associated Chaos Utils
+
+- [pumba/network_chaos/network_chaos.yml](/chaoslib/pumba/network_chaos/network_chaos.yml) 
+- [pumba/network_chaos/induce_latency.yml](/chaoslib/pumba/network_chaos/induce_latency.yml)
+
+## Litmusbook Environment Variables
+
+### Application
+
+| Parameter     | Description                                                  |TYPE|
+| ------------- | ------------------------------------------------------------ |-----
+| APP_NAMESPACE | Namespace in which application pods are deployed             |Mandatory
+| APP_LABEL     | Unique Labels in `key=value` format of application deployment |Mandatory
+| TARGET_CONTAINER | Name of container which is subjected to network latency   |Mandatory
+| NETWORK_INTERFACE | Name of ethernet interface considered for shaping traffic|Mandatory
+
+### Chaos 
+
+| Parameter      | Description                           |TYPE|
+| -------------- | ------------------------------------- |----
+| NETWORK_LATENCY  | The latency/delay in milliseconds   |Mandatory
+| CHAOS_DURATION | The time duration for chaos insertion |Mandatory
+| LIB            | The chaos tool used to inject the chaos | Mandatory
+| CHAOSENGINE    | ChaosEngine CR name associated with the experiment instance |Optional
+| CHAOS_SERVICE_ACCOUNT | Service account used by the pumba daemonset| Optional
+
+
+
+### Procedure
+
+- Identify the values for the mandatory ENV variables
+- Create the chaos job via `kubectl create -f pod_network_latency_k8s_job.yml` 
+- Check result of the experiment via `kubectl describe chaosresult pod-network-latency` (prefix chaosengine name to experiment name if applicable)
+- View experiment logs  via `kubectl logs -f <chaos-pod-name>` 

--- a/experiments/generic/pod_network_latency/chaosutil.j2
+++ b/experiments/generic/pod_network_latency/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if c_lib is defined and c_lib == 'pumba' %}
+   c_util: /chaoslib/pumba/network_chaos/network_chaos.yml
+{% endif %}

--- a/experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml
+++ b/experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml
@@ -1,0 +1,76 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "pod-network-latency"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_container: "{{ lookup('env','TARGET_CONTAINER') }}"
+    n_latency: "{{ lookup('env','NETWORK_LATENCY') }}"
+    n_interface: "{{ lookup('env','NETWORK_INTERFACE') }}"
+    c_lib: "{{ lookup('env','LIB') }}"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+    a_kind: "{{ lookup('env','APP_KIND') }}"
+
+  tasks:
+    - block:
+
+        ## DETERMINE THE CHAOSLIB TASKFILES TO BE USED
+        - include: pod_network_latency_ansible_prerequisites.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        ## GENERATE EXP RESULT NAME
+        - block: 
+            - name: Construct chaos result name (experiment_name)
+              set_fact: 
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+          when: lookup('env','CHAOSENGINE')
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars: 
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60
+
+        ## FAULT INJECTION 
+        - include_tasks: "{{ c_util }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60        
+
+
+        - set_fact:
+            flag: "pass"
+
+    
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+      
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"  

--- a/experiments/generic/pod_network_latency/pod_network_latency_ansible_prerequisites.yml
+++ b/experiments/generic/pod_network_latency/pod_network_latency_ansible_prerequisites.yml
@@ -1,0 +1,4 @@
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml

--- a/experiments/generic/pod_network_latency/pod_network_latency_k8s_job.yml
+++ b/experiments/generic/pod_network_latency/pod_network_latency_k8s_job.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pod-network-latency- 
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: pod-network-latency
+    spec:
+      # Placeholder that is updated by the executor for automated runs
+      # Provide appropriate SA (with desired permissions) if executed manually
+      serviceAccountName: CHAOS_SERVICE_ACCOUNT
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: litmuschaos/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: default 
+
+          - name: APP_LABEL
+            value: 'app=hello'
+
+          - name: APP_KIND
+            value: deployment
+
+          - name: TARGET_CONTAINER
+            value: "flux-test"
+
+          - name: NETWORK_INTERFACE
+            value: "eth0"
+
+          - name: NETWORK_LATENCY
+            value: "60000" # in ms
+
+          - name: TOTAL_CHAOS_DURATION
+            value: "60000" # in ms
+            
+          - name: LIB
+            value: "pumba"
+
+          - name: CHAOSENGINE
+            value: ""
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0"]
+        

--- a/experiments/generic/pod_network_loss/README.md
+++ b/experiments/generic/pod_network_loss/README.md
@@ -1,0 +1,57 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | K8s Platform |
+| ----- | ------------------------------------------------------------ | -------------|
+| Chaos | Inject packet loss into application pod                      | Any          |
+
+## Entry-Criteria
+
+- Application pods are healthy before chaos injection
+
+## Exit-Criteria
+
+- Application pods are healthy post chaos injection
+
+## Pre-Requisites
+
+- Application subjected to chaos must have `tc` network traffic shaping tool installed
+
+## Notes
+
+- Typically used as a disruptive test, to cause loss of access to application replica by injecting packet loss using pumba.
+- The application pod should be healthy once chaos is stopped. Service-requests should be served (say, via alternate replicas) despite chaos.
+
+## Associated Chaos Utils
+
+- [pumba/network_chaos/network_chaos.yml](/chaoslib/pumba/network_chaos/network_chaos.yml) 
+- [pumba/network_chaos/induce_packet_loss.yml](/chaoslib/pumba/network_chaos/induce_packet_loss.yml)
+
+## Litmusbook Environment Variables
+
+### Application
+
+| Parameter     | Description                                                  |TYPE|
+| ------------- | ------------------------------------------------------------ |-----
+| APP_NAMESPACE | Namespace in which application pods are deployed             |Mandatory
+| APP_LABEL     | Unique Labels in `key=value` format of application deployment |Mandatory
+| TARGET_CONTAINER | Name of container which is subjected to network latency   |Mandatory
+| NETWORK_INTERFACE | Name of ethernet interface considered for shaping traffic|Mandatory
+
+### Chaos 
+
+| Parameter      | Description                           |TYPE|
+| -------------- | ------------------------------------- |----
+| NETWORK_PACKET_LOSS_PERCENTAGE  | The packet loss in percentage   |Mandatory
+| CHAOS_DURATION | The time duration for chaos injection |Mandatory
+| LIB            | The chaos tool used to inject the chaos | Mandatory
+| CHAOSENGINE    | ChaosEngine CR name associated with the experiment instance |Optional
+| CHAOS_SERVICE_ACCOUNT | Service account used by the pumba daemonset| Optional
+
+
+
+### Procedure
+
+- Identify the values for the mandatory ENV variables
+- Create the chaos job via `kubectl create -f pod_network_loss_k8s_job.yml` 
+- Check result of the experiment via `kubectl describe chaosresult pod-network-loss` (prefix chaosengine name to experiment name if applicable)
+- View experiment logs  via `kubectl logs -f <chaos-pod-name>` 

--- a/experiments/generic/pod_network_loss/chaosutil.j2
+++ b/experiments/generic/pod_network_loss/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if c_lib is defined and c_lib == 'pumba' %}
+   c_util: /chaoslib/pumba/network_chaos/network_chaos.yml
+{% endif %}

--- a/experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml
@@ -1,0 +1,76 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "pod-network-loss"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_container: "{{ lookup('env','TARGET_CONTAINER') }}"
+    n_packet_loss: "{{ lookup('env','NETWORK_PACKET_LOSS_PERCENTAGE') }}"
+    n_interface: "{{ lookup('env','NETWORK_INTERFACE') }}"
+    c_lib: "{{ lookup('env','LIB') }}"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+    a_kind: "{{ lookup('env','APP_KIND') }}"
+
+  tasks:
+    - block:
+
+        ## DETERMINE THE CHAOSLIB TASKFILES TO BE USED
+        - include: pod_network_loss_ansible_prerequisites.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        ## GENERATE EXP RESULT NAME
+        - block: 
+            - name: Construct chaos result name (experiment_name)
+              set_fact: 
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+          when: lookup('env','CHAOSENGINE')
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars: 
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60
+
+        ## FAULT INJECTION 
+        - include_tasks: "{{ c_util }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60        
+
+
+        - set_fact:
+            flag: "pass"
+
+    
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+      
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"  

--- a/experiments/generic/pod_network_loss/pod_network_loss_ansible_prerequisites.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_ansible_prerequisites.yml
@@ -1,0 +1,4 @@
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml

--- a/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pod-network-loss- 
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: pod-network-loss
+    spec:
+      # Placeholder that is updated by the executor for automated runs
+      # Provide appropriate SA (with desired permissions) if executed manually
+      serviceAccountName: CHAOS_SERVICE_ACCOUNT
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: litmuschaos/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: default 
+
+          - name: APP_LABEL
+            value: 'app=hello'
+
+          - name: APP_KIND
+            value: deployment
+
+          - name: TARGET_CONTAINER
+            value: "flux-test"
+
+          - name: NETWORK_INTERFACE
+            value: "eth0"
+
+          - name: NETWORK_PACKET_LOSS_PERCENTAGE
+            value: "70" # in ms
+
+          - name: TOTAL_CHAOS_DURATION
+            value: "60000" # in ms
+            
+          - name: LIB
+            value: "pumba"
+
+          - name: CHAOSENGINE
+            value: ""
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0"]
+        


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Introduces network chaos on Kubernetes pods using Pumba (network latency/delays & percentage-based packet loss)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [x] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

[network-latency.log](https://github.com/litmuschaos/litmus/files/3710846/network-latency.log)
[network-packet-loss.log](https://github.com/litmuschaos/litmus/files/3710847/network-packet-loss.log)

- Further optimizations (to reduce repeated execution of some tasks, such as pumba setup/teardown for example will be placed as separate utils owned by the lib). These will be considered in separate PRs. 