### PR TITLE
(refactor): update readme & change pumba image

### DIFF
--- a/experiments/generic/pod_network_loss/README.md
+++ b/experiments/generic/pod_network_loss/README.md
@@ -1,9 +1,14 @@
 ## Experiment Metadata
 
-| Type  | Description                                                  | K8s Platform |
-| ----- | ------------------------------------------------------------ | -------------|
-| Chaos | Inject packet loss into application pod                      | Any          |
-
-## Experiment documentation
-
-The corresponding documentation can be found [here](https://docs.litmuschaos.io/docs/pod-network-loss/)
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> Pod Network Loss </td>
+ <td> This experiment injects chaos to disrupt network connectivity to kubernetes pods.The application pod should be healthy once chaos is stopped. It causes loss of access to application replica by injecting packet loss using pumba </td>
+ <td>  <a href="https://docs.litmuschaos.io/docs/pod-network-loss/"> Here </a> </td>
+ </tr>
+ </table>

--- a/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
@@ -51,7 +51,7 @@ spec:
           
            # provide lib image
           - name: LIB_IMAGE
-            value: 'gaiaadm/pumba:0.4.8' 
+            value: 'gaiaadm/pumba:0.6.5' 
 
            # provide chaosengine name
           - name: CHAOSENGINE


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Update readme of pod network loss experiment

-  Change lib-image in job



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
