### PR TITLE
(refactor)kafka: add updated liveness checks

### DIFF
--- a/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-ansible-logic.yml
@@ -14,6 +14,7 @@
     kafka_kind: "{{ lookup('env','KAFKA_KIND') }}"
     kafka_broker: "{{ lookup('env','KAFKA_BROKER') }}"
     kafka_stream: "{{ lookup('env','KAFKA_LIVENESS_STREAM') }}" 
+    kafka_consumer_timeout: "{{ lookup('env','KAFKA_CONSUMER_TIMEOUT') }}" 
     kafka_service: "{{ lookup('env','KAFKA_SERVICE') }}"
     kafka_port: "{{ lookup('env','KAFKA_PORT') }}" 
     kafka_replication_factor: "{{ lookup('env','KAFKA_REPLICATION_FACTOR') }}" 

--- a/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-k8s-job.yml
@@ -28,6 +28,10 @@ spec:
           - name: KAFKA_LIVENESS_STREAM
             value: 'enabled'
 
+          # in milliseconds
+          - name: KAFKA_CONSUMER_TIMEOUT
+            value: '30000'
+
           - name: TOTAL_CHAOS_DURATION
             value: '30'
 

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
@@ -14,6 +14,7 @@
     kafka_kind: "{{ lookup('env','KAFKA_KIND') }}"
     kafka_broker: "{{ lookup('env','KAFKA_BROKER') }}"
     kafka_stream: "{{ lookup('env','KAFKA_LIVENESS_STREAM') }}" 
+    kafka_consumer_timeout: "{{ lookup('env','KAFKA_CONSUMER_TIMEOUT') }}" 
     kafka_service: "{{ lookup('env','KAFKA_SERVICE') }}"
     kafka_port: "{{ lookup('env','KAFKA_PORT') }}" 
     kafka_replication_factor: "{{ lookup('env','KAFKA_REPLICATION_FACTOR') }}" 

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-k8s-job.yml
@@ -27,6 +27,10 @@ spec:
           - name: KAFKA_LIVENESS_STREAM
             value: 'enabled'
 
+          # in milliseconds
+          - name: KAFKA_CONSUMER_TIMEOUT
+            value: '30000'
+
           - name: TOTAL_CHAOS_DURATION
             value: '15'
 

--- a/utils/apps/kafka/kafka_liveness.j2
+++ b/utils/apps/kafka/kafka_liveness.j2
@@ -6,6 +6,7 @@ metadata:
   labels: 
     name: kafka-liveness 
 spec:
+  restartPolicy: Never
   initContainers:
   - name: kafka-topic-creator
     image: litmuschaos/kafka-client:ci
@@ -39,11 +40,13 @@ spec:
     command:
       - sh
       - -c
-      - "./producer.sh"
+      - "stdbuf -oL ./producer.sh"
   - name: kafka-consumer
     image: litmuschaos/kafka-client:ci
     imagePullPolicy: Always
     env:
+      - name: KAFKA_CONSUMER_TIMEOUT
+        value: "{{ kafka_consumer_timeout }}"
       - name: TOPIC_NAME
         value: {{ kafka_topic }}
       - name: KAFKA_SERVICE
@@ -53,4 +56,4 @@ spec:
     command:
       - sh
       - -c
-      - "./consumer.sh"
+      - "stdbuf -oL ./consumer.sh"

--- a/utils/common/status_app_pod.yml
+++ b/utils/common/status_app_pod.yml
@@ -8,14 +8,14 @@
 
 - name: Get the container status of application.
   shell: >
-     kubectl get pod -n {{ a_ns }} -l {{ a_label }}
-     -o custom-columns=:..containerStatuses[].state --no-headers | grep -w "running"
+     kubectl get pod -n {{ a_ns }} -l {{ a_label }} --no-headers
+     -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | tr ' ' '\n' | uniq
   args:
     executable: /bin/bash
   register: containerStatus
-  until: "'running' in containerStatus.stdout"
-  delay: 2
-  retries: 150
+  until: "containerStatus.stdout == 'true'"
+  delay: '{{ delay }}'
+  retries: '{{ retries }}'
 
 
 


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds a new ENV for kafka consumer timeouts
- Optimizes app pod status check util

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
