### PR TITLE
refactor(experiments): Make the time-duration consistent(in seconds) in all experiments

### DIFF
--- a/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
+++ b/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
@@ -30,7 +30,7 @@ spec:
             ## optional: provide duration of cpu chaos 
             ## default: 60 (in sec)
           - name: DURATION
-            value: "{{ c_duration_sec }}"
+            value: "{{ c_duration }}"
             ## optional: provide number of cpu cores to be consumed in container
             ## default: 1
           - name: CORES

--- a/chaoslib/litmus/cpu_hog/pod_cpu_hog.yml
+++ b/chaoslib/litmus/cpu_hog/pod_cpu_hog.yml
@@ -69,10 +69,10 @@
       set_fact:
         c_container_id: "{{ container_id.stdout }}"
 
-    - name: Derive chaos duration in seconds (from ms)
-      set_fact:
-        c_duration_sec: "{{ ((c_duration|int)/1000)| int }}"
-    
+    - name: Wait for the specified ramp time before injecting chaos
+      wait_for: timeout="{{ ramp_time }}"
+      when: "ramp_time is defined and ramp_time != ''" 
+ 
     - name: Patch the chaos params to cpu stress job template
       template:
         src:  /chaoslib/litmus/cpu_hog/app_cpu_stress.j2
@@ -89,18 +89,9 @@
       register: cpu_app_deploy_result
 
     - name: Calculate the total wait time for cpu stress job
-      ## considering duration in milliseconds from spec
       ## with a grace period of 2 min before cpu stress job terminate
       set_fact:
-        job_wait_time: "{{ ((c_duration|int)/1000 + 120)| int }}"
-      when: "ramp_time is not defined or ramp_time == ''"
-
-    - name: Calculate the total wait time for cpu stress job
-      ## considering duration in milliseconds from spec
-      ## with a grace period of 2 min before cpu stress job terminate
-      set_fact:
-        job_wait_time: "{{ ((c_duration|int)/1000 + (ramp_time|int) + 120)| int }}"
-      when: "ramp_time is defined and ramp_time != ''"
+        job_wait_time: "{{ ((c_duration|int) + 120)| int }}"
 
     - name: Wait until the cpu stress job is completed
       shell: >

--- a/chaoslib/pumba/network_chaos/network_chaos.yml
+++ b/chaoslib/pumba/network_chaos/network_chaos.yml
@@ -87,9 +87,8 @@
         register: result
         until: "result.stdout == 'Succeeded'"
         delay: 1
-        ## considering duration in milliseconds from spec
         ## with a grace period of 1 min before pumba terminate
-        retries: "{{ ((c_duration|int)/1000 + 60)| int }}"
+        retries: "{{ ((c_duration|int) + 60)| int }}"
   
       - name: Wait for the specified ramp time after injecting chaos
         wait_for: timeout="{{ ramp_time }}"

--- a/chaoslib/pumba/network_chaos/pumba_netem_job.j2
+++ b/chaoslib/pumba/network_chaos/pumba_netem_job.j2
@@ -26,7 +26,7 @@ spec:
           - --interface
           - {{ n_interface }}
           - --duration
-          - {{ c_duration }}ms
+          - {{ c_duration }}s
 {% if n_latency is defined and n_latency != '' %}
           - delay
           - --time

--- a/experiments/generic/pod_cpu_hog/pod_cpu_hog_k8s_job.yml
+++ b/experiments/generic/pod_cpu_hog/pod_cpu_hog_k8s_job.yml
@@ -43,7 +43,7 @@ spec:
             value: '1'
 
           - name: TOTAL_CHAOS_DURATION
-            value: '60000' # in ms
+            value: '60' # in seconds
 
           # Period to wait before injection of chaos in sec
           - name: RAMP_TIME

--- a/experiments/generic/pod_network_corruption/pod_network_corruption_k8s_job.yml
+++ b/experiments/generic/pod_network_corruption/pod_network_corruption_k8s_job.yml
@@ -47,7 +47,7 @@ spec:
             value: '100' # in percentage
 
           - name: TOTAL_CHAOS_DURATION
-            value: '60000' # in ms
+            value: '60'  # in seconds
 
           # Period to wait before injection of chaos in sec
           - name: RAMP_TIME

--- a/experiments/generic/pod_network_latency/pod_network_latency_k8s_job.yml
+++ b/experiments/generic/pod_network_latency/pod_network_latency_k8s_job.yml
@@ -47,7 +47,7 @@ spec:
             value: '60000' # in ms
 
           - name: TOTAL_CHAOS_DURATION
-            value: '60000' # in ms
+            value: '60'  # in seconds
             
           # Period to wait before injection of chaos in sec
           - name: RAMP_TIME

--- a/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_k8s_job.yml
@@ -44,7 +44,7 @@ spec:
             value: '70' # in percentage
 
           - name: TOTAL_CHAOS_DURATION
-            value: '60000' # in ms
+            value: '60'  # in seconds
 
           # Period to wait before injection of chaos in sec
           - name: RAMP_TIME

--- a/experiments/kafka/kafka-broker-network-latency/kafka-broker-network-latency-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-network-latency/kafka-broker-network-latency-k8s-job.yml
@@ -34,9 +34,8 @@ spec:
           - name: KAFKA_CONSUMER_TIMEOUT
             value: '30000'
 
-          # in milliseconds  
           - name: TOTAL_CHAOS_DURATION
-            value: '60000'
+            value: '60'  # in seconds
 
           - name: TARGET_CONTAINER
             value: 'k8skafka'

--- a/experiments/kafka/kafka-broker-network-loss/kafka-broker-network-loss-k8s-job.yml
+++ b/experiments/kafka/kafka-broker-network-loss/kafka-broker-network-loss-k8s-job.yml
@@ -34,9 +34,8 @@ spec:
           - name: KAFKA_CONSUMER_TIMEOUT
             value: '30000'
 
-          # in milliseconds  
           - name: TOTAL_CHAOS_DURATION
-            value: '60000'
+            value: '60'  # in seconds
 
           - name: TARGET_CONTAINER
             value: 'k8skafka'

--- a/experiments/openebs/openebs-pool-network-delay/openebs_pool_network_delay_k8s_job.yml
+++ b/experiments/openebs/openebs-pool-network-delay/openebs_pool_network_delay_k8s_job.yml
@@ -53,7 +53,7 @@ spec:
             value: '60000' # in milliseconds
 
           - name: TOTAL_CHAOS_DURATION
-            value: '60000' # in milliseconds
+            value: '60'  # in seconds
 
           - name: CHAOS_INTERVAL
             value: '1000'

--- a/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_ansible_logic.yml
@@ -7,7 +7,6 @@
     a_pvc: "{{ lookup('env','APP_PVC') }}"
     c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
     c_experiment: "openebs-pool-network-loss"
-    c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
     data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"

--- a/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_k8s_job.yml
+++ b/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_k8s_job.yml
@@ -52,11 +52,8 @@ spec:
             value: '100' # in percentage
 
           - name: TOTAL_CHAOS_DURATION
-            value: '120000' # in milliseconds
+            value: '120' # in seconds
           
-          - name: CHAOS_INTERVAL
-            value: '1000'
-
           - name: LIVENESS_APP_LABEL
             value: ''
 

--- a/experiments/openebs/openebs-target-network-delay/openebs_target_network_delay_k8s_job.yml
+++ b/experiments/openebs/openebs-target-network-delay/openebs_target_network_delay_k8s_job.yml
@@ -52,7 +52,7 @@ spec:
             value: '60000' # in milliseconds
 
           - name: CHAOS_DURATION
-            value: '60000' # in milliseconds
+            value: '60' # in seconds
             
           - name: LIVENESS_APP_LABEL
             value: ''

--- a/experiments/openebs/openebs-target-network-loss/openebs_target_network_loss_k8s_job.yml
+++ b/experiments/openebs/openebs-target-network-loss/openebs_target_network_loss_k8s_job.yml
@@ -55,7 +55,7 @@ spec:
             value: '100' # in percentage
 
           - name: CHAOS_DURATION
-            value: '120000' # in milliseconds
+            value: '120' # in seconds
 
           - name: LIVENESS_APP_LABEL
             value: ''


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Make the total-time-duration consistent in all experiments. It should be in seconds

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
