### PR TITLE
(feat) kafka: include kafka broker kill experiment

### DIFF
--- a/chaoslib/litmus/kill_random_pod.yml
+++ b/chaoslib/litmus/kill_random_pod.yml
@@ -11,14 +11,14 @@
     set_fact:
       app_pod: "{{ pod_list.resources | random | json_query('metadata.name') }}"
 
-  when: app_pod_name is undefined
+  when: app_pod_name is undefined or app_pod_name == ''
 
 - block:
   - name: Record app pod 
     set_fact:
       app_pod: "{{ app_pod_name }}"
 
-  when: app_pod_name is defined
+  when: app_pod_name is defined and app_pod_name != ''
 
 - debug:
     msg: "Killing pod {{ app_pod }}"

--- a/experiments/kafka/kafka-broker-pod-failure/chaosutil.j2
+++ b/experiments/kafka/kafka-broker-pod-failure/chaosutil.j2
@@ -1,0 +1,7 @@
+{% if c_lib is defined and c_lib == 'chaoskube' %}
+   c_util: /chaoslib/chaoskube/pod_failure_by_chaoskube.yml
+{% elif c_lib is defined and c_lib == 'powerfulseal' %}
+   c_util: /chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
+{% else %}
+   c_util: /chaoslib/litmus/pod_failure_by_litmus.yml
+{% endif %}

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
@@ -1,0 +1,112 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: "kafka-broker-pod-failure"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
+    c_force: "{{ lookup('env','FORCE') }}"
+    c_lib: "{{ lookup('env','LIB') }}"
+    kafka_ns: "{{ lookup('env','KAFKA_NAMESPACE') }}"
+    kafka_label: "{{ lookup('env','KAFKA_LABEL') }}"
+    kafka_kind: "{{ lookup('env','KAFKA_KIND') }}"
+    kafka_broker: "{{ lookup('env','KAFKA_BROKER') }}"
+    kafka_stream: "{{ lookup('env','KAFKA_LIVENESS_STREAM') }}" 
+    kafka_service: "{{ lookup('env','KAFKA_SERVICE') }}"
+    kafka_port: "{{ lookup('env','KAFKA_PORT') }}" 
+    kafka_replication_factor: "{{ lookup('env','KAFKA_REPLICATION_FACTOR') }}" 
+    zk_ns: "{{ lookup('env','ZOOKEEPER_NAMESPACE') }}"
+    zk_label: "{{ lookup('env','ZOOKEEPER_LABEL') }}"
+    zk_service: "{{ lookup('env','ZOOKEEPER_SERVICE') }}"
+    zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}" 
+
+  tasks:
+    - block:
+
+        - include: kafka-broker-pod-failure-ansible-prerequisites.yml 
+      
+        - include_vars:
+            file: chaosutil.yml
+
+        ## GENERATE EXP RESULT NAME
+        - block:
+
+            - name: Construct chaos result name (experiment_name)
+              set_fact:
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+
+          when: lookup('env','CHAOSENGINE')    
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ kafka_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the Kafka cluster is healthy
+          include_tasks: "/utils/apps/kafka/kafka_cluster_health.yml"
+          vars:     
+            delay: 1
+            retries: 60
+
+        ## SETUP KAFKA CHAOS INFRA AND DERIVE BROKERS UNDER TEST
+       
+        - include_tasks: "{{ kafka_broker_util }}" 
+
+        ## FAULT INJECTION 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            app_ns: "{{ kafka_ns }}"
+            app_label: "{{ kafka_label }}"
+
+            # derived from the 'kafka_broker_util' task
+            app_pod_name: "{{ kafka_broker }}" 
+          
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        
+        - name: Verify that the Kafka cluster is healthy
+          include_tasks: "/utils/apps/kafka/kafka_cluster_health.yml"
+          vars:     
+            delay: 1
+            retries: 60
+
+        ## CHECK FOR KAFKA LIVENESS & CLEANUP
+
+        - block: 
+
+            - name: Verify that the Kafka liveness pod (pub-sub) is uninterrupted
+              include_tasks: "/utils/common/status_app_pod.yml"
+              vars: 
+                a_ns: "{{ kafka_ns }}"
+                a_label: "name=kafka-liveness" 
+                delay: 1
+                retries: 60
+
+            - include_tasks: "/utils/apps/kafka/kafka_liveness_cleanup.yml"
+
+          when: kafka_stream is defined and kafka_stream != ''
+
+        - set_fact:
+            flag: "pass"
+
+
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+
+        - name: Cleanup kafka liveness pods if present
+          include_tasks: "/utils/apps/kafka/kafka_liveness_cleanup.yml"
+          ignore_errors: true
+
+      always: 
+ 
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ kafka_ns }}"
+

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-prerequisites.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-prerequisites.yml
@@ -1,0 +1,31 @@
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml
+
+- block: 
+
+    - set_fact: 
+        kafka_broker_util: "/utils/apps/kafka/kafka_liveness_stream.yml"
+      when: kafka_stream is defined and kafka_stream != ''
+
+    - set_fact:
+        kafka_broker_util: "/utils/apps/kafka/display_kafka_broker_info.yml"
+      when: kafka_stream is not defined or kafka_stream == ''
+
+  when: kafka_broker is defined and kafka_broker != '' 
+
+- block:
+
+    - set_fact: 
+        kafka_broker_util: "/utils/apps/kafka/kafka_launch_stream_derive_leader_broker.yml"
+      when: kafka_stream is defined and kafka_stream != ''
+
+    - set_fact: 
+        kafka_broker_util: "/utils/apps/kafka/kafka_select_broker.yml"
+      when: kafka_stream is not defined or kafka_stream == ''
+
+  when: kafka_broker is not defined or kafka_broker == ''  
+
+    
+

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
@@ -1,0 +1,89 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: kafka-broker-pod-failure-
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: kafka-broker-pod-failure
+    spec:
+      # Placeholder that is updated by the executor for automated runs
+      # Provide appropriate SA (with desired permissions) if executed manually
+      serviceAccountName: nginx
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: ksatchit/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'
+
+          # provide application namespace
+          - name: KAFKA_NAMESPACE
+            value: 'default'
+
+          # provide application labels
+          - name: KAFKA_LABEL
+            value: 'app=cp-kafka'
+
+           # provide application kind
+          - name: KAFKA_KIND
+            value: 'statefulset'
+
+          - name: KAFKA_BROKER
+            value: ''
+
+          - name: KAFKA_LIVENESS_STREAM
+            value: 'enabled'
+
+          - name: KAFKA_REPLICATION_FACTOR
+            value: '3'
+
+          - name: KAFKA_SERVICE
+            value: 'kafka-demo-cp-kafka-headless'
+
+          - name: KAFKA_PORT
+            value: '9092'
+
+          - name: ZOOKEEPER_NAMESPACE
+            value: 'default'
+
+          # provide application labels
+          - name: ZOOKEEPER_LABEL
+            value: 'app=cp-zookeeper'
+
+
+          - name: ZOOKEEPER_SERVICE
+            value: 'kafka-demo-cp-zookeeper-headless'
+
+          - name: ZOOKEEPER_PORT
+            value: '2181'
+
+          - name: TOTAL_CHAOS_DURATION
+            value: '15'
+
+          - name: CHAOS_INTERVAL
+            value: '5'
+
+          - name: FORCE
+            value: 'true'
+
+          ## env var that describes the library used to execute the chaos
+          ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+          - name: LIB
+            value: ''
+
+          - name: CHAOSENGINE
+            value: ''
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml -vv -i /etc/ansible/hosts; exit 0"]
+

--- a/utils/apps/kafka/display_kafka_broker_info.yml
+++ b/utils/apps/kafka/display_kafka_broker_info.yml
@@ -1,0 +1,7 @@
+- debug: 
+    msg: "{{ kafka_broker }}"
+  when: kafka_broker != ''
+
+- debug:
+    msg: "kafka broker will be selected randomly across the cluster"
+  when: kafka_broker == ''

--- a/utils/apps/kafka/kafka_cluster_health.yml
+++ b/utils/apps/kafka/kafka_cluster_health.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify that all kafka pods are running
+  include_tasks: "/utils/common/status_app_pod.yml"
+  vars:
+    delay: 1
+    retries: 60
+    a_ns: "{{ kafka_ns }}"
+    a_label: "{{ kafka_label }}"
+
+- name: Verify that all zookeeper pods are running
+  include_tasks: "/utils/common/status_app_pod.yml"
+  vars:
+    delay: 1
+    retries: 60
+    a_ns: "{{ zk_ns }}"
+    a_label: "{{ zk_label }}"

--- a/utils/apps/kafka/kafka_launch_stream_derive_leader_broker.yml
+++ b/utils/apps/kafka/kafka_launch_stream_derive_leader_broker.yml
@@ -1,0 +1,3 @@
+- include_tasks: "/utils/apps/kafka/kafka_liveness_stream.yml"
+- include_tasks: "/utils/apps/kafka/kafka_select_broker.yml"
+- include_tasks: "/utils/apps/kafka/display_kafka_broker_info.yml"

--- a/utils/apps/kafka/kafka_liveness.j2
+++ b/utils/apps/kafka/kafka_liveness.j2
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kafka-liveness
+  labels: 
+    name: kafka-liveness 
+spec:
+  initContainers:
+  - name: kafka-topic-creator
+    image: litmuschaos/kafka-client:ci
+    imagePullPolicy: Always
+    env: 
+      - name: TOPIC_NAME
+        value: {{ kafka_topic }}
+      - name: ZOOKEEPER_SERVICE
+        value: {{ zk_service }}
+      - name: ZOOKEEPER_PORT
+        value: "{{ zk_port }}"
+      - name: REPLICATION_FACTOR
+        value: "{{ kafka_replication_factor  }}"
+    command: 
+      - sh
+      - -c
+      - "./topic.sh"
+  containers:
+  - name: kafka-producer
+    image: litmuschaos/kafka-client:ci
+    imagePullPolicy: Always
+    env:
+      - name: TOPIC_NAME
+        value: {{ kafka_topic }}
+      - name: KAFKA_SERVICE
+        value: {{ kafka_service }} 
+      - name: KAFKA_PORT
+        value: "{{ kafka_port }}"
+    command:
+      - sh
+      - -c
+      - "./producer.sh"
+  - name: kafka-consumer
+    image: litmuschaos/kafka-client:ci
+    imagePullPolicy: Always
+    env:
+      - name: TOPIC_NAME
+        value: {{ kafka_topic }}
+      - name: KAFKA_SERVICE
+        value: {{ kafka_service }}
+      - name: KAFKA_PORT
+        value: "{{ kafka_port }}"
+    command:
+      - sh
+      - -c
+      - "./consumer.sh"

--- a/utils/apps/kafka/kafka_liveness_cleanup.yml
+++ b/utils/apps/kafka/kafka_liveness_cleanup.yml
@@ -1,0 +1,16 @@
+- name: Remove the Kafka liveness pod 
+  shell: 
+    kubectl delete -f kafka_liveness.yml -n {{ kafka_ns }}
+  args:
+    executable: /bin/bash
+  register: result
+    
+- name: Confirm that the Kafka liveness pod is deleted successfully
+  shell:
+    kubectl get pod -l name=kafka-liveness --no-headers -n {{ kafka_ns }}
+  args: 
+    executable: /bin/bash
+  register: result
+  until: "'Running' not in result.stdout"
+  delay: 1
+  retries: 120

--- a/utils/apps/kafka/kafka_liveness_stream.yml
+++ b/utils/apps/kafka/kafka_liveness_stream.yml
@@ -1,0 +1,60 @@
+- name: Generate a random strint as suffix to topic name 
+  shell: echo $(mktemp) | cut -d '.' -f 2
+  args: 
+    executable: /bin/bash
+  register: uniqstr
+
+- name: Set the kafka topic name to a variable
+  set_fact:
+    kafka_topic: "topic-{{ uniqstr.stdout }}"
+
+- name: Generate the kafka liveness spec from template
+  template: 
+    src: /utils/apps/kafka/kafka_liveness.j2
+    dest: kafka_liveness.yml
+
+- name: Apply the pub-sub kafka liveness applicaton
+  shell: 
+    kubectl apply -f kafka_liveness.yml -n {{ kafka_ns }}
+  args:
+    executable: /bin/bash
+  register: result
+  failed_when: "result.rc != 0"
+
+- name: Confirm that the kafka liveness pod is running
+  shell: 
+    kubectl get pod -l name=kafka-liveness --no-headers -n {{ kafka_ns }}
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'Running' in result.stdout"
+  delay: 1
+  retries: 120
+
+- name: Fetch the kafka-liveness pod name
+  shell: 
+    kubectl get pods -n {{ kafka_ns }} -l name=kafka-liveness -o jsonpath='{.items[0].metadata.name}' 
+  register: kafka_liveness_pod
+
+- name: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness
+  shell: > 
+    kubectl exec {{ kafka_liveness_pod.stdout }} -n {{ kafka_ns }} -c kafka-consumer 
+    -- kafka-topics --topic {{ kafka_topic }} --describe --zookeeper {{ zk_service }}:{{ zk_port }}
+    | grep -o 'Leader: [^[:space:]]*' | awk '{print $2}'
+  args:
+    executable: /bin/bash
+  register: ordinality
+  failed_when: "ordinality.rc != 0"
+
+- name: Determine the leader broker pod name
+  shell: 
+    kubectl get pods -l app=cp-kafka --no-headers -o custom-columns=:metadata.name | grep '^.*-{{ ordinality.stdout }}$'
+  args:
+    executable: /bin/bash
+  register: leader_broker
+  failed_when: "result.rc != 0"
+
+- name: Set the kafka broker to be subjected to chaos
+  set_fact: 
+    liveness_topic_leader: "{{ leader_broker.stdout }}"
+

--- a/utils/apps/kafka/kafka_select_broker.yml
+++ b/utils/apps/kafka/kafka_select_broker.yml
@@ -1,0 +1,11 @@
+- name: select leader broker as per the liveness topic (partition) 
+  set_fact: 
+    kafka_broker: "{{ liveness_topic_leader }}"
+  when: kafka_stream is defined and kafka_stream != ''
+
+- name: allow random pod selection by chaosutil 
+  set_fact: 
+    kafka_broker: ''
+  when: kafka_stream is undefined or kafka_stream == ''
+
+


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Introduces a kafka chaos experiment to  kill kafka-broker pod while a message stream is being published/consumed. The experiment aims to test the deployment sanity of the kafka cluster, by checking that the data stream consumption is un-interrupted upon kill of either the leader broker (for a specified topic partition) or its in-sync replicas (ISRs)

- The experiment can be performed in three different modes, where the broker under test (to be killed) is determined in the following ways:

   - Select a specific kafka-broker pod which is known to maintain known data partitions
   - Allow a custom kafka liveness client that simulates the producer/consumer nodes to create a topic with desired replication factor and determine the partition leader
   - Allow random selection of kafka cluster nodes

- The liveness client pod runs individual producer/consumer containers to stream `date -u` outputs continuously. It uses an initContainer to create the topic before the pub-sub is setup.

- The pre & post checks involve : 
   - verification of kafka cluster health (kafka-broker & zookeeper components) 
   - verification of pub-sub clients being unaffected   

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # (in partial fulfilment of #822 )

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [x] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [x] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
