### PR TITLE
feat(experiment) Adding support for generation of experiment events in chaosengine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ansible-runner-image:
 	@echo "------------------"
 	@echo "--> Build ansible-runner image" 
 	@echo "------------------"
-	sudo docker build . -f build/ansible-runner/Dockerfile -t litmuschaos/ansible-runner:ci
+	sudo docker build . -f build/ansible-runner/Dockerfile -t shubh214/ansible-runner:ci
 	REPONAME="litmuschaos" IMGNAME="ansible-runner" IMGTAG="ci" ./hack/push
 
 .PHONY: ansible-syntax-check

--- a/chaoslib/litmus/container_kill/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/litmus/container_kill/containerd_chaos/crictl-chaos.yml
@@ -129,6 +129,14 @@
       register: container_id
       failed_when: container_id is failed
 
+     ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "container-kill"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on {{ app_pod }}"
+
     - name: Kill the container
       shell: >
         kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 

--- a/chaoslib/litmus/cordon_drain_node.yml
+++ b/chaoslib/litmus/cordon_drain_node.yml
@@ -4,6 +4,14 @@
       wait_for: timeout="{{ ramp_time }}"
       when: "ramp_time is defined and ramp_time != ''"
 
+    ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "node-drain"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on {{ app_node }}"
+
     - name: Drain the application node
       shell: >
         kubectl drain {{ app_node }}

--- a/chaoslib/litmus/cpu_hog/pod_cpu_hog.yml
+++ b/chaoslib/litmus/cpu_hog/pod_cpu_hog.yml
@@ -81,6 +81,14 @@
         cpu_stress_image: "{{ lib_image }}"
         chaosUID: "{{ chaos_uid }}"
 
+    ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "pod-cpu-hog"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on {{ app_pod }}"
+
     - name: Setup cpu chaos infrastructure
       shell: >
         kubectl create -f /chaoslib/litmus/cpu_hog/app_cpu_stress.yml -n {{ app_ns }}

--- a/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
+++ b/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
@@ -66,6 +66,14 @@
       vars:
         chaosUID: "{{ chaos_uid }}"
 
+    ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "disk-fill"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on {{ pod_name.stdout }}"
+
     - name: Create the DaemonSet for Disk-Fill
       shell: >
         kubectl apply -f /chaoslib/litmus/disk_fill/disk_fill_ds.yml -n {{ a_ns }}

--- a/chaoslib/litmus/kill_random_pod.yml
+++ b/chaoslib/litmus/kill_random_pod.yml
@@ -53,6 +53,14 @@
 
   when: "app_pod_name is defined and app_pod_name != ''"
 
+## RECORD EVENT FOR CHAOS INJECTION
+- include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+  vars:
+    stage: "ChaosInject"
+    exp_pod_name: "pod-delete"
+    engine_ns: "{{ a_ns }}"
+    message: "Injecting {{ c_experiment }} chaos on {{ app_pod }}"
+
 - debug:
     msg: "Killing pod {{ app_pod }}"
 

--- a/chaoslib/litmus/platform/aws/disk_loss.yml
+++ b/chaoslib/litmus/platform/aws/disk_loss.yml
@@ -2,6 +2,14 @@
   wait_for: timeout="{{ ramp_time }}"
   when: "ramp_time is defined and ramp_time != ''"
 
+## RECORD EVENT FOR CHAOS INJECTION
+- include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+  vars:
+    stage: "ChaosInject"
+    exp_pod_name: "disk-loss"
+    engine_ns: "{{ a_ns }}"
+    message: "Injecting {{ c_experiment }} chaos on {{ disk_name }}"
+
 - name: Detaching the disk
   ec2_vol:
     id: "{{ disk_name }}"

--- a/chaoslib/litmus/platform/gke/disk_loss.yml
+++ b/chaoslib/litmus/platform/gke/disk_loss.yml
@@ -2,6 +2,14 @@
   wait_for: timeout="{{ ramp_time }}"
   when: "ramp_time is defined and ramp_time != ''"
 
+## RECORD EVENT FOR CHAOS INJECTION
+- include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+  vars:
+    stage: "ChaosInject"
+    exp_pod_name: "disk-loss"
+    engine_ns: "{{ a_ns }}"
+    message: "Injecting {{ c_experiment }} chaos on {{ disk_name }}"
+
 - name: Detaching the disk
   shell: gcloud compute instances detach-disk {{ node_name }} --disk {{ disk_name }} --zone {{ zone_name }}
 

--- a/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
+++ b/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
@@ -3,6 +3,14 @@
     - name: Wait for the specified ramp time before injecting chaos
       wait_for: timeout="{{ ramp_time }}"
       when: "ramp_time is defined and ramp_time != ''"
+
+     ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "pod-delete"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on application pod"
     
     - name: Generate the powerfulseal deployment spec from template
       template:

--- a/chaoslib/pumba/network_chaos/network_chaos.yml
+++ b/chaoslib/pumba/network_chaos/network_chaos.yml
@@ -70,6 +70,14 @@
         vars:
           pumba_image: "{{ lib_image }}"
           chaosUID: "{{ chaos_uid }}"
+
+      ## RECORD EVENT FOR CHAOS INJECTION
+      - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "ChaosInject"
+          exp_pod_name: "network-lib"
+          engine_ns: "{{ a_ns }}"
+          message: "Injecting {{ c_experiment }} chaos on {{ app_pod }}"
   
       - name: Setup pumba chaos infrastructure
         shell: >

--- a/chaoslib/pumba/pod_failure_by_sigkill.yml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yml
@@ -61,6 +61,14 @@
         app_pod: "{{ app_pod }}"
         app_container: "{{ a_container }}"
 
+    ## RECORD EVENT FOR CHAOS INJECTION
+    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+      vars:
+        stage: "ChaosInject"
+        exp_pod_name: "container-kill"
+        engine_ns: "{{ a_ns }}"
+        message: "Injecting {{ c_experiment }} chaos on {{ app_pod }}"
+
     - name: Setup pumba chaos infrastructure
       shell: >
         kubectl apply -f /chaoslib/pumba/pumba_kube.yml
@@ -68,7 +76,7 @@
       args:
         executable: /bin/bash
       register: pumba_job_result
-
+      
     - name: Wait until the pumba sig-kill job is completed
       shell: >
         kubectl get pods -l job-name=pumba-sig-kill-{{ chaos_uid }} --no-headers -n {{ namespace }}

--- a/experiments/generic/container_kill/container_kill_ansible_logic.yml
+++ b/experiments/generic/container_kill/container_kill_ansible_logic.yml
@@ -11,6 +11,7 @@
     a_label: "{{ lookup('env','APP_LABEL') }}"
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}" 
 
   tasks:
     - block:
@@ -45,6 +46,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "container-kill"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## FAULT INJECTION 
 
         - include_tasks: "{{ c_util }}"
@@ -61,7 +70,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"      
             delay: 2
-            retries: 90        
+            retries: 90
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "container-kill"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/generic/disk_fill/disk_fill_ansible_logic.yml
+++ b/experiments/generic/disk_fill/disk_fill_ansible_logic.yml
@@ -14,6 +14,7 @@
     fill_percentage: "{{ lookup('env','FILL_PERCENTAGE') }}"
     auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
     
   tasks:
     - block:
@@ -61,6 +62,14 @@
 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "disk-fill"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## FAULT INJECTION 
 
         - include_tasks: "{{ c_util }}"
@@ -75,8 +84,8 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"      
             delay: 2
-            retries: 90    
-            
+            retries: 90  
+              
          # Auxiliary application health check status
         - block:
 
@@ -90,6 +99,14 @@
               - "{{ auxiliary_appinfo_list }}" 
 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "disk-fill"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/generic/disk_loss/disk_loss_ansible_logic.yml
+++ b/experiments/generic/disk_loss/disk_loss_ansible_logic.yml
@@ -16,6 +16,7 @@
     project_id: "{{ lookup('env','PROJECT_ID') }}"
     zone_name: "{{ lookup('env','ZONE_NAME') }}"
     auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
 
@@ -65,6 +66,14 @@
               - "{{ auxiliary_appinfo_list }}" 
 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
+
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "PreChaosCheck"
+          exp_pod_name: "disk-loss"
+          engine_ns: "{{ a_ns }}"
+          message: "AUT is Running successfully"
 
         # Gcloud authentication
         - name: Gcloud authentication
@@ -121,6 +130,14 @@
               - "{{ auxiliary_appinfo_list }}" 
 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "PostChaosCheck"
+          exp_pod_name: "disk-loss"
+          engine_ns: "{{ a_ns }}"
+          message: "AUT is Running successfully"
 
         ## POST-CHAOS DISK LIVENESS CHECK
         - name: Verify that the disk is connected to node (post)

--- a/experiments/generic/node_cpu_hog/node_cpu_hog_ansible_logic.yml
+++ b/experiments/generic/node_cpu_hog/node_cpu_hog_ansible_logic.yml
@@ -12,6 +12,7 @@
     a_platform: "{{ lookup('env', 'PLATFORM') }}"
     auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
 
@@ -61,6 +62,14 @@
               - "{{ auxiliary_appinfo_list }}" 
 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
+
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "node-cpu-hog"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
          ## READY TO HOG THE NODE CPU
         - name: Ready to hog the node cpu
@@ -121,6 +130,14 @@
             when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
 
           when: node_status is defined and node_status.stdout != 'Ready'
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "node-cpu-hog"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/generic/node_drain/node_drain_ansible_logic.yml
+++ b/experiments/generic/node_drain/node_drain_ansible_logic.yml
@@ -11,7 +11,8 @@
     c_experiment: "node-drain"
     liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
     liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-    auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"  
+    auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"  
 
   tasks:
     - block:
@@ -78,12 +79,22 @@
                 
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "node-drain"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+            
         ## STORAGE FAULT INJECTION 
 
         - include_tasks: /chaoslib/litmus/cordon_drain_node.yml
           vars: 
             app_ns: "{{ a_ns }}"
             app_node: "{{ a_node }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
           include_tasks: "/utils/common/status_app_pod.yml"
@@ -107,7 +118,13 @@
               
           when: auxiliary_appinfo is defined and auxiliary_appinfo != ''
 
-        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "node-drain"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - include_tasks: /utils/common/application_liveness_check.yml
           when: liveness_label != ''

--- a/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml
+++ b/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml
@@ -14,6 +14,7 @@
     a_kind: "{{ lookup('env','APP_KIND') }}"
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
     - block:
@@ -46,6 +47,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "pod-cpu-hog"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## FAULT INJECTION 
         - include_tasks: "{{ c_util }}"
           vars:
@@ -59,7 +68,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90       
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "pod-cpu-hog"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
 
         - set_fact:

--- a/experiments/generic/pod_delete/pod_delete_ansible_logic.yml
+++ b/experiments/generic/pod_delete/pod_delete_ansible_logic.yml
@@ -15,6 +15,7 @@
     a_kind: "{{ lookup('env','APP_KIND') }}"
     kill_count: "{{ lookup('env','KILL_COUNT') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}" 
   
   tasks:
     - block:
@@ -38,7 +39,7 @@
           vars:
             status: 'SOT'
             namespace: "{{ a_ns }}"
-
+     
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify that the AUT (Application Under Test) is running 
@@ -49,13 +50,21 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "pod-delete"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+            
         ## FAULT INJECTION 
 
         - include_tasks: "{{ c_util }}"
           vars:
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"
-          
+   
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
@@ -64,7 +73,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90   
+            
+        ## RECORD EVENT FOR POST CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "pod-delete"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/generic/pod_network_corruption/pod_network_corruption_ansible_logic.yml
+++ b/experiments/generic/pod_network_corruption/pod_network_corruption_ansible_logic.yml
@@ -15,6 +15,7 @@
     a_kind: "{{ lookup('env','APP_KIND') }}" # will be used in the future
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
     - block:
@@ -37,7 +38,7 @@
           vars: 
             status: 'SOT'
             namespace: "{{ a_ns }}"
-
+            
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
         - name: Verify that the AUT (Application Under Test) is running 
           include_tasks: "/utils/common/status_app_pod.yml"
@@ -46,6 +47,14 @@
             app_label: "{{ a_label }}"       
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "pod-network-corruption"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## FAULT INJECTION 
         - include_tasks: "{{ c_util }}"
@@ -59,7 +68,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90 
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "pod-network-corruption"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
 
         - set_fact:

--- a/experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml
+++ b/experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml
@@ -15,6 +15,7 @@
     a_kind: "{{ lookup('env','APP_KIND') }}"
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
     
   tasks:
     - block:
@@ -47,6 +48,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "pod-network-latency"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## FAULT INJECTION 
         - include_tasks: "{{ c_util }}"
           vars:
@@ -59,7 +68,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "pod-network-latency"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
 
         - set_fact:

--- a/experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml
+++ b/experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml
@@ -15,6 +15,7 @@
     a_kind: "{{ lookup('env','APP_KIND') }}"
     lib_image: "{{ lookup('env','LIB_IMAGE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
     - block:
@@ -47,6 +48,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "pod-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## FAULT INJECTION 
         - include_tasks: "{{ c_util }}"
           vars:
@@ -59,7 +68,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"    
             delay: 2
-            retries: 90        
+            retries: 90
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "pod-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-ansible-logic.yml
@@ -23,7 +23,8 @@
     zk_ns: "{{ lookup('env','ZOOKEEPER_NAMESPACE') }}"
     zk_label: "{{ lookup('env','ZOOKEEPER_LABEL') }}"
     zk_service: "{{ lookup('env','ZOOKEEPER_SERVICE') }}"
-    zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}" 
+    zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}" 
 
   tasks:
     - block:
@@ -66,6 +67,14 @@
           vars:     
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "PreChaosCheck"
+          exp_pod_name: "kafka-broker-disk-failure"
+          engine_ns: "{{ a_ns }}"
+          message: "AUT is Running successfully"
 
         - name: Derive the kafka-broker node name
           shell: 
@@ -120,6 +129,14 @@
                 app_label: "name=kafka-liveness" 
                 delay: 2
                 retries: 90
+
+            ## RECORD EVENT FOR POST-CHAOS CHECK
+            - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+              vars:
+                stage: "PostChaosCheck"
+                exp_pod_name: "kafka-broker-disk-failure"
+                engine_ns: "{{ a_ns }}"
+                message: "AUT is Running successfully"
 
             - include_tasks: "/utils/apps/kafka/kafka_liveness_cleanup.yml"
 

--- a/experiments/kafka/kafka-broker-network-latency/kafka-broker-network-latency-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-network-latency/kafka-broker-network-latency-ansible-logic.yml
@@ -26,6 +26,7 @@
     zk_service: "{{ lookup('env','ZOOKEEPER_SERVICE') }}"
     zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}" 
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
     - block:
@@ -58,6 +59,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "kafka-broker-network-latency"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## SETUP KAFKA CHAOS INFRA AND DERIVE BROKERS UNDER TEST
        
         - include_tasks: "{{ kafka_broker_util }}" 
@@ -80,6 +89,14 @@
           vars:     
             delay: 2
             retries: 90
+
+         ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "kafka-broker-network-latency"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## CHECK FOR KAFKA LIVENESS & CLEANUP
 

--- a/experiments/kafka/kafka-broker-network-loss/kafka-broker-network-loss-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-network-loss/kafka-broker-network-loss-ansible-logic.yml
@@ -26,6 +26,7 @@
     zk_service: "{{ lookup('env','ZOOKEEPER_SERVICE') }}"
     zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}" 
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   tasks:
     - block:
@@ -58,6 +59,14 @@
             delay: 2
             retries: 90
 
+         ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "kafka-broker-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## SETUP KAFKA CHAOS INFRA AND DERIVE BROKERS UNDER TEST
        
         - include_tasks: "{{ kafka_broker_util }}" 
@@ -80,6 +89,14 @@
           vars:     
             delay: 2
             retries: 90
+
+         ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "kafka-broker-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## CHECK FOR KAFKA LIVENESS & CLEANUP
 

--- a/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
+++ b/experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml
@@ -26,7 +26,8 @@
     zk_label: "{{ lookup('env','ZOOKEEPER_LABEL') }}"
     zk_service: "{{ lookup('env','ZOOKEEPER_SERVICE') }}"
     zk_port: "{{ lookup('env','ZOOKEEPER_PORT') }}"
-    chaos_uid: "{{ lookup('env','CHAOS_UID') }}" 
+    chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}" 
 
   tasks:
     - block:
@@ -59,6 +60,14 @@
             delay: 2
             retries: 90
 
+         ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "kafka-broker-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         ## SETUP KAFKA CHAOS INFRA AND DERIVE BROKERS UNDER TEST
        
         - include_tasks: "{{ kafka_broker_util }}" 
@@ -79,6 +88,14 @@
           vars:     
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "kafka-broker-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## CHECK FOR KAFKA LIVENESS & CLEANUP
 

--- a/experiments/openebs/openebs-control-plane-chaos/openebs_control_plane_chaos_ansible_logic.yml
+++ b/experiments/openebs/openebs-control-plane-chaos/openebs_control_plane_chaos_ansible_logic.yml
@@ -11,6 +11,7 @@
     c_svc_acc: "{{ lookup('env','CHAOS_SERVICE_ACCOUNT') }}"
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     kill_count: "{{ lookup('env','KILL_COUNT') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
     
   tasks:
     - block:
@@ -39,10 +40,26 @@
             status: 'SOT'
             namespace: "{{ openebs_ns }}"
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-control-plane-chaos"
+            engine_ns: "{{ openebs_ns }}"
+            message: "AUT is Running successfully"
+
         ## INJECT CHAOS ON CONTROL PLANE COMPONENTS
         - name: Including main components
           include_tasks: openebs_control_plane_chaos_internal_tasks.yml
           loop: "{{ openebs.components }}"
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-control-plane-chaos"
+            engine_ns: "{{ openebs_ns }}"
+            message: "AUT is Running successfully"
 
         - set_fact:
             flag: "Pass"

--- a/experiments/openebs/openebs-pool-container-failure/openebs_pool_container_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-container-failure/openebs_pool_container_failure_ansible_logic.yml
@@ -15,6 +15,7 @@
     openebs_ns: "{{ lookup('env','OPENEBS_NS') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
     pool_debug_msg: 'uncorrectable I/O failure|suspended|ERROR ZFS event'
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
     
   vars_files:
     - /mnt/parameters.yml
@@ -88,6 +89,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-pool-container-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Create some test data 
           include: "{{ data_consistency_util_path }}"
           vars:
@@ -110,6 +119,14 @@
             app_label: "{{ a_label }}" 
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-pool-container-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
  
         - name: Verify application data persistence  
           include: "{{ data_consistency_util_path }}"

--- a/experiments/openebs/openebs-pool-network-delay/openebs_pool_network_delay_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-network-delay/openebs_pool_network_delay_ansible_logic.yml
@@ -15,6 +15,7 @@
     n_delay: "{{ lookup('env','NETWORK_DELAY') }}" 
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -66,6 +67,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-pool-network-delay"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers -o=custom-columns=NAME:".metadata.name"
@@ -101,6 +110,14 @@
             app_label: "{{ a_label }}"      
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-pool-container-delay"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - name: Verify application data persistence  
           include: "{{ consistencyutil }}"

--- a/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_ansible_logic.yml
@@ -14,6 +14,7 @@
     packet_loss_perc: "{{ lookup('env','NETWORK_PACKET_LOSS_PERCENTAGE') }}"  
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -65,6 +66,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-pool-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers -o=custom-columns=NAME:".metadata.name"
@@ -100,6 +109,14 @@
             app_label: "{{ a_label }}"      
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-pool-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - name: Verify application data persistence  
           include: "{{ consistencyutil }}"

--- a/experiments/openebs/openebs-pool-pod-failure/openebs_pool_pod_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-pod-failure/openebs_pool_pod_failure_ansible_logic.yml
@@ -16,6 +16,7 @@
     liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
     openebs_ns: openebs
     pool_debug_msg: 'uncorrectable I/O failure|suspended|ERROR ZFS event'
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
    
   vars_files:
     - /mnt/parameters.yml
@@ -91,6 +92,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-pool-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - block:
 
             - name: Get application pod name 
@@ -129,6 +138,14 @@
             app_label: "{{ a_label }}" 
             delay: 2
             retries: 90
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-pool-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         - block:
           

--- a/experiments/openebs/openebs-target-container-failure/openebs_target_container_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-container-failure/openebs_target_container_failure_ansible_logic.yml
@@ -19,6 +19,7 @@
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -87,6 +88,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-target-container-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers
@@ -119,7 +128,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90   
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-target-container-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /utils/common/application_liveness_check.yml

--- a/experiments/openebs/openebs-target-network-delay/openebs_target_network_delay_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-network-delay/openebs_target_network_delay_ansible_logic.yml
@@ -15,6 +15,7 @@
     n_delay: "{{ lookup('env','NETWORK_DELAY') }}" 
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -84,6 +85,14 @@
             delay: 2
             retries: 90 
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-target-network-delay"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name 
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers
@@ -113,6 +122,14 @@
             app_label: "{{ a_label }}" 
             delay: 2
             retries: 90 
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-target-network-delay"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
             
         - include_tasks: /utils/common/application_liveness_check.yml
           when: liveness_label != ''

--- a/experiments/openebs/openebs-target-network-loss/openebs_target_network_loss_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-network-loss/openebs_target_network_loss_ansible_logic.yml
@@ -16,6 +16,7 @@
     packet_loss_perc: "{{ lookup('env','NETWORK_PACKET_LOSS_PERCENTAGE') }}"  
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
     chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -84,6 +85,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-target-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers
@@ -113,6 +122,14 @@
             app_label: "{{ a_label }}" 
             delay: 2
             retries: 90 
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-target-network-loss"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
             
         - include_tasks: /utils/common/application_liveness_check.yml
           when: liveness_label != ''

--- a/experiments/openebs/openebs-target-pod-failure/openebs_target_pod_failure_ansible_logic.yml
+++ b/experiments/openebs/openebs-target-pod-failure/openebs_target_pod_failure_ansible_logic.yml
@@ -15,6 +15,7 @@
     liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
     liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
     openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"
+    engine_name: "{{ lookup('env','CHAOSENGINE') }}"
 
   vars_files:
     - /mnt/parameters.yml
@@ -83,6 +84,14 @@
             delay: 2
             retries: 90
 
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "openebs-target-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
+
         - name: Get application pod name
           shell: >
             kubectl get pods -n {{ a_ns }} -l {{ a_label }} --no-headers
@@ -115,7 +124,15 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"     
             delay: 2
-            retries: 90        
+            retries: 90   
+            
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "openebs-target-pod-failure"
+            engine_ns: "{{ a_ns }}"
+            message: "AUT is Running successfully"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /utils/common/application_liveness_check.yml

--- a/utils/common/generate-kubernetes-chaos-events.yml
+++ b/utils/common/generate-kubernetes-chaos-events.yml
@@ -1,0 +1,35 @@
+- name: Obtain the date in ISO8601 format
+  shell: date --iso-8601=seconds
+  register: date_from_linux_shell
+
+- set_fact:
+    ts: "{{ date_from_linux_shell.stdout.split('+')[0] + 'Z'}}"
+
+- name: Create an test event on the chaosengine
+  k8s:
+   state: present
+   definition:
+    apiVersion: v1
+    kind: Event
+    metadata:
+     # standardize for stages for experiment
+     name: event-"{{ stage }}"
+     namespace: "{{ engine_ns }}"
+    message: "{{ message }}"
+    # change this as per stage of experiment
+    reason: "{{ stage }}"
+    source: 
+     # this needs to be replaced by the exp job/pod name
+     component: "{{ exp_pod_name }}"
+    type: Normal
+    count: 1
+    firstTimestamp: "{{ ts }}"
+    involvedObject:
+     apiVersion: litmuschaos.io/v1alpha1
+     kind: ChaosEngine
+     # this needs to be replaced by actual chaosengine name
+     name: "{{ engine_name }}"
+     # this needs to be replaced by actual resource ns
+     namespace: "{{ engine_ns }}"
+     ## uid is passed as env from chaos-runner
+     uid: "{{ chaos_uid }}"


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding event generation support in all experiments for the following sections:
    - pre-chaos check
    - post-chaos check
    - chaos injection
    - summary 

- sample events for pod-delete exp (if pass)
```Events:
  Type    Reason               Age    From                     Message
  ----    ------               ----   ----                     -------
  Normal  ChaosInject          53s    pod-delete-1dp2j9-bd98p  Injecting pod-delete chaos on nginx1-88b9989dd-b8cnf pod
  Normal  PostChaosCheck       13s    pod-delete-1dp2j9-bd98p  AUT is Running successfully
  Normal  PreChaosCheck        2m1s   pod-delete-1dp2j9-bd98p  AUT is Running successfully
  Normal  Summary              10s    pod-delete-1dp2j9-bd98p  pod-delete Experiment Passed!
  Normal  ChaosEngine Started  2m27s  chaos-operator           Creating the experiment resources allocated to ChaosEngine: engine, in Namespace: shubham

```
- sample event for pod-delete exp ( if fails)
```
Events:
  Type    Reason               Age   From                     Message
  ----    ------               ----  ----                     -------
  Normal  PreChaosCheck        42s   pod-delete-y3uh1m-thjbn  AUT is Running successfully
  Normal  Summary              13s   pod-delete-y3uh1m-thjbn  pod-delete Experiment Failed!
  Normal  ChaosEngine Started  67s   chaos-operator           Creating the experiment resources allocated to ChaosEngine: engine, in Namespace: shubham
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1244 Events:
  Type    Reason               Age    From                     Message
  ----    ------               ----   ----                     -------
  Normal  ChaosInject          53s    pod-delete-1dp2j9-bd98p  Injecting pod-delete chaos on nginx1-88b9989dd-b8cnf pod
  Normal  PostChaosCheck       13s    pod-delete-1dp2j9-bd98p  AUT is Running successfully
  Normal  PreChaosCheck        2m1s   pod-delete-1dp2j9-bd98p  AUT is Running successfully
  Normal  Summary              10s    pod-delete-1dp2j9-bd98p  pod-delete Experiment Passed!
  Normal  ChaosEngine Started  2m27s  chaos-operator           Creating the experiment resources allocated to ChaosEngine: engine, in Namespace: shubham


**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
