### PR TITLE
update(README): steps to add monitor and executor image added

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -94,8 +94,8 @@
 
 -   To provide a chaos executor (runner) & exporter (monitor) of choice, provide the image names (in the form registry/user/image:tag) in the chaosEngine as shown below. The defaults at this point correspond to the litmuschaos CI images in dockerhub:
     
-  -  Executor: litmuschaos/ansible-runner:ci
-  -  Monitor: litmuschaos/chaos-exporter:ci
+    -  Executor: litmuschaos/ansible-runner:ci
+    -  Monitor: litmuschaos/chaos-exporter:ci
 
 -  Make changes in the ChaosEngine CR manifest,
         

--- a/executor/README.md
+++ b/executor/README.md
@@ -89,6 +89,41 @@
             - name: FORCE
               value: "true"
     ```
+    
+### How to Override Executor and Exporter image
+
+-   To provide a chaos executor (runner) & exporter (monitor) of choice, provide the image names (in the form registry/user/image:tag) in the chaosEngine as shown below. The defaults at this point correspond to the litmuschaos CI images in dockerhub:
+    
+  -  Executor: litmuschaos/ansible-runner:ci
+  -  Monitor: litmuschaos/chaos-exporter:ci
+
+-  Make changes in the ChaosEngine CR manifest,
+        
+    ```
+    apiVersion: litmuschaos.io/v1alpha1
+    kind: ChaosEngine
+    metadata:
+      name: engine-nginx
+      namespace: litmus 
+    spec:
+      jobCleanUpPolicy: ""  
+      appinfo: 
+        appns: litmus
+        # FYI, To see app label, apply kubectl get pods --show-labels
+        applabel: "app=hello-deployment"
+      components:
+        monitor:
+          image: ""     <----------- ADD EXPORTER(MONITOR) IMAGE HERE
+        runner:
+          image: ""      <----------- ADD EXECUTOR(RUNNER) IMAGE HERE
+      chaosServiceAccount: litmus 
+      experiments:
+        - name: pod-delete
+          spec:
+            components:
+            - name: FORCE
+              value: "true"
+    ```
 
 ### Limitations
 

--- a/executor/README.md
+++ b/executor/README.md
@@ -94,10 +94,10 @@
 
 -   To provide a chaos executor (runner) & exporter (monitor) of choice, provide the image names (in the form registry/user/image:tag) in the chaosEngine as shown below. The defaults at this point correspond to the litmuschaos CI images in dockerhub:
     
-    -  Executor: litmuschaos/ansible-runner:ci
-    -  Monitor: litmuschaos/chaos-exporter:ci
+    -   Executor: litmuschaos/ansible-runner:ci
+    -   Monitor: litmuschaos/chaos-exporter:ci
 
--  Make changes in the ChaosEngine CR manifest,
+-   Make changes in the ChaosEngine CR manifest,
         
     ```
     apiVersion: litmuschaos.io/v1alpha1


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

-  update readme - add Steps to get executor and monitor image from the engine spec

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
