### PR TITLE
(refactor)kafka: support liveness checks on kudo kafka cluster

### DIFF
--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
@@ -8,6 +8,7 @@
     c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
     c_force: "{{ lookup('env','FORCE') }}"
     c_lib: "{{ lookup('env','LIB') }}"
+    kafka_instance: "{{ lookup('env','KAFKA_INSTANCE_NAME') }}"
     kafka_ns: "{{ lookup('env','KAFKA_NAMESPACE') }}"
     kafka_label: "{{ lookup('env','KAFKA_LABEL') }}"
     kafka_kind: "{{ lookup('env','KAFKA_KIND') }}"

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
@@ -36,6 +36,9 @@ spec:
           - name: FORCE
             value: 'true'
 
+          - name: KAFKA_INSTANCE_NAME
+            value: ''
+
           - name: KAFKA_NAMESPACE
             value: ''
 

--- a/utils/apps/kafka/kafka_liveness.j2
+++ b/utils/apps/kafka/kafka_liveness.j2
@@ -13,6 +13,8 @@ spec:
     env: 
       - name: TOPIC_NAME
         value: {{ kafka_topic }}
+      - name: KAFKA_INSTANCE_NAME
+        value: {{ kafka_instance }} 
       - name: ZOOKEEPER_SERVICE
         value: {{ zk_service }}
       - name: ZOOKEEPER_PORT


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Existing kafka liveness checks fail on kudo-based kafka clusters due to the difference in zookeeper uri used by the kafka cli scripts.

- kudo: ${ZOOKEEPER_SERVICE}:${ZOOKEEPER_PORT}/${KAFKA_INSTANCE_NAME}
- confluent: ${ZOOKEEPER_SERVICE}:${ZOOKEEPER_PORT} 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
