### PR TITLE
(fix): update the chaos-result name

### DIFF
--- a/experiments/openebs/openebs-target-container-failure/openebs_target_container_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-container-failure/openebs_target_container_failure_ansible_logic.yml
@@ -6,7 +6,7 @@
     a_label: "{{ lookup('env','APP_LABEL') }}"
     a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
     a_pvc: "{{ lookup('env','APP_PVC') }}"
-    c_experiment: openebs-target-failure
+    c_experiment: openebs-target-container-failure
     c_force: "{{ lookup('env','FORCE') }}"
     c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
     chaos_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"

--- a/experiments/openebs/openebs-target-pod-failure/openebs_target_pod_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-pod-failure/openebs_target_pod_failure_ansible_logic.yml
@@ -6,7 +6,7 @@
     a_label: "{{ lookup('env','APP_LABEL') }}"
     a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
     a_pvc: "{{ lookup('env','APP_PVC') }}"
-    c_experiment: openebs-target-failure
+    c_experiment: openebs-target-pod-failure
     c_force: "{{ lookup('env','FORCE') }}"
     c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
     chaos_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

-   Update the chaos result name in openebs target pod/container failure experiments

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1003 

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
