### PR TITLE
(refactor): Update the name of chaos-result in openebs pool container/pod failure experiment

### DIFF
--- a/experiments/openebs/openebs-pool-container-failure/cstor_kill_and_verify_pool.yml
+++ b/experiments/openebs/openebs-pool-container-failure/cstor_kill_and_verify_pool.yml
@@ -27,7 +27,6 @@
 # including pumba chaoslib pod_failure_by_sigkill - container kill
 - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
   vars:
-    action: "killapp"
     namespace: "{{ openebs_ns }}"
     label: "app=cstor-pool"
     app_pod: "{{ cstor_pool_pod }}"

--- a/experiments/openebs/openebs-pool-container-failure/openebs_pool_container_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-container-failure/openebs_pool_container_failure_ansible_logic.yml
@@ -6,7 +6,6 @@
     a_label: "{{ lookup('env','APP_LABEL') }}"
     a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
     a_pvc: "{{ lookup('env','APP_PVC') }}"
-    c_engine: "{{ lookup('env','CHAOSENGINE') }}"
     c_experiment: openebs-pool-container-failure
     chaos_duration: 600
     chaos_iterations: "{{ lookup('env','CHAOS_ITERATIONS') }}"
@@ -51,9 +50,9 @@
 
             - name: Construct chaos result name (experiment_name)
               set_fact:
-                c_result: "{{ c_engine }}-{{ c_experiment }}"
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
 
-          when: c_engine != ''
+          when: lookup('env','CHAOSENGINE') 
 
         ## RECORD START-OF-EXPERIMENT IN CHAOS RESULT CR
         - include_tasks: /utils/runtime/update_chaos_result_resource.yml

--- a/experiments/openebs/openebs-pool-pod-failure/openebs_pool_pod_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-pod-failure/openebs_pool_pod_failure_ansible_logic.yml
@@ -8,7 +8,6 @@
     a_pvc: "{{ lookup('env','APP_PVC') }}"
     c_duration: 600
     c_interval: 5
-    c_engine: "{{ lookup('env','CHAOSENGINE') }}"
     c_experiment: openebs-pool-pod-failure
     c_force: "{{ lookup('env','FORCE') }}"
     c_iterations: "{{ lookup('env','CHAOS_ITERATIONS') }}"
@@ -52,9 +51,9 @@
 
             - name: Construct chaos result name (experiment_name)
               set_fact:
-                c_result: "{{ c_engine }}-{{ c_experiment }}"
+                c_experiment: "{{ lookup('env','CHAOSENGINE') }}-{{ c_experiment }}"
 
-          when: c_engine != ''
+          when: lookup('env','CHAOSENGINE') 
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Previously the name of chaos-result for `openebs-pool-container-failure` experiment is only the name of c_experiment. It will update the name of  chaos-result to `<engine-name>-<c_experiment>`

- Previously the name of chaos-result for `openebs-pool-pod-failure` experiment is only the name of c_experiment. It will update the name of  chaos-result to `<engine-name>-<c_experiment>`

- Remove the action field from the `cstor_kill_and_verify_pool`. As we already removed the action field from `pod_failure_by_sigkill` Lib 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1149 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
