### PR TITLE
(Fix):Check availablity of daemonset after deletion in cpu-hog and disk-fill

### DIFF
--- a/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
+++ b/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
@@ -151,12 +151,12 @@
         executable: /bin/bash
 
     - name: Confirm that the Disk Fill DaemonSet is deleted successfully
-      shell: >
-        kubectl get ds -l app=disk-fill --no-headers 
-      args:
-        executable: /bin/bash
-      register: result
-      until: "'No resources found' in result.stderr"
+      k8s_facts:
+        kind: DaemonSet
+        label_selectors:
+          - app=disk-fill
+      register: resource_daemonset
+      until: "resource_daemonset.resources | length < 1"
       delay: 5
       retries: 60
 
@@ -172,14 +172,14 @@
           when: "disk_fill_ds_result.rc == 0 "
     
         - name: Confirm that the Disk Fill DaemonSet is deleted successfully
-          shell: >
-            kubectl get ds -l app=disk-fill --no-headers 
-          args:
-            executable: /bin/bash
-          register: result
-          until: "'No resources found' in result.stderr"
+          k8s_facts:
+            kind: DaemonSet
+            label_selectors:
+              - app=disk-fill
+          register: resource_daemonset
+          until: "resource_daemonset.resources | length < 1"
           delay: 5
-          retries: 60
+          retries: 60   
       when: "disk_fill_ds_result is defined"
     
     - fail:

--- a/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
+++ b/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
@@ -164,7 +164,7 @@
 
     - block: 
     
-        - name: Deleting the Cpu Hog DaemonSet
+        - name: Deleting the Disk-fill DaemonSet
           shell: >
             kubectl delete -f /chaoslib/litmus/disk_fill/disk_fill_ds.yaml -n {{ a_ns }}
           args:

--- a/chaoslib/litmus/platform/gke/pod_cpu_consumption.yml
+++ b/chaoslib/litmus/platform/gke/pod_cpu_consumption.yml
@@ -86,12 +86,12 @@
         executable: /bin/bash
 
     - name: Confirm that the Cpu Hog DaemonSet is deleted successfully
-      shell: >
-        kubectl get ds -l app=cpu-hog --no-headers 
-      args:
-        executable: /bin/bash
-      register: result
-      until: "'No resources found' in result.stderr"
+      k8s_facts:
+        kind: DaemonSet
+        label_selectors:
+          - app=cpu-hog
+      register: resource_daemonset
+      until: "resource_daemonset.resources | length < 1"
       delay: 5
       retries: 60
 
@@ -107,12 +107,12 @@
           when: "cpu_hog_ds_result is succeeded"
         
         - name: Confirm that the Cpu Hog DaemonSet is deleted successfully
-          shell: >
-            kubectl get ds -l app=cpu-hog --no-headers 
-          args:
-            executable: /bin/bash
-          register: result
-          until: "'No resources found' in result.stderr"
+          k8s_facts:
+            kind: DaemonSet
+            label_selectors:
+              - app=cpu-hog
+          register: resource_daemonset
+          until: "resource_daemonset.resources | length < 1"
           delay: 5
           retries: 60
       when: "cpu_hog_ds_result is defined"


### PR DESCRIPTION
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Unable to confirm that the Disk Fill DaemonSet is deleted successfully.
- Unable to confirm that the Cpu-Hog DaemonSet is deleted successfully.
- Removed typo

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/litmuschaos/litmus/issues/1080

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
