### PR TITLE
(refactor) ramp_time support for node_drain experiment

### DIFF
--- a/chaoslib/litmus/cordon_drain_node.yaml
+++ b/chaoslib/litmus/cordon_drain_node.yaml
@@ -1,5 +1,9 @@
 - block:
 
+  - name: Wait for the specified ramp time before injecting chaos
+    wait_for: timeout="{{ ramp_time }}"
+    when: "ramp_time is defined and ramp_time != ''"
+
   - name: Drain the application node
     shell: >
       kubectl drain {{ app_node }}

--- a/experiments/generic/node_drain/node_drain_ansible_logic.yml
+++ b/experiments/generic/node_drain/node_drain_ansible_logic.yml
@@ -7,6 +7,7 @@
     a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
     a_node: "{{ lookup('env','APP_NODE') }}"
     c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    ramp_time: "{{ lookup('env','RAMP_TIME') }}"
     c_experiment: "node-drain"
     liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
     liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"

--- a/experiments/generic/node_drain/node_drain_k8s_job.yml
+++ b/experiments/generic/node_drain/node_drain_k8s_job.yml
@@ -39,6 +39,10 @@ spec:
           - name: TOTAL_CHAOS_DURATION
             value: '60'
 
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
           - name: LIVENESS_APP_LABEL
             value: ''
 


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds support for ramp time (pre-chaos wait/warm-up period) for injection of chaos

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #(partially addresses #1152 )

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
