### PR TITLE
(feat): Add auxiliaryAppInfo Env variable in job

### DIFF
--- a/executor/executor.yml
+++ b/executor/executor.yml
@@ -38,8 +38,8 @@
   register: c_env_length
 
 - set_fact:
-    envNameList: ["APP_NAMESPACE", "APP_LABEL", "APP_KIND", "CHAOSENGINE"]
-    envValueList: ["{{ c_app_ns }}", "{{ c_app_label }}", "{{ c_app_kind }}", "{{ c_engine }}"]
+    envNameList: ["APP_NAMESPACE", "APP_LABEL", "APP_KIND", "CHAOSENGINE","AUXILIARY_APPINFO"]
+    envValueList: ["{{ c_app_ns }}", "{{ c_app_label }}", "{{ c_app_kind }}", "{{ c_engine }}", "{{ c_auxiliary_appinfo }}"]
     c_env_list: ""
     envdict: {}
 
@@ -100,7 +100,7 @@
 
 - name: merging appinfo from chaosengine
   set_fact: 
-    envdict: "{{envdict | combine({\"APP_NAMESPACE\" : c_app_ns},{\"APP_LABEL\" : c_app_label},{\"APP_KIND\" : c_app_kind},{\"CHAOSENGINE\" : c_engine})}}"
+    envdict: "{{envdict | combine({\"APP_NAMESPACE\" : c_app_ns},{\"APP_LABEL\" : c_app_label},{\"APP_KIND\" : c_app_kind},{\"CHAOSENGINE\" : c_engine},{\"AUXILIARY_APPINFO\" : c_auxiliary_appinfo})}}"
 
 - name: Fetching env from dictionary
   set_fact:

--- a/executor/test.yml
+++ b/executor/test.yml
@@ -11,6 +11,7 @@
     c_svc_acc: "{{ lookup('env','CHAOS_SVC_ACC') }}"
     c_rand: "{{ lookup('env','RANDOM') }}"
     c_max: "{{ lookup('env','MAX_DURATION') }}"
+    c_auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
    
   tasks:
     - debug:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

-  Get the auxiliaryAppInfo variable from runner pod Env

-  Add auxiliaryAppInfo variable as a job env so that we can use this for multiple app health check status in infra chaos experiments.

- auxiliaryAppinfo contains namespaces and labels of all the dependent jobs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
