### PR TITLE
(feat): add readme for kafka broker pod failure experiment

### DIFF
--- a/experiments/kafka/kafka-broker-pod-failure/README.md
+++ b/experiments/kafka/kafka-broker-pod-failure/README.md
@@ -1,0 +1,49 @@
+### Sanple ChaosEngine manifest to execute kafka broker kill experiment
+
+    ```
+    apiVersion: litmuschaos.io/v1alpha1
+    kind: ChaosEngine
+    metadata:
+      name: engine-nginx
+      namespace: default
+    spec:
+      appinfo: 
+        appns: default
+        applabel: ''
+        appkind: statefulset
+      chaosServiceAccount: default
+      monitoring: true
+      experiments:
+        - name: kafka-broker-pod-failure
+          spec:
+          components:             <--- ADD ALL ENV VARIABLES HERE - WHICH NEEDS TO BE OVERRIDDEN
+            - name: KAFKA_NAMESPACE
+              value: ''
+
+            - name: KAFKA_LABEL
+              value: ''
+
+            - name: KAFKA_BROKER
+              value: ''
+
+            - name: KAFKA_REPLICATION_FACTOR
+              value: ''
+
+            - name: KAFKA_SERVICE
+              value: ''
+
+            - name: KAFKA_PORT
+              value: ''
+
+            - name: ZOOKEEPER_NAMESPACE
+              value: ''
+
+            - name: ZOOKEEPER_LABEL
+              value: ''
+
+            - name: ZOOKEEPER_SERVICE
+              value: ''
+
+            - name: ZOOKEEPER_PORT
+              value: ''
+    ```

--- a/experiments/kafka/kafka-broker-pod-failure/README.md
+++ b/experiments/kafka/kafka-broker-pod-failure/README.md
@@ -1,49 +1,55 @@
-### Sanple ChaosEngine manifest to execute kafka broker kill experiment
+### Sample ChaosEngine manifest to execute kafka broker kill experiment
 
-    ```
+-   To override experiment defaults, add the ENV variables in `spec.components` of the experiment. 
+
+    ```yml
     apiVersion: litmuschaos.io/v1alpha1
     kind: ChaosEngine
     metadata:
-      name: engine-nginx
+      name: kafka-chaos
       namespace: default
     spec:
       appinfo: 
         appns: default
-        applabel: ''
+        applabel: 'app=cp-kafka'
         appkind: statefulset
-      chaosServiceAccount: default
-      monitoring: true
+      chaosServiceAccount: kafka-sa
+      monitoring: false
       experiments:
         - name: kafka-broker-pod-failure
           spec:
-          components:             <--- ADD ALL ENV VARIABLES HERE - WHICH NEEDS TO BE OVERRIDDEN
-            - name: KAFKA_NAMESPACE
-              value: ''
+            components:  
+              # choose based on available kafka broker replicas           
+              - name: KAFKA_REPLICATION_FACTOR
+                value: '3'
 
-            - name: KAFKA_LABEL
-              value: ''
+              # get via "kubectl get pods --show-labels -n <kafka-namespace>"
+              - name: KAFKA_LABEL
+                value: 'app=cp-kafka'
 
-            - name: KAFKA_BROKER
-              value: ''
+              - name: KAFKA_NAMESPACE
+                value: 'default'
+     
+              # get via "kubectl get svc -n <kafka-namespace>" 
+              - name: KAFKA_SERVICE
+                value: 'kafka-cp-kafka-headless'
 
-            - name: KAFKA_REPLICATION_FACTOR
-              value: ''
+              # get via "kubectl get svc -n <kafka-namespace>  
+              - name: KAFKA_PORT
+                value: '9092'
 
-            - name: KAFKA_SERVICE
-              value: ''
+              - name: ZOOKEEPER_NAMESPACE
+                value: 'default'
 
-            - name: KAFKA_PORT
-              value: ''
+              # get via "kubectl get pods --show-labels -n <zk-namespace>"
+              - name: ZOOKEEPER_LABEL
+                value: 'app=cp-zookeeper'
 
-            - name: ZOOKEEPER_NAMESPACE
-              value: ''
+              # get via "kubectl get svc -n <zk-namespace>  
+              - name: ZOOKEEPER_SERVICE
+                value: 'kafka-cp-zookeeper-headless'
 
-            - name: ZOOKEEPER_LABEL
-              value: ''
-
-            - name: ZOOKEEPER_SERVICE
-              value: ''
-
-            - name: ZOOKEEPER_PORT
-              value: ''
+              # get via "kubectl get svc -n <zk-namespace>  
+              - name: ZOOKEEPER_PORT
+                value: '2181'
     ```


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**What this PR does / why we need it**:

-  Add sample chaosengine manifest for the kafka broker pod failure experiment

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
