### PR TITLE
Add pytest suite to verify successful scaffolding of experiment artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+__pycache__/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 ---
 stages:
   - litmusImageBuild
-  - litmusImageTest
+  - litmusPythonTest
+  - litmusAnsibleTest
   - litmusImagePush
 
 Build Litmus Image:
@@ -9,8 +10,13 @@ Build Litmus Image:
   script:
     - sudo docker build . -f build/ansible-runner/Dockerfile -t litmuschaos/ansible-runner:ci
 
+Test Litmus PyTest Suite: 
+  stage: litmusPythonTest
+  script:
+    - ./hack/pytest-suite
+
 Test Litmus Playbook Syntax: 
-  stage: litmusImageTest
+  stage: litmusAnsibleTest
   script:
     - sudo docker run litmuschaos/ansible-runner:ci ./syntax-check 
 

--- a/contribute/developer_guide/templates/package.tmpl
+++ b/contribute/developer_guide/templates/package.tmpl
@@ -1,0 +1,2 @@
+packageName: {{ category }}
+experiments:

--- a/contribute/developer_guide/test/templates/chartserviceversion.expected
+++ b/contribute/developer_guide/test/templates/chartserviceversion.expected
@@ -1,0 +1,22 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: kill-hello-replicas 
+  version: 0.1.0
+  annotations:
+    categories: hello-world
+    repository: https://github.com/litmuschaos/demo-app/tree/master/sample_apps/hellonode
+    support: https://kubernetes.slack.com/messages/CNXNB0ZTN
+spec:
+  displayName: kill-hello-replicas 
+  description: >
+    kills hello-world pods in a random manner 
+  keywords: ['pods', 'kubernetes', 'hello-world', 'nodejs'] 
+  maturity: alpha 
+  minKubeVersion: 1.12.0 
+  maintainers: ['ksatchit@mayadata.io'] 
+  contributors: ['ksatchit@mayadata.io'] 
+  links: ['https://docs.litmuschaos.io/docs/getstarted/'] 
+  icon:
+    - url: 
+      mediatype: ""

--- a/contribute/developer_guide/test/templates/experiment_cr.expected
+++ b/contribute/developer_guide/test/templates/experiment_cr.expected
@@ -1,0 +1,25 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    kills hello-world pods in a random manner
+kind: ChaosExperiment
+metadata:
+  name: kill-hello-replicas
+  version: 0.1.0 
+spec:
+  definition:
+    image: "litmuschaos/ansible-runner:ci"
+    args:
+    - -c
+    - ansible-playbook ./experiments//kill-hello-replicas/kill-hello-replicas-ansible-logic.yml -i /etc/ansible/hosts -vv; exit 0
+    command:
+    - /bin/bash
+    env:
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: default
+    - name: TOTAL_CHAOS_DURATION
+      value: "" 
+    - name: LIB
+      value: ""
+    labels:
+      experiment: kill-hello-replicas 

--- a/contribute/developer_guide/test/templates/experiment_csv.expected
+++ b/contribute/developer_guide/test/templates/experiment_csv.expected
@@ -1,0 +1,22 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: kill-hello-replicas 
+  version: 0.1.0
+  annotations:
+    categories: hello-world
+    repository: https://github.com/litmuschaos/demo-app/tree/master/sample_apps/hellonode
+    support: https://kubernetes.slack.com/messages/CNXNB0ZTN
+spec:
+  displayName: kill-hello-replicas 
+  description: >
+    kills hello-world pods in a random manner 
+  keywords: ['pods', 'kubernetes', 'hello-world', 'nodejs'] 
+  maturity: alpha 
+  minKubeVersion: 1.12.0 
+  maintainers: ['ksatchit@mayadata.io'] 
+  contributors: ['ksatchit@mayadata.io'] 
+  links: ['https://docs.litmuschaos.io/docs/getstarted/'] 
+  icon:
+    - url: 
+      mediatype: ""

--- a/contribute/developer_guide/test/templates/experiment_logic.expected
+++ b/contribute/developer_guide/test/templates/experiment_logic.expected
@@ -1,0 +1,74 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    c_experiment: kill-hello-replicas
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+    a_kind: "{{ lookup('env','APP_KIND') }}"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_util: ""
+
+  tasks:
+    - block:
+
+        - include: kill-hello-replicas-ansible-prerequisites.yml
+      
+        ## GENERATE EXP RESULT NAME
+        - block:
+
+            - name: Construct chaos result name (experiment_name)
+              set_fact:
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
+
+          when: lookup('env','CHAOSENGINE')    
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ a_ns }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60
+
+        ## FAULT INJECTION 
+
+        - include_tasks: "{{ c_util }}"
+          vars:
+            c_svc_acc: "{{ lookup('env','CHAOS_SERVICE_ACCOUNT') }}"
+          
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/common/status_app_pod.yml"
+          vars:
+            app_ns: "{{ a_ns }}" 
+            app_lkey: "{{ a_label.split('=')[0] }}"
+            app_lvalue: "{{ a_label.split('=')[1] }}"       
+            delay: 1
+            retries: 60        
+
+        - set_fact:
+            flag: "pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "fail"
+
+      always: 
+ 
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ a_ns }}"

--- a/contribute/developer_guide/test/templates/package.expected
+++ b/contribute/developer_guide/test/templates/package.expected
@@ -1,0 +1,2 @@
+packageName: hello-world
+experiments:

--- a/contribute/developer_guide/test_generate_chart.py
+++ b/contribute/developer_guide/test_generate_chart.py
@@ -11,7 +11,7 @@ def jinja_template_dir():
 @pytest.fixture
 def config_content():
     c_path = 'attributes.yaml.sample'
-    config = yaml.load(open(c_path))
+    config = yaml.safe_load(open(c_path))
     return config
 
 @pytest.fixture
@@ -48,7 +48,6 @@ def test_generate_package(jinja_template_dir, config_content, expected_file_dir)
     assert result
 
 def test_generate_litmusbook(jinja_template_dir, config_content, expected_file_dir):
-     
     litmusbook_dict = {
             "experiment_cr": ['experiment_custom_resource.tmpl', 'experiment_cr.expected'],
             "experiment_logic": ['experiment_ansible_logic.tmpl', 'experiment_logic.expected']
@@ -57,8 +56,6 @@ def test_generate_litmusbook(jinja_template_dir, config_content, expected_file_d
     for every_value in litmusbook_dict.values():
         artifact_tmpl = jinja_template_dir + every_value[0]
         artifact_actual = expected_file_dir + every_value[1]
-        print(artifact_tmpl)
-        print(artifact_actual)
         text_banner(artifact_tmpl, artifact_actual)
         result = verify_generated_artifact(artifact_tmpl, config_content, artifact_actual)
         assert result

--- a/contribute/developer_guide/test_generate_chart.py
+++ b/contribute/developer_guide/test_generate_chart.py
@@ -1,0 +1,65 @@
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import filecmp
+
+@pytest.fixture
+def jinja_template_dir():
+    j_path = './templates/'
+    return j_path
+
+@pytest.fixture
+def config_content():
+    c_path = 'attributes.yaml.sample'
+    config = yaml.load(open(c_path))
+    return config
+
+@pytest.fixture
+def expected_file_dir():
+    e_path = './test/templates/'
+    return e_path
+
+def text_banner(template_file, expected_file):
+    banner_text = "\n\n### TestInputs ###\n\nTemplate: %s\nExpectedFile: %s\n" %(
+            template_file, expected_file)
+    print(banner_text)
+
+def verify_generated_artifact(template_file, config_file, expected_file):
+    env = Environment(loader = FileSystemLoader('./'), trim_blocks=True, lstrip_blocks=True, autoescape=select_autoescape(['yaml']))
+    tmpl = env.get_template(template_file)
+    output_from_parsed_template = tmpl.render(config_file)
+    with open('test_generated_artifact.yml', "w+") as f:
+        f.write(output_from_parsed_template)
+    comparison_result = filecmp.cmp('test_generated_artifact.yml', expected_file)
+    return comparison_result
+
+def test_generate_csv(jinja_template_dir, config_content, expected_file_dir):
+    artifact_tmpl = jinja_template_dir + 'chartserviceversion.tmpl'
+    artifact_actual = expected_file_dir + 'chartserviceversion.expected'
+    text_banner(artifact_tmpl, artifact_actual)
+    result = verify_generated_artifact(artifact_tmpl, config_content, artifact_actual)
+    assert result
+   
+def test_generate_package(jinja_template_dir, config_content, expected_file_dir):
+    artifact_tmpl = jinja_template_dir + 'package.tmpl'
+    artifact_actual = expected_file_dir + 'package.expected'
+    text_banner(artifact_tmpl, artifact_actual)
+    result = verify_generated_artifact(artifact_tmpl, config_content, artifact_actual)
+    assert result
+
+def test_generate_litmusbook(jinja_template_dir, config_content, expected_file_dir):
+     
+    litmusbook_dict = {
+            "experiment_cr": ['experiment_custom_resource.tmpl', 'experiment_cr.expected'],
+            "experiment_logic": ['experiment_ansible_logic.tmpl', 'experiment_logic.expected']
+    }
+
+    for every_value in litmusbook_dict.values():
+        artifact_tmpl = jinja_template_dir + every_value[0]
+        artifact_actual = expected_file_dir + every_value[1]
+        print(artifact_tmpl)
+        print(artifact_actual)
+        text_banner(artifact_tmpl, artifact_actual)
+        result = verify_generated_artifact(artifact_tmpl, config_content, artifact_actual)
+        assert result
+

--- a/hack/pytest-suite
+++ b/hack/pytest-suite
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pytest contribute/developer_guide/test_generate_chart.py --verbose -s
+rc_counter=$(echo $?)
+
+exit ${rc_counter}


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds a pytest suite to test whether experiment artefacts (csv, package, custom resource, ansible logic yaml) are generated successfully using the `generate_chart.py` script
- A function mimicking the scaffold generation in actual script is created & tests created against it to bring out an initial suite that validates whether the artefacts are generated without errors. 
- The tests will be carried out in a separate gitlab stage (gitlab executor VM has been patched with the dependencies) 

 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

- Path generation has been ignored in the current tests. The suite will be enhanced to use functions from generate_chart.py in subsequent PRs
