### PR TITLE
(refactor)kafka-liveness: use correct zookeeper uri for kudo kafka cluster

### DIFF
--- a/utils/apps/kafka/kafka_liveness_stream.yml
+++ b/utils/apps/kafka/kafka_liveness_stream.yml
@@ -36,15 +36,32 @@
     kubectl get pods -n {{ kafka_ns }} -l name=kafka-liveness -o jsonpath='{.items[0].metadata.name}' 
   register: kafka_liveness_pod
 
-- name: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness
-  shell: > 
-    kubectl exec {{ kafka_liveness_pod.stdout }} -n {{ kafka_ns }} -c kafka-consumer 
-    -- kafka-topics --topic {{ kafka_topic }} --describe --zookeeper {{ zk_service }}:{{ zk_port }}
-    | grep -o 'Leader: [^[:space:]]*' | awk '{print $2}'
-  args:
-    executable: /bin/bash
-  register: ordinality
-  failed_when: "ordinality.rc != 0"
+- block: 
+
+    - name: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness
+      shell: > 
+        kubectl exec {{ kafka_liveness_pod.stdout }} -n {{ kafka_ns }} -c kafka-consumer 
+        -- kafka-topics --topic {{ kafka_topic }} --describe --zookeeper {{ zk_service }}:{{ zk_port }}
+        | grep -o 'Leader: [^[:space:]]*' | awk '{print $2}'
+      args:
+        executable: /bin/bash
+      register: ordinality
+      failed_when: "ordinality.rc != 0"
+  when: kafka_instance is not defined or kafka_instance == ''
+
+- block: 
+
+    - name: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness
+      shell: > 
+        kubectl exec {{ kafka_liveness_pod.stdout }} -n {{ kafka_ns }} -c kafka-consumer 
+        -- kafka-topics --topic {{ kafka_topic }} --describe --zookeeper {{ zk_service }}:{{ zk_port }}/{{ kafka_instance }}
+        | grep -o 'Leader: [^[:space:]]*' | awk '{print $2}'
+      args:
+        executable: /bin/bash
+      register: ordinality
+      failed_when: "ordinality.rc != 0"
+  when: kafka_instance is defined and kafka_instance != ''
+
 
 - name: Determine the leader broker pod name
   shell: 


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Fix the zookeeper URI used in the liveness util (determine topic/partition leader) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
