### PR TITLE
(feat) modify ansible stdout log

### DIFF
--- a/build/ansible-runner/Dockerfile
+++ b/build/ansible-runner/Dockerfile
@@ -27,12 +27,15 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LAT
 #Adding hosts entries and making ansible folders
 RUN mkdir /etc/ansible/ /ansible && \
     echo "[local]" >> /etc/ansible/hosts && \
-    echo "127.0.0.1" >> /etc/ansible/hosts
+    echo "127.0.0.1" >> /etc/ansible/hosts && \
+    echo "[defaults]" >> /etc/ansible/ansible.cfg && \
+    echo "display_skipped_hosts = False" >> /etc/ansible/ansible.cfg 
 
 #Copying Necessary Files
 COPY ./chaoslib ./chaoslib/
 COPY ./hack/syntax-check ./hack/*.j2 ./
 COPY ./utils ./utils/
 COPY ./build/plugins /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/
+COPY ./build/utils/display.py /usr/local/lib/python2.7/dist-packages/ansible/utils/display.py
 COPY experiments ./experiments
 COPY executor ./executor

--- a/build/plugins/default.py
+++ b/build/plugins/default.py
@@ -1,0 +1,393 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: default
+    type: stdout
+    short_description: default Ansible screen output
+    version_added: historical
+    description:
+        - This is the default output callback for ansible-playbook.
+    extends_documentation_fragment:
+      - default_callback
+    requirements:
+      - set as stdout in configuration
+'''
+
+from ansible import constants as C
+from ansible.playbook.task_include import TaskInclude
+from ansible.plugins.callback import CallbackBase
+from ansible.utils.color import colorize, hostcolor
+
+
+# These values use ansible.constants for historical reasons, mostly to allow
+# unmodified derivative plugins to work. However, newer options added to the
+# plugin are not also added to ansible.constants, so authors of derivative
+# callback plugins will eventually need to add a reference to the common docs
+# fragment for the 'default' callback plugin
+
+# these are used to provide backwards compat with old plugins that subclass from default
+# but still don't use the new config system and/or fail to document the options
+COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
+                  ('display_ok_hosts', True),
+                  ('show_custom_stats', C.SHOW_CUSTOM_STATS),
+                  ('display_failed_stderr', False),)
+
+
+class CallbackModule(CallbackBase):
+
+    '''
+    This is the default callback interface, which simply prints messages
+    to stdout when new callback events are received.
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'default'
+
+    def __init__(self):
+
+        self._play = None
+        self._last_task_banner = None
+        self._last_task_name = None
+        self._task_type_cache = {}
+        super(CallbackModule, self).__init__()
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        # for backwards compat with plugins subclassing default, fallback to constants
+        for option, constant in COMPAT_OPTIONS:
+            try:
+                value = self.get_option(option)
+            except (AttributeError, KeyError):
+                value = constant
+            setattr(self, option, value)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._clean_results(result._result, result._task.action)
+
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        self._handle_exception(result._result, use_stderr=self.display_failed_stderr)
+        self._handle_warnings(result._result)
+
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+
+        else:
+            if delegated_vars:
+                self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
+                                                                            self._dump_results(result._result)),
+                                      color=C.COLOR_ERROR, stderr=self.display_failed_stderr)
+            else:
+                self._display.display("fatal: [%s]: FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result)),
+                                      color=C.COLOR_ERROR, stderr=self.display_failed_stderr)
+
+        if ignore_errors:
+            self._display.display("...ignoring", color=C.COLOR_SKIP)
+
+    def v2_runner_on_ok(self, result):
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+
+        if isinstance(result._task, TaskInclude):
+            return
+        elif result._result.get('changed', False):
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            if delegated_vars:
+                msg = "changed: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            else:
+                msg = "changed: [%s]" % result._host.get_name()
+            color = C.COLOR_CHANGED
+        else:
+            if not self.display_ok_hosts:
+                return
+
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            if delegated_vars:
+                msg = "ok: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            else:
+                msg = "ok: [%s]" % result._host.get_name()
+            color = C.COLOR_OK
+
+        self._handle_warnings(result._result)
+
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+        else:
+            self._clean_results(result._result, result._task.action)
+
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+                msg += " => %s" % (self._dump_results(result._result),)
+                ## refactored for litmuschaos: print host info for 'OK' tasks only upon verbose enabled
+                self._display.display(msg, color=color)
+
+    def v2_runner_on_skipped(self, result):
+
+        if self.display_skipped_hosts:
+
+            self._clean_results(result._result, result._task.action)
+
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            if result._task.loop and 'results' in result._result:
+                self._process_items(result)
+            else:
+                msg = "skipping: [%s]" % result._host.get_name()
+                if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+                    msg += " => %s" % self._dump_results(result._result)
+                self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_runner_on_unreachable(self, result):
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        if delegated_vars:
+            self._display.display("fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
+                                                                             self._dump_results(result._result)),
+                                  color=C.COLOR_UNREACHABLE)
+        else:
+            self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+
+    def v2_playbook_on_no_hosts_matched(self):
+        self._display.display("skipping: no hosts matched", color=C.COLOR_SKIP)
+
+    def v2_playbook_on_no_hosts_remaining(self):
+        self._display.banner("NO MORE HOSTS LEFT")
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self._task_start(task, prefix='TASK')
+
+    def _task_start(self, task, prefix=None):
+        # Cache output prefix for task if provided
+        # This is needed to properly display 'RUNNING HANDLER' and similar
+        # when hiding skipped/ok task results
+        if prefix is not None:
+            self._task_type_cache[task._uuid] = prefix
+
+        # Preserve task name, as all vars may not be available for templating
+        # when we need it later
+        if self._play.strategy == 'free':
+            # Explicitly set to None for strategy 'free' to account for any cached
+            # task title from a previous non-free play
+            self._last_task_name = None
+        else:
+            self._last_task_name = task.get_name().strip()
+
+            # Display the task banner immediately if we're not doing any filtering based on task result
+            if self.display_skipped_hosts and self.display_ok_hosts:
+                self._print_task_banner(task)
+
+    def _print_task_banner(self, task):
+        # args can be specified as no_log in several places: in the task or in
+        # the argument spec.  We can check whether the task is no_log but the
+        # argument spec can't be because that is only run on the target
+        # machine and we haven't run it thereyet at this time.
+        #
+        # So we give people a config option to affect display of the args so
+        # that they can secure this if they feel that their stdout is insecure
+        # (shoulder surfing, logging stdout straight to a file, etc).
+        args = ''
+        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
+            args = u', '.join(u'%s=%s' % a for a in task.args.items())
+            args = u' %s' % args
+
+        # refactored for litmuschaos: rename banner prefix to 'STEP' instead of 'TASK'
+        prefix = self._task_type_cache.get(task._uuid, 'STEP')
+
+        # Use cached task name
+        task_name = self._last_task_name
+        if task_name is None:
+            task_name = task.get_name().strip()
+
+        self._display.banner(u"%s [%s%s]" % (prefix, task_name, args))
+        if self._display.verbosity >= 2:
+            path = task.get_path()
+            if path:
+                self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
+
+        self._last_task_banner = task._uuid
+
+    def v2_playbook_on_cleanup_task_start(self, task):
+        self._task_start(task, prefix='CLEANUP TASK')
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self._task_start(task, prefix='RUNNING HANDLER')
+
+    def v2_playbook_on_play_start(self, play):
+        name = play.get_name().strip()
+        if not name:
+            msg = u"PLAY"
+        else:
+            msg = u"PLAY [%s]" % name
+
+        self._play = play
+
+        self._display.banner(msg)
+
+    def v2_on_file_diff(self, result):
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        if result._task.loop and 'results' in result._result:
+            for res in result._result['results']:
+                if 'diff' in res and res['diff'] and res.get('changed', False):
+                    diff = self._get_diff(res['diff'])
+                    if diff:
+                        self._display.display(diff)
+        elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
+            diff = self._get_diff(result._result['diff'])
+            if diff:
+                self._display.display(diff)
+
+    def v2_runner_item_on_ok(self, result):
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._clean_results(result._result, result._task.action)
+        if isinstance(result._task, TaskInclude):
+            return
+        elif result._result.get('changed', False):
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            msg = 'changed'
+            color = C.COLOR_CHANGED
+        else:
+            if not self.display_ok_hosts:
+                return
+
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            msg = 'ok'
+            color = C.COLOR_OK
+
+        if delegated_vars:
+            msg += ": [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        else:
+            msg += ": [%s]" % result._host.get_name()
+
+        msg += " => (item=%s)" % (self._get_item_label(result._result),)
+
+        if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            msg += " => %s" % self._dump_results(result._result)
+            ## refactored for litmuschaos: print items info for 'OK' tasks only upon verbose enabled
+            self._display.display(msg, color=color)
+
+    def v2_runner_item_on_failed(self, result):
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._clean_results(result._result, result._task.action)
+        self._handle_exception(result._result)
+
+        msg = "failed: "
+        if delegated_vars:
+            msg += "[%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        else:
+            msg += "[%s]" % (result._host.get_name())
+
+        self._handle_warnings(result._result)
+        self._display.display(msg + " (item=%s) => %s" % (self._get_item_label(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
+
+    def v2_runner_item_on_skipped(self, result):
+        if self.display_skipped_hosts:
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            self._clean_results(result._result, result._task.action)
+            msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item_label(result._result))
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+                msg += " => %s" % self._dump_results(result._result)
+            self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_playbook_on_include(self, included_file):
+        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+        if 'item' in included_file._args:
+            msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
+        self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_playbook_on_stats(self, stats):
+        self._display.banner("PLAY RECAP")
+
+        hosts = sorted(stats.processed.keys())
+        for h in hosts:
+            t = stats.summarize(h)
+
+            self._display.display(u"%s : %s %s %s %s" % (
+                hostcolor(h, t),
+                colorize(u'ok', t['ok'], C.COLOR_OK),
+                colorize(u'changed', t['changed'], C.COLOR_CHANGED),
+                colorize(u'unreachable', t['unreachable'], C.COLOR_UNREACHABLE),
+                colorize(u'failed', t['failures'], C.COLOR_ERROR)),
+                screen_only=True
+            )
+
+            self._display.display(u"%s : %s %s %s %s" % (
+                hostcolor(h, t, False),
+                colorize(u'ok', t['ok'], None),
+                colorize(u'changed', t['changed'], None),
+                colorize(u'unreachable', t['unreachable'], None),
+                colorize(u'failed', t['failures'], None)),
+                log_only=True
+            )
+
+        self._display.display("", screen_only=True)
+
+        # print custom stats if required
+        if stats.custom and self.show_custom_stats:
+            self._display.banner("CUSTOM STATS: ")
+            # per host
+            # TODO: come up with 'pretty format'
+            for k in sorted(stats.custom.keys()):
+                if k == '_run':
+                    continue
+                self._display.display('\t%s: %s' % (k, self._dump_results(stats.custom[k], indent=1).replace('\n', '')))
+
+            # print per run custom stats
+            if '_run' in stats.custom:
+                self._display.display("", screen_only=True)
+                self._display.display('\tRUN: %s' % self._dump_results(stats.custom['_run'], indent=1).replace('\n', ''))
+            self._display.display("", screen_only=True)
+
+    def v2_playbook_on_start(self, playbook):
+        if self._display.verbosity > 1:
+            from os.path import basename
+            self._display.banner("PLAYBOOK: %s" % basename(playbook._file_name))
+
+        if self._display.verbosity > 3:
+            # show CLI options
+            if self._options is not None:
+                for option in dir(self._options):
+                    if option.startswith('_') or option in ['read_file', 'ensure_value', 'read_module']:
+                        continue
+                    val = getattr(self._options, option)
+                    if val and self._display.verbosity > 3:
+                        self._display.display('%s: %s' % (option, val), color=C.COLOR_VERBOSE, screen_only=True)
+
+    def v2_runner_retry(self, result):
+        task_name = result.task_name or result._task
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
+        if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            msg += "Result was: %s" % self._dump_results(result._result)
+        self._display.display(msg, color=C.COLOR_DEBUG)
+
+    def v2_playbook_on_notify(self, handler, host):
+        if self._display.verbosity > 1:
+            self._display.display("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host), color=C.COLOR_VERBOSE, screen_only=True)

--- a/build/utils/display.py
+++ b/build/utils/display.py
@@ -1,0 +1,359 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import errno
+import fcntl
+import getpass
+import locale
+import logging
+import os
+import random
+import subprocess
+import sys
+import textwrap
+import time
+
+from struct import unpack, pack
+from termios import TIOCGWINSZ
+
+from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.utils.color import stringc
+
+
+try:
+    # Python 2
+    input = raw_input
+except NameError:
+    # Python 3, we already have raw_input
+    pass
+
+
+class FilterBlackList(logging.Filter):
+    def __init__(self, blacklist):
+        self.blacklist = [logging.Filter(name) for name in blacklist]
+
+    def filter(self, record):
+        return not any(f.filter(record) for f in self.blacklist)
+
+
+logger = None
+# TODO: make this a logging callback instead
+if getattr(C, 'DEFAULT_LOG_PATH'):
+    path = C.DEFAULT_LOG_PATH
+    if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
+        logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
+        mypid = str(os.getpid())
+        user = getpass.getuser()
+        logger = logging.getLogger("p=%s u=%s | " % (mypid, user))
+        for handler in logging.root.handlers:
+            handler.addFilter(FilterBlackList(getattr(C, 'DEFAULT_LOG_FILTER', [])))
+    else:
+        print("[WARNING]: log file at %s is not writeable and we cannot create it, aborting\n" % path, file=sys.stderr)
+
+b_COW_PATHS = (
+    b"/usr/bin/cowsay",
+    b"/usr/games/cowsay",
+    b"/usr/local/bin/cowsay",  # BSD path for cowsay
+    b"/opt/local/bin/cowsay",  # MacPorts path for cowsay
+)
+
+
+class Display:
+
+    def __init__(self, verbosity=0):
+
+        self.columns = None
+        self.verbosity = verbosity
+
+        # list of all deprecation messages to prevent duplicate display
+        self._deprecations = {}
+        self._warns = {}
+        self._errors = {}
+
+        self.b_cowsay = None
+        self.noncow = C.ANSIBLE_COW_SELECTION
+
+        self.set_cowsay_info()
+
+        if self.b_cowsay:
+            try:
+                cmd = subprocess.Popen([self.b_cowsay, "-l"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                (out, err) = cmd.communicate()
+                self.cows_available = set([to_text(c) for c in out.split()])
+                if C.ANSIBLE_COW_WHITELIST:
+                    self.cows_available = set(C.ANSIBLE_COW_WHITELIST).intersection(self.cows_available)
+            except:
+                # could not execute cowsay for some reason
+                self.b_cowsay = False
+
+        self._set_column_width()
+
+    def set_cowsay_info(self):
+        if C.ANSIBLE_NOCOWS:
+            return
+
+        if C.ANSIBLE_COW_PATH:
+            self.b_cowsay = C.ANSIBLE_COW_PATH
+        else:
+            for b_cow_path in b_COW_PATHS:
+                if os.path.exists(b_cow_path):
+                    self.b_cowsay = b_cow_path
+
+    def display(self, msg, color=None, stderr=False, screen_only=False, log_only=False):
+        """ Display a message to the user
+
+        Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
+        """
+
+        nocolor = msg
+        if color:
+            msg = stringc(msg, color)
+
+        if not log_only:
+            if not msg.endswith(u'\n'):
+                msg2 = msg + u'\n'
+            else:
+                msg2 = msg
+
+            msg2 = to_bytes(msg2, encoding=self._output_encoding(stderr=stderr))
+            if sys.version_info >= (3,):
+                # Convert back to text string on python3
+                # We first convert to a byte string so that we get rid of
+                # characters that are invalid in the user's locale
+                msg2 = to_text(msg2, self._output_encoding(stderr=stderr), errors='replace')
+
+            # Note: After Display() class is refactored need to update the log capture
+            # code in 'bin/ansible-connection' (and other relevant places).
+            if not stderr:
+                fileobj = sys.stdout
+            else:
+                fileobj = sys.stderr
+
+            fileobj.write(msg2)
+
+            try:
+                fileobj.flush()
+            except IOError as e:
+                # Ignore EPIPE in case fileobj has been prematurely closed, eg.
+                # when piping to "head -n1"
+                if e.errno != errno.EPIPE:
+                    raise
+
+        if logger and not screen_only:
+            msg2 = nocolor.lstrip(u'\n')
+
+            msg2 = to_bytes(msg2)
+            if sys.version_info >= (3,):
+                # Convert back to text string on python3
+                # We first convert to a byte string so that we get rid of
+                # characters that are invalid in the user's locale
+                msg2 = to_text(msg2, self._output_encoding(stderr=stderr))
+
+            if color == C.COLOR_ERROR:
+                logger.error(msg2)
+            else:
+                logger.info(msg2)
+
+    def v(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=0)
+
+    def vv(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=1)
+
+    def vvv(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=2)
+
+    def vvvv(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=3)
+
+    def vvvvv(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=4)
+
+    def vvvvvv(self, msg, host=None):
+        return self.verbose(msg, host=host, caplevel=5)
+
+    def debug(self, msg, host=None):
+        if C.DEFAULT_DEBUG:
+            if host is None:
+                self.display("%6d %0.5f: %s" % (os.getpid(), time.time(), msg), color=C.COLOR_DEBUG)
+            else:
+                self.display("%6d %0.5f [%s]: %s" % (os.getpid(), time.time(), host, msg), color=C.COLOR_DEBUG)
+
+    def verbose(self, msg, host=None, caplevel=2):
+        if self.verbosity > caplevel:
+            if host is None:
+                self.display(msg, color=C.COLOR_VERBOSE)
+            else:
+                self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE, screen_only=True)
+
+    def deprecated(self, msg, version=None, removed=False):
+        ''' used to print out a deprecation message.'''
+
+        if not removed and not C.DEPRECATION_WARNINGS:
+            return
+
+        if not removed:
+            if version:
+                new_msg = "[DEPRECATION WARNING]: %s. This feature will be removed in version %s." % (msg, version)
+            else:
+                new_msg = "[DEPRECATION WARNING]: %s. This feature will be removed in a future release." % (msg)
+            new_msg = new_msg + " Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.\n\n"
+        else:
+            raise AnsibleError("[DEPRECATED]: %s.\nPlease update your playbooks." % msg)
+
+        wrapped = textwrap.wrap(new_msg, self.columns, drop_whitespace=False)
+        new_msg = "\n".join(wrapped) + "\n"
+
+        if new_msg not in self._deprecations:
+            self.display(new_msg.strip(), color=C.COLOR_DEPRECATE, stderr=True)
+            self._deprecations[new_msg] = 1
+
+    def warning(self, msg, formatted=False):
+
+        if not formatted:
+            new_msg = "\n[WARNING]: %s" % msg
+            wrapped = textwrap.wrap(new_msg, self.columns)
+            new_msg = "\n".join(wrapped) + "\n"
+        else:
+            new_msg = "\n[WARNING]: \n%s" % msg
+
+        if new_msg not in self._warns:
+            self.display(new_msg, color=C.COLOR_WARN, stderr=True)
+            self._warns[new_msg] = 1
+
+    def system_warning(self, msg):
+        if C.SYSTEM_WARNINGS:
+            self.warning(msg)
+
+    def banner(self, msg, color=None, cows=True):
+        '''
+        Prints a header-looking line with cowsay or stars wit hlength depending on terminal width (3 minimum)
+        '''
+        if self.b_cowsay and cows:
+            try:
+                self.banner_cowsay(msg)
+                return
+            except OSError:
+                self.warning("somebody cleverly deleted cowsay or something during the PB run.  heh.")
+
+        msg = msg.strip()
+        ## refactored for litmuschaos: remove '*' character from task banner
+        stars = "" 
+        self.display(u"%s %s" % (msg, stars), color=color)
+
+    def banner_cowsay(self, msg, color=None):
+        if u": [" in msg:
+            msg = msg.replace(u"[", u"")
+            if msg.endswith(u"]"):
+                msg = msg[:-1]
+        runcmd = [self.b_cowsay, b"-W", b"60"]
+        if self.noncow:
+            thecow = self.noncow
+            if thecow == 'random':
+                thecow = random.choice(list(self.cows_available))
+            runcmd.append(b'-f')
+            runcmd.append(to_bytes(thecow))
+        runcmd.append(to_bytes(msg))
+        cmd = subprocess.Popen(runcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (out, err) = cmd.communicate()
+        self.display(u"%s\n" % to_text(out), color=color)
+
+    def error(self, msg, wrap_text=True):
+        if wrap_text:
+            new_msg = u"\n[ERROR]: %s" % msg
+            wrapped = textwrap.wrap(new_msg, self.columns)
+            new_msg = u"\n".join(wrapped) + u"\n"
+        else:
+            new_msg = u"ERROR! %s" % msg
+        if new_msg not in self._errors:
+            self.display(new_msg, color=C.COLOR_ERROR, stderr=True)
+            self._errors[new_msg] = 1
+
+    @staticmethod
+    def prompt(msg, private=False):
+        prompt_string = to_bytes(msg, encoding=Display._output_encoding())
+        if sys.version_info >= (3,):
+            # Convert back into text on python3.  We do this double conversion
+            # to get rid of characters that are illegal in the user's locale
+            prompt_string = to_text(prompt_string)
+
+        if private:
+            return getpass.getpass(prompt_string)
+        else:
+            return input(prompt_string)
+
+    def do_var_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+
+        result = None
+        if sys.__stdin__.isatty():
+
+            do_prompt = self.prompt
+
+            if prompt and default is not None:
+                msg = "%s [%s]: " % (prompt, default)
+            elif prompt:
+                msg = "%s: " % prompt
+            else:
+                msg = 'input for %s: ' % varname
+
+            if confirm:
+                while True:
+                    result = do_prompt(msg, private)
+                    second = do_prompt("confirm " + msg, private)
+                    if result == second:
+                        break
+                    self.display("***** VALUES ENTERED DO NOT MATCH ****")
+            else:
+                result = do_prompt(msg, private)
+        else:
+            result = None
+            self.warning("Not prompting as we are not in interactive mode")
+
+        # if result is false and default is not None
+        if not result and default is not None:
+            result = default
+
+        if encrypt:
+            # Circular import because encrypt needs a display class
+            from ansible.utils.encrypt import do_encrypt
+            result = do_encrypt(result, encrypt, salt_size, salt)
+
+        # handle utf-8 chars
+        result = to_text(result, errors='surrogate_or_strict')
+        return result
+
+    @staticmethod
+    def _output_encoding(stderr=False):
+        encoding = locale.getpreferredencoding()
+        # https://bugs.python.org/issue6202
+        # Python2 hardcodes an obsolete value on Mac.  Use MacOSX defaults
+        # instead.
+        if encoding in ('mac-roman',):
+            encoding = 'utf-8'
+        return encoding
+
+    def _set_column_width(self):
+        if os.isatty(0):
+            tty_size = unpack('HHHH', fcntl.ioctl(0, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
+        else:
+            tty_size = 0
+        self.columns = max(79, tty_size - 1)


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: 

- The experiments (and executor) consist of multiple conditional tasks (using `when` operator) which causes multiple "skipped" log entries causing the output to be clustered, especially with verbose mode. This PR suppresses the skipped tasks by default by a configuration param. If however, this needs to enabled for debug purposes, it can be achieved via the ENV "DISPLAY_SKIPPED_HOSTS" set to "True".

- The ansible tasks by default mention the "hostname" performing the task along with a task result "status" param depending on whether the task was indeed executed to modify state (`changed`) or the desired state is already achieved, hence not needing a modification (idempotence) (`ok`). Considering litmus's usage of ansible is to primarily run `kubectl` based shell commands, the task status is almost always `changed`. Note that these lines also add to the verbosity of the output. Hence, this PR moves this mode of display only when verbosity is enabled. 

-  Modifies the task banners to make it more "experiment steps" oriented than "configuration tasks"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #987  (along w/ other enhancements)

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
