### PR TITLE
(fix)chaos_executor: ensure executor waits for the experiment chaos duration before completion

### DIFF
--- a/executor/executor.yml
+++ b/executor/executor.yml
@@ -154,7 +154,14 @@
 
 - include: experiment_configmap.yml
   when:  configMap_available != '' or  secret_available != ''
-  
+
+- name: Fetching monitoring time from chaos experiment job
+  shell: >
+    kubectl get job {{ job_name }} -n {{c_app_ns}} -ojsonpath="{range .spec.template.spec.containers[*]}{.env[?(@.name=='TOTAL_CHAOS_DURATION')].value}"
+  args:
+    executable: /bin/bash
+  register: chaos_monitoring_time
+
 - name: Monitoring the litmus chaos job for completion
   shell: >
     kubectl get job {{ job_name }} -n {{ c_app_ns}} 
@@ -163,8 +170,8 @@
    executable: /bin/bash
   register: c_job_status
   until: c_job_status.stdout == "Complete"
-  delay: 1
-  retries: 300
+  delay: 10
+  retries: "{{ (chaos_monitoring_time.stdout)|int + 500}}"
 
 - name: Fetching verdict from the chaos result CR
   shell: >


### PR DESCRIPTION
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR ensures that the chaos executor monitors the experiment for the period of  ```TOTAL_CHAOS_DURATION``` (adds some default period of 500s to it) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #953 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
