### PR TITLE
(feat): Adding rescue block in pod-failure-by sigkill  lib

### DIFF
--- a/chaoslib/pumba/pod_failure_by_sigkill.yaml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -1,12 +1,12 @@
 --- 
-- name: Patch the chaoslib image
-  template:
-    src:  /chaoslib/pumba/pumba.j2
-    dest: /chaoslib/pumba/pumba_kube.yml
-  vars:
-    pumba_image: "{{ lib_image }}"
-
 - block:
+
+    - name: Patch the chaoslib image
+      template:
+        src:  /chaoslib/pumba/pumba.j2
+        dest: /chaoslib/pumba/pumba_kube.yml
+      vars:
+        pumba_image: "{{ lib_image }}"
 
     - name: Setup pumba chaos infrastructure
       shell: >
@@ -14,7 +14,7 @@
         -n {{ namespace }}
       args:
         executable: /bin/bash
-      register: result
+      register: pumba_ds_result
 
       # Verifies pumba ds pods status against Ready Nodes
       # The nested kubectl command returns (via command substitution) a list of Ready nodes: 
@@ -31,7 +31,7 @@
         executable: /bin/bash
       register: result
       until: "result.stdout == 'Running'"
-      delay: 1
+      delay: 2
       retries: 60
       ignore_errors: true
 
@@ -115,7 +115,7 @@
       vars:
         app_label: "app=pumba"
         app_ns: "{{ namespace }}"  
-        delay: 1
+        delay: 2
         retries: 60
 
     - name: Force kill the application pod using pumba
@@ -138,43 +138,45 @@
       delay: 2
       retries: 60
 
-  when: action == "killapp"
-
-- block:
-
-    - name: Check if pumba is indeed running
+    - name: Tear down pumba infrastructure
       shell: >
-        kubectl get pod -l app=pumba
-        --no-headers -o custom-columns=:status.phase
-        -n {{ namespace }} | sort | uniq
+        kubectl delete -f /chaoslib/pumba/pumba_kube.yml -n {{ namespace }}
+      args:
+        executable: /bin/bash
+
+    - name: Confirm that the pumba job is deleted successfully
+      shell: >
+        kubectl get pods -l app=pumba --no-headers -n {{ namespace }}
       args:
         executable: /bin/bash
       register: result
-      until: "result.stdout == 'Running'"
-      delay: 1
+      until: "'No resources found' in result.stderr"
+      delay: 2
       retries: 60
-      ignore_errors: true
+
+  rescue: 
 
     - block: 
 
-        - name: Delete the pumba daemonset
+        - name: Tear down pumba infrastructure, if setup
           shell: >
             kubectl delete -f /chaoslib/pumba/pumba_kube.yml -n {{ namespace }}
           args:
             executable: /bin/bash
-          register: result
-
-        - name: Confirm that the pumba ds is deleted successfully
+          when: pumba_ds_result.rc == 0
+        
+        - name: Confirm that the pumba job is not present
           shell: >
-            kubectl get pod -l app=pumba
-            --no-headers -n {{ namespace }}
+            kubectl get pods -l app=pumba --no-headers -n {{ namespace }}
           args:
             executable: /bin/bash
           register: result
-          until: "'Running' not in result.stdout"
-          delay: 1
-          retries: 150
+          until: "'No resources found' in result.stderr"
+          delay: 2
+          retries: 60
+      when: "pumba_ds_result is defined"
 
-      when: result.stdout is defined and result.stdout == "Running"
-
-  when: action == "deletepumba"
+    - fail:
+        msg: "pod_failure_by_sigkill lib failed"
+      when: true
+        

--- a/experiments/generic/container_kill/container_kill_ansible_logic.yml
+++ b/experiments/generic/container_kill/container_kill_ansible_logic.yml
@@ -50,7 +50,6 @@
             namespace: "{{ a_ns }}"
             label: "{{ a_label }}"
             app_container: "{{ c_container }}"
-            action: "killapp"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
@@ -70,13 +69,6 @@
             flag: "fail"
 
       always: 
-
-        - include_tasks: "{{ c_util }}"
-          vars:
-            namespace: "{{ a_ns }}"
-            label: "{{ a_label }}"
-            app_container: ""
-            action: "deletepumba"
 
         ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
         - include_tasks: /utils/runtime/update_chaos_result_resource.yml

--- a/experiments/openebs/openebs-pool-container-failure/cstor_kill_and_verify_pool.yml
+++ b/experiments/openebs/openebs-pool-container-failure/cstor_kill_and_verify_pool.yml
@@ -27,7 +27,6 @@
 # including pumba chaoslib pod_failure_by_sigkill - container kill
 - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
   vars:
-    action: "killapp"
     namespace: "{{ openebs_ns }}"
     label: "app=cstor-pool"
     app_pod: "{{ cstor_pool_pod }}"


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding rescue block in pod-failure-by-sigkill lib so that it will always delete the Pumba DS

- The playbook will fail if any task inside that playbook fails

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1140 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [x] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
