### PR TITLE
(feat): Adding rescue block in pod-delete by powerseal lib

### DIFF
--- a/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
+++ b/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
@@ -1,44 +1,72 @@
-- name: Generate the powerfulseal deployment spec from template
-  template:
-    src: /chaoslib/powerfulseal/powerfulseal.j2
-    dest: powerfulseal.yml
+- block:
+    
+    - name: Generate the powerfulseal deployment spec from template
+      template:
+        src: /chaoslib/powerfulseal/powerfulseal.j2
+        dest: powerfulseal.yml
 
-- name: Setup powerfulseal to initiate random pod chaos 
-  shell:
-    kubectl apply -f powerfulseal.yml -n {{ a_ns }}
-  args:
-    executable: /bin/bash
-  register: result
-  failed_when: "result.rc != 0"
+    - name: Setup powerfulseal to initiate random pod chaos 
+      shell:
+        kubectl apply -f powerfulseal.yml -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: deployment_result
+      failed_when: "deployment_result.rc != 0"
 
-- name: Confirm that powerfulseal pod is running
-  shell: >
-    kubectl get pod -l name=powerfulseal --no-headers -n {{ a_ns }}
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'Running' in result.stdout"
-  delay: 1
-  retries: 90
-  
-- name: Wait for chaos duration
-  wait_for: timeout={{ c_duration }}
+    - name: Confirm that powerfulseal pod is running
+      shell: >
+        kubectl get pod -l name=powerfulseal --no-headers -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' in result.stdout"
+      delay: 1
+      retries: 90
+    
+    - name: Wait for chaos duration
+      wait_for: timeout={{ c_duration }}
 
-- name: Tear down the powerfulseal deployment
-  shell: 
-    kubectl delete -f powerfulseal.yml -n {{ a_ns }}
-  args:
-    executable: /bin/bash
-  register: result
-  failed_when: "result.rc != 0"
+    - name: Tear down the powerfulseal deployment
+      shell: 
+        kubectl delete -f powerfulseal.yml -n {{ a_ns }}
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "result.rc != 0"
 
-- name: Confirm that powerfulseal pod is cleaned up
-  shell: >
-    kubectl get pod -l name=powerfulseal --no-headers -n {{ a_ns }}
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'Running' not in result.stdout"
-  delay: 1
-  retries: 120
+    - name: Confirm that powerfulseal pod is cleaned up
+      k8s_facts:
+        kind: Deployment
+        label_selectors:
+          - name=powerfulseal
+      register: resource_deployment
+      until: "resource_deployment.resources | length < 1"
+      delay: 1
+      retries: 120
 
+  rescue:
+
+    - block: 
+
+        - name: Tear down the powerfulseal deployment
+          shell: >
+            kubectl delete -f powerfulseal.yml -n {{ a_ns }}
+          args:
+            executable: /bin/bash
+          when: deployment_result.rc == 0
+        
+        - name: Confirm that powerfulseal pod is cleaned up
+          k8s_facts:
+            kind: Deployment
+            label_selectors:
+              - name=powerfulseal
+          register: resource_deployment
+          until: "resource_deployment.resources | length < 1"
+          delay: 1
+          retries: 120
+
+      when: "deployment_result is defined"
+
+    - fail:
+        msg: "pod_failure_by_powerfulseal lib failed"
+      when: true


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding rescue block in powefulseal lib so that it will always delete the powerfulseal deployment

- The playbook will fail if any task inside that playbook fails

**Logs for all possible conditions**
[powerfulseal-pass.txt](https://github.com/litmuschaos/litmus/files/4039164/powerfulseal-pass.txt)
[powerfulseal-fail-before-deployment-creation.txt](https://github.com/litmuschaos/litmus/files/4039165/powerfulseal-fail-before-deployment-creation.txt)
[powerfulseal-fail-after-deployment-creation.txt](https://github.com/litmuschaos/litmus/files/4039166/powerfulseal-fail-after-deployment-creation.txt)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1084 

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
