### PR TITLE
feat(pod-delete): Add ability to select only running pods

### DIFF
--- a/chaoslib/litmus/kill_random_pod.yml
+++ b/chaoslib/litmus/kill_random_pod.yml
@@ -6,6 +6,8 @@
         namespace: "{{ app_ns }}"
         label_selectors:
           - "{{ app_label }}"
+        field_selectors:
+          - status.phase=Running
       register: pod_list
 
     - name: Initialize deletion list
@@ -73,3 +75,9 @@
 - name: Wait for the interval timer
   pause:
     seconds: "{{ c_interval }}"
+
+- name: Verify that the application replica is recreated
+  include_tasks: "/utils/common/status_app_pod.yml"
+  vars:
+    delay: 2
+    retries: 90   


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Add ability to select only the running pods.

- Add the AUT running status check after the deletion of replica in each iteration. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/litmuschaos/litmus/issues/1258

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from withinhttps://github.com/litmuschaos/litmus/issues/1258 & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
