### PR TITLE
(feat): Add ability to provide cmap/secret in engine

### DIFF
--- a/executor/engine_configmap_getter.yml
+++ b/executor/engine_configmap_getter.yml
@@ -12,6 +12,6 @@
     executable: /bin/bash
   register: engine_cmap_mountPath
 
-- name: append engine configmap
+- name: Append engine configmap
   set_fact:
     c_map_details: "{{c_map_details | combine({engine_cmap_name.stdout : engine_cmap_mountPath.stdout})}}"

--- a/executor/engine_configmap_getter.yml
+++ b/executor/engine_configmap_getter.yml
@@ -1,0 +1,17 @@
+- name: Get configmap names from Chaos Engine
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.configMaps[{{item}}].name' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: engine_cmap_name
+
+- name: Get configmap mountPath from Chaos Engine
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.configMaps[{{item}}].mountPath' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: engine_cmap_mountPath
+
+- name: append engine configmap
+  set_fact:
+    c_map_details: "{{c_map_details | combine({engine_cmap_name.stdout : engine_cmap_mountPath.stdout})}}"

--- a/executor/engine_env_getter.yml
+++ b/executor/engine_env_getter.yml
@@ -1,7 +1,7 @@
 - name: Get ENV names for Chaos Engine
   shell: >
     kubectl get chaosengine {{ c_engine }} -o json 
-    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components[{{item}}].name' | tr -d "\""
+    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.env[{{item}}].name' | tr -d "\""
   args:
     executable: /bin/bash
   register: c_engine_name
@@ -9,7 +9,7 @@
 - name: Get ENV values for Chaos Engine
   shell: >
     kubectl get chaosengine {{ c_engine }} -o json
-    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components[{{item}}].value' | tr -d "\""
+    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.env[{{item}}].value' | tr -d "\""
   args:
     executable: /bin/bash
   register: c_engine_value

--- a/executor/engine_secret_getter.yml
+++ b/executor/engine_secret_getter.yml
@@ -1,0 +1,17 @@
+- name: Get secret names from Chaos Engine
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.secrets[{{item}}].name' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: engine_secret_name
+
+- name: Get secret mountPath from Chaos Engine
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.secrets[{{item}}].mountPath' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: engine_secret_mountPath
+
+- name: append engine secret_details
+  set_fact:
+    secret_details: "{{secret_details | combine({engine_secret_name.stdout : engine_secret_mountPath.stdout})}}"

--- a/executor/executor.yml
+++ b/executor/executor.yml
@@ -65,24 +65,40 @@
     executable: /bin/bash
   register: c_job_args
 
-- name: Check configmaps defined or not.
+- name: Check configmaps defined or not in chaos experiment.
   shell: >
     kubectl get chaosexperiment -n {{ c_app_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ c_experiment_name }}")].spec.definition.configmaps}'
   args:
     executable: /bin/bash
-  register: configMap_defined
+  register: configMap_defined_experiment
 
-- name: Check secrets defined or not.
+- name: Check configmaps defined or not in chaos engine.
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o jsonpath='{range .spec.experiments[?(@.name=="{{ c_experiment_name }}")]}{.spec.components.configMaps}'
+  args:
+    executable: /bin/bash
+  register: configMap_defined_engine
+
+- name: Check secrets defined or not in chaos experiment.
   shell: >
     kubectl get chaosexperiment -n {{ c_app_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ c_experiment_name }}")].spec.definition.secrets}'
   args:
     executable: /bin/bash
-  register: secret_defined
+  register: secret_defined_experiment
+
+- name: Check secrets defined or not in chaos engine.
+  shell: >
+    kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o jsonpath='{range .spec.experiments[?(@.name=="{{ c_experiment_name }}")]}{.spec.components.secrets}'
+  args:
+    executable: /bin/bash
+  register: secret_defined_engine
 
 - name: Record configmaps and secrets are defined or not.
   set_fact:
-    configMap_defined: "{{ configMap_defined.stdout }}"
-    secret_defined: "{{ secret_defined.stdout }}"
+    configMap_defined_experiment: "{{ configMap_defined_experiment.stdout }}"
+    configMap_defined_engine: "{{ configMap_defined_engine.stdout }}"
+    secret_defined_experiment: "{{ secret_defined_experiment.stdout }}"
+    secret_defined_engine: "{{ secret_defined_engine.stdout }}"
 
 - include: experiment_env_getter.yml
   with_sequence: start=0 count="{{ c_env_length.stdout | int }}"
@@ -90,7 +106,7 @@
 - name: Obtain the env param list length from spec of Engine
   shell: >
     kubectl get chaosengine {{ c_engine }} -o json 
-    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components | length'
+    | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.env | length'
   args:
     executable: /bin/bash
   register: c_engine_envlen
@@ -151,12 +167,12 @@
   args:
     executable: /bin/bash
   when:  
-    - configMap_defined == "[map[]]" or  configMap_defined == ''
-    - secret_defined == "[map[]]"  or  secret_defined == ''
+    - configMap_defined_experiment == "[map[]]" or  configMap_defined_experiment == '' or configMap_defined_engine == "[map[]]" or  configMap_defined_engine == ''
+    - secret_defined_experiment == "[map[]]"  or  secret_defined_experiment == '' or secret_defined_engine == "[map[]]"  or  secret_defined_engine == ''
   
 - include: experiment_volumes.yml
   when: 
-    - (configMap_defined != '' and  configMap_defined != "[map[]]") or (secret_defined != '' and  secret_defined != "[map[]]")
+    - (configMap_defined_experiment != '' and  configMap_defined_experiment != "[map[]]" and configMap_defined_engine != '' and  configMap_defined_engine != "[map[]]") or (secret_defined_experiment != '' and  secret_defined_experiment != "[map[]]" and secret_defined_engine != '' and  secret_defined_engine != "[map[]]")
 
 - name: Fetching monitoring time from chaos experiment job
   shell: >

--- a/executor/experiment_configmap_getter.yml
+++ b/executor/experiment_configmap_getter.yml
@@ -14,6 +14,6 @@
     executable: /bin/bash
   register: experiment_cmap_mountPath
 
-- name: append experiment configMap
+- name: Append experiment configMap
   set_fact:
     c_map_details: "{{c_map_details | combine({experiment_cmap_name.stdout : experiment_cmap_mountPath.stdout})}}"

--- a/executor/experiment_configmap_getter.yml
+++ b/executor/experiment_configmap_getter.yml
@@ -1,0 +1,19 @@
+- name: Get configmap names from Chaos Experiment
+  shell: >
+    kubectl get chaosexperiment {{ c_experiment_name }} -o json
+    | jq '.spec.definition.configmaps[{{item}}].name' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: experiment_cmap_name
+
+- name: Get configmap mountPath from Chaos Experiment
+  shell: >
+    kubectl get chaosexperiment {{ c_experiment_name }} -o json
+    | jq '.spec.definition.configmaps[{{item}}].mountPath' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: experiment_cmap_mountPath
+
+- name: append experiment configMap
+  set_fact:
+    c_map_details: "{{c_map_details | combine({experiment_cmap_name.stdout : experiment_cmap_mountPath.stdout})}}"

--- a/executor/experiment_secret_getter.yml
+++ b/executor/experiment_secret_getter.yml
@@ -1,0 +1,19 @@
+- name: Get secret names from Chaos Experiment
+  shell: >
+    kubectl get chaosexperiment {{ c_experiment_name }} -o json
+    | jq '.spec.definition.secrets[{{item}}].name' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: secret_name_experiment
+
+- name: Get secret mountPath from Chaos Experiment
+  shell: >
+    kubectl get chaosexperiment {{ c_experiment_name }} -o json
+    | jq '.spec.definition.secrets[{{item}}].mountPath' | tr -d "\""
+  args:
+    executable: /bin/bash
+  register: secret_mountPath_experiment
+
+- name: append Experiment secret_details
+  set_fact:
+    secret_details: "{{secret_details | combine({secret_name_experiment.stdout : secret_mountPath_experiment.stdout})}}"

--- a/executor/experiment_secret_getter.yml
+++ b/executor/experiment_secret_getter.yml
@@ -14,6 +14,6 @@
     executable: /bin/bash
   register: secret_mountPath_experiment
 
-- name: append Experiment secret_details
+- name: Append Experiment secret_details
   set_fact:
     secret_details: "{{secret_details | combine({secret_name_experiment.stdout : secret_mountPath_experiment.stdout})}}"

--- a/executor/experiment_volumes.yml
+++ b/executor/experiment_volumes.yml
@@ -1,64 +1,84 @@
 - block:
 
-  - name: Fetching name of configmap
-    shell: >
-      kubectl get chaosexperiment {{c_experiment_name}} -n {{c_app_ns}} -o jsonpath='{range .spec.definition.configmaps[*]}{.name}{"\n"}'
-    args:
-      executable: /bin/bash
-    register: c_map_name
+  - set_fact:
+      c_map_details: {}
 
-  - name: Fetching mount path for configmap
+  - name: Obtain the configmap param length from spec of experiment
     shell: >
-      kubectl get chaosexperiment {{c_experiment_name}} -n {{c_app_ns}} -o jsonpath='{range .spec.definition.configmaps[*]}{.mountPath}{"\n"}'
+      kubectl get chaosexperiment {{ c_experiment_name }} -n {{ c_app_ns }} -o json
+      | jq '.spec.definition.configmaps | length'
     args:
       executable: /bin/bash
-    register: c_mount_path_configmap
+    register: c_map_length_experiment
+
+  - include: experiment_configmap_getter.yml
+    with_sequence: start=0 count="{{ c_map_length_experiment.stdout | int }}"
+
+  - name: Obtain the configmap param length from spec of engine
+    shell: >
+      kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.configMaps | length'
+    args:
+      executable: /bin/bash
+    register: c_map_length_engine
+
+  - include: engine_configmap_getter.yml
+    with_sequence: start=0 count="{{ c_map_length_engine.stdout | int }}"
 
   - name: validate configmap present inside cluster or not.
     shell: >
-      kubectl get configmaps -n {{c_app_ns}} --no-headers -o=custom-columns=NAME:".metadata.name"
+      kubectl get configmaps -n {{ c_app_ns }} --no-headers -o=custom-columns=NAME:".metadata.name"
     args:
       executable: /bin/bash
     register: config_present
 
   - name: Check existence of config map
     fail:
-      msg: "config map {{ item }} doesn't exist in cluster"
-    when: item not in config_present.stdout_lines
-    with_items: "{{ c_map_name.stdout_lines }}"
+      msg: "config map {{ item.key }} doesn't exist in cluster"
+    when: item.key not in config_present.stdout_lines
+    with_dict: "{{ c_map_details }}"
 
-  when: configMap_defined != ''
+  when: configMap_defined_experiment != '' or configMap_defined_engine != ''
   
 - block:
 
-  - name: Fetching name of secret
-    shell: >
-      kubectl get chaosexperiment {{c_experiment_name}} -n {{c_app_ns}} -o jsonpath='{range .spec.definition.secrets[*]}{.name}{"\n"}'
-    args:
-      executable: /bin/bash
-    register: c_secret_name
+  - set_fact:
+      secret_details: {}
 
-  - name: Fetching mount path for secret
+  - name: Obtain the secret param length from spec of experiment
     shell: >
-      kubectl get chaosexperiment {{c_experiment_name}} -n {{c_app_ns}} -o jsonpath='{range .spec.definition.secrets[*]}{.mountPath}{"\n"}'
+      kubectl get chaosexperiment {{ c_experiment_name }} -n {{ c_app_ns }} -o json
+      | jq '.spec.definition.secrets | length'
     args:
       executable: /bin/bash
-    register: c_mount_path
+    register: secret_length_experiment
+  
+  - include: experiment_secret_getter.yml
+    with_sequence: start=0 count="{{ secret_length_experiment.stdout | int }}"
+  
+  - name: Obtain the secret param length from spec of engine
+    shell: >
+      kubectl get chaosengine {{ c_engine }} -n {{ c_app_ns }} -o json | jq '.spec.experiments[] | select(.name == "{{ c_experiment_name }}") | .spec.components.secrets | length'
+    args:
+      executable: /bin/bash
+    register: secret_length_engine
+  
+  - include: engine_secret_getter.yml
+    with_sequence: start=0 count="{{ secret_length_engine.stdout | int }}"
 
   - name: validate secrets present inside cluster or not.
     shell: >
-      kubectl get secrets -n {{c_app_ns}} --no-headers -o=custom-columns=NAME:".metadata.name"
+      kubectl get secrets -n {{ c_app_ns }} --no-headers -o=custom-columns=NAME:".metadata.name"
     args:
       executable: /bin/bash
     register: secret_present
 
   - name: Check existence of secrets
     fail:
-      msg: "secret {{ item }} doesn't exist in cluster"
-    when: item not in secret_present.stdout_lines
-    with_items: "{{ c_secret_name.stdout_lines }}"
+      msg: "secret {{ item.key }} doesn't exist in cluster"
+    when: item.key not in secret_present.stdout_lines
+    with_dict: "{{ secret_details }}"
   
-  when: secret_defined != ''
+  when: secret_defined_experiment != '' or  secret_defined_engine != ''
 
 - name: Get the job yaml
   shell:
@@ -86,14 +106,12 @@
 
   - include: volumePatcher.yml
     vars:
-      configName: "{{ item.0 }}"
-      mountPathConfigMap: "{{ item.1 }}"
+      configName: "{{ item.key }}"
+      mountPathConfigMap: "{{ item.value }}"
       executeBlock: "config_map"
-    with_together:
-      - "{{ c_map_name.stdout_lines }}"
-      - "{{ c_mount_path_configmap.stdout_lines }}"
+    with_dict: "{{ c_map_details }}"
 
-  when: configMap_defined != ''
+  when: configMap_defined_experiment != '' or configMap_defined_engine != ''
 
 - block:
 
@@ -113,14 +131,12 @@
     
   - include: volumePatcher.yml
     vars: 
-      secretName: "{{ item.0}}"
-      mountPathSecret: "{{ item.1}}"
+      secretName: "{{ item.key }}"
+      mountPathSecret: "{{ item.value }}"
       executeBlock: "secret"
-    with_together:
-      - "{{ c_secret_name.stdout_lines }}"
-      - "{{ c_mount_path.stdout_lines }}"
+    with_dict: "{{ secret_details }}"
 
-  when: secret_defined != ''
+  when: secret_defined_experiment != '' or secret_defined_engine != ''
 
 - name: create job
   shell:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Add the ability to provide ENV, ConfigMap and secrets in chaosengine.

- Tested by providing multiple ENV, configmaps and secrets. It is able to override ENV, configmaps and secrets from the engine. If the ENV, configmaps or secrets not present inside chaos experiment then it will append them.

**Job-pod description**
[drain-node-job-pod.txt](https://github.com/litmuschaos/litmus/files/4076647/drain-node-job-pod.txt)


**engine and experiment yaml**
[drain-node.txt](https://github.com/litmuschaos/litmus/files/4076648/drain-node.txt)
[chaosengine.txt](https://github.com/litmuschaos/litmus/files/4076650/chaosengine.txt)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes  , ...)` format, will close that issue when PR gets merged)*: fixes #1126 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [x] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [x] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
