### PR TITLE
bug-fix(jinja-template): Adding checks for chaos-uid in all jinja templates

### DIFF
--- a/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
+++ b/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: containerd-chaos
+  name: containerd-chaos-{{ run_id }}
   labels:
-    app: crictl
-{% if c_engine is defined and c_engine != '' %}        
+    name: containerd-chaos
+{% if chaos_uid is defined and chaos_uid != '' %}        
     chaosUID: {{ chaos_uid }}
 {% endif %}        
 spec:
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         app: crictl
-{% if c_engine is defined and c_engine != '' %}        
+{% if chaos_uid is defined and chaos_uid != '' %}        
         chaosUID: {{ chaos_uid }}
 {% endif %}        
     spec:

--- a/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
+++ b/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
@@ -3,13 +3,18 @@ kind: Job
 metadata:
   name: containerd-chaos
   labels:
+    app: crictl
+{% if c_engine is defined and c_engine != '' %}        
     chaosUID: {{ chaos_uid }}
+{% endif %}        
 spec:
   template:
     metadata:
       labels:
         app: crictl
+{% if c_engine is defined and c_engine != '' %}        
         chaosUID: {{ chaos_uid }}
+{% endif %}        
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{ app_node }}

--- a/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
+++ b/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
@@ -1,19 +1,18 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-{% if c_engine is defined and c_engine != '' %}
   name: app-cpu-stress-{{ run_id }}
-{% else %}
-  name: app-cpu-stress
-{% endif %}
-  labels: 
+  labels:
+    app: app-cpu-stress  
+{% if chaos_uid is defined and chaos_uid != '' %}        
     chaosUID: {{ chaos_uid }}
+{% endif %}   
 spec:
   template:
     metadata:
       labels:
         app: app-cpu-stress
-{% if c_engine is defined and c_engine != '' %}        
+{% if chaos_uid is defined and chaos_uid != '' %}        
         chaosUID: {{ chaos_uid }}
 {% endif %}        
     spec:

--- a/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
+++ b/chaoslib/litmus/cpu_hog/app_cpu_stress.j2
@@ -1,7 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+{% if c_engine is defined and c_engine != '' %}
   name: app-cpu-stress-{{ run_id }}
+{% else %}
+  name: app-cpu-stress
+{% endif %}
   labels: 
     chaosUID: {{ chaos_uid }}
 spec:
@@ -9,7 +13,9 @@ spec:
     metadata:
       labels:
         app: app-cpu-stress
+{% if c_engine is defined and c_engine != '' %}        
         chaosUID: {{ chaos_uid }}
+{% endif %}        
     spec:
       nodeSelector:
         ## mandatory: provide name of host where target container resides

--- a/chaoslib/litmus/disk_fill/disk_fill_job.j2
+++ b/chaoslib/litmus/disk_fill/disk_fill_job.j2
@@ -3,13 +3,17 @@ kind: Job
 metadata:
   name: disk-fill
   labels:
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   template:
     metadata:
       labels:
         app: disk-fill
+{% if c_engine is defined and c_engine != '' %}
         chaosUID: {{ chaos_uid }}
+{% endif %}
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{ app_node }}

--- a/chaoslib/litmus/disk_fill/disk_fill_job.j2
+++ b/chaoslib/litmus/disk_fill/disk_fill_job.j2
@@ -1,9 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: disk-fill
+  name: disk-fill-{{ run_id }}
   labels:
-{% if c_engine is defined and c_engine != '' %}
+    app: disk-fill
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
@@ -11,7 +12,7 @@ spec:
     metadata:
       labels:
         app: disk-fill
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
 {% endif %}
     spec:

--- a/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
@@ -1,14 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-{% if c_engine is defined and c_engine != '' %}
-  name: node-cpu-hog-{{ chaos_uid }}
-{% else %}
-  name: node-cpu-hog
-{% endif %}
+  name: node-cpu-hog-{{ run_id }}
   labels: 
     app: node-cpu-hog
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
@@ -16,7 +12,7 @@ spec:
     metadata:
       labels:
         app: node-cpu-hog
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
 {% endif %}
     spec:

--- a/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
@@ -1,15 +1,24 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+{% if c_engine is defined and c_engine != '' %}
   name: node-cpu-hog-{{ chaos_uid }}
+{% else %}
+  name: node-cpu-hog
+{% endif %}
   labels: 
+    app: node-cpu-hog
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   template:
     metadata:
       labels:
         app: node-cpu-hog
+{% if c_engine is defined and c_engine != '' %}
         chaosUID: {{ chaos_uid }}
+{% endif %}
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{ node_name }}

--- a/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
@@ -4,6 +4,7 @@ metadata:
   name: node-memory-hog-{{ run_id }}
   labels:
     app: memory-hog
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:

--- a/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
@@ -1,9 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: node-memory-hog
+  name: node-memory-hog-{{ run_id }}
   labels:
-{% if c_engine is defined and c_engine != '' %}
+    app: memory-hog
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
@@ -11,7 +12,9 @@ spec:
     metadata:
       labels:
         app: memory-hog
+{% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
+{% endif %}
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{ node_name }}

--- a/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
@@ -2,8 +2,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: node-memory-hog
-  labels: 
+  labels:
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   template:
     metadata:

--- a/chaoslib/litmus/platform/gke/node_cpu_consumption.yml
+++ b/chaoslib/litmus/platform/gke/node_cpu_consumption.yml
@@ -21,11 +21,15 @@
     - set_fact:
         cpu_limit: "{{ c_limit | json_query('resources[0].status.capacity.cpu') }}"
 
-    - name: Patch the engine uid
-      template:
-        src:  /chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
-        dest: /chaoslib/litmus/platform/gke/node-cpu-hog-job.yml
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
 
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+  
     ## RECORD EVENT FOR CHAOS INJECTION
     - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
       vars:
@@ -33,7 +37,12 @@
         exp_pod_name: "{{ chaos_pod_name }}"
         engine_ns: "{{ a_ns }}"
         message: "Injecting {{ c_experiment }} chaos on {{ node_name }} node"
-      when: "c_engine is defined and c_engine != ''"
+      when: "c_engine is defined and c_engine != ''"        
+
+    - name: Patch the engine uid
+      template:
+        src:  /chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
+        dest: /chaoslib/litmus/platform/gke/node-cpu-hog-job.yml
       
     - name: Wait for the specified ramp time before injecting chaos
       wait_for: timeout="{{ ramp_time }}"
@@ -50,7 +59,7 @@
     ## WAIT UNTIL THE JOB IS COMPLETED
     - name: Wait until the node cpu hog job is completed
       shell: >
-        kubectl get pods -l app=node-cpu-hog --no-headers -n {{ a_ns }}
+        kubectl get pods -l job-name=node-cpu-hog-{{ run_id }} --no-headers -n {{ a_ns }}
         --no-headers -o custom-columns=:status.phase
       args: 
         executable: /bin/bash
@@ -82,7 +91,7 @@
       k8s_facts:
         kind: Job
         label_selectors:
-          - app=node-cpu-hog
+          - job-name=node-cpu-hog-{{ run_id }}
       register: resource_job
       until: "resource_job.resources | length < 1"
       delay: 2
@@ -102,7 +111,7 @@
           k8s_facts:
             kind: Job
             label_selectors:
-              - app=node-cpu-hog
+              - job-name=node-cpu-hog-{{ run_id }}
           register: resource_job
           until: "resource_job.resources | length < 1"
           delay: 2

--- a/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
+++ b/chaoslib/powerfulseal/pod_failure_by_powerfulseal.yml
@@ -12,6 +12,15 @@
         engine_ns: "{{ a_ns }}"
         message: "Injecting {{ c_experiment }} chaos on application pod"
       when: "c_engine is defined and c_engine != ''"
+
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
     
     - name: Generate the powerfulseal deployment spec from template
       template:
@@ -28,7 +37,7 @@
 
     - name: Confirm that powerfulseal pod is running
       shell: >
-        kubectl get pod -l name=powerfulseal --no-headers -n {{ app_ns }}
+        kubectl get pod -l name=powerfulseal-{{ run_id }} --no-headers -n {{ app_ns }}
       args:
         executable: /bin/bash
       register: result
@@ -55,7 +64,7 @@
       k8s_facts:
         kind: Deployment
         label_selectors:
-          - name=powerfulseal
+          - name=powerfulseal-{{ run_id }}
       register: resource_deployment
       until: "resource_deployment.resources | length < 1"
       delay: 2
@@ -76,7 +85,7 @@
           k8s_facts:
             kind: Deployment
             label_selectors:
-              - name=powerfulseal
+              - name=powerfulseal-{{ run_id }}
           register: resource_deployment
           until: "resource_deployment.resources | length < 1"
           delay: 2

--- a/chaoslib/powerfulseal/powerfulseal.j2
+++ b/chaoslib/powerfulseal/powerfulseal.j2
@@ -26,25 +26,26 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: powerfulseal
+  name: powerfulseal-{{ run_id }}
   labels:
-    name: powerfulseal
-{% if c_engine is defined and c_engine != '' %}
+    name: powerfulseal--{{ run_id }}
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
   selector:
     matchLabels:
-      name: powerfulseal
-{% if c_engine is defined and c_engine != '' %}
-    chaosUID: {{ chaos_uid }}
-{% endif %}  replicas: 1
+      name: powerfulseal-{{ run_id }}
+{% if chaos_uid is defined and chaos_uid != '' %}
+      chaosUID: {{ chaos_uid }}
+{% endif %}
+  replicas: 1
   template:
     metadata:
       labels:
         name: powerfulseal
-{% if c_engine is defined and c_engine != '' %}
-    chaosUID: {{ chaos_uid }}
+{% if chaos_uid is defined and chaos_uid != '' %}
+        chaosUID: {{ chaos_uid }}
 {% endif %}
     spec:
       serviceAccountName: {{ c_svc_acc }}

--- a/chaoslib/powerfulseal/powerfulseal.j2
+++ b/chaoslib/powerfulseal/powerfulseal.j2
@@ -28,18 +28,24 @@ kind: Deployment
 metadata:
   name: powerfulseal
   labels:
+    name: powerfulseal
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   selector:
     matchLabels:
       name: powerfulseal
-      chaosUID: {{ chaos_uid }}
-  replicas: 1
+{% if c_engine is defined and c_engine != '' %}
+    chaosUID: {{ chaos_uid }}
+{% endif %}  replicas: 1
   template:
     metadata:
       labels:
         name: powerfulseal
-        chaosUID: {{ chaos_uid }}
+{% if c_engine is defined and c_engine != '' %}
+    chaosUID: {{ chaos_uid }}
+{% endif %}
     spec:
       serviceAccountName: {{ c_svc_acc }}
       terminationGracePeriodSeconds: 0

--- a/chaoslib/powerfulseal/powerfulseal.j2
+++ b/chaoslib/powerfulseal/powerfulseal.j2
@@ -28,7 +28,7 @@ kind: Deployment
 metadata:
   name: powerfulseal-{{ run_id }}
   labels:
-    name: powerfulseal--{{ run_id }}
+    name: powerfulseal-{{ run_id }}
 {% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}

--- a/chaoslib/powerfulseal/powerfulseal.j2
+++ b/chaoslib/powerfulseal/powerfulseal.j2
@@ -43,7 +43,7 @@ spec:
   template:
     metadata:
       labels:
-        name: powerfulseal
+        name: powerfulseal-{{ run_id }}
 {% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
 {% endif %}

--- a/chaoslib/pumba/network_chaos/pumba_netem_job.j2
+++ b/chaoslib/pumba/network_chaos/pumba_netem_job.j2
@@ -2,15 +2,19 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: pumba-netem-{{ run_id }}
-  labels: 
+  labels:
+{% if c_engine is defined and c_engine != '' %}  
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   template:
     metadata:
       labels:
         app: pumba
-        chaosUID: {{ chaos_uid }}
         com.gaiaadm.pumba: "true"
+{% if c_engine is defined and c_engine != '' %}
+        chaosUID: {{ chaos_uid }}
+{% endif %}
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{ app_node }}  

--- a/chaoslib/pumba/network_chaos/pumba_netem_job.j2
+++ b/chaoslib/pumba/network_chaos/pumba_netem_job.j2
@@ -3,7 +3,8 @@ kind: Job
 metadata:
   name: pumba-netem-{{ run_id }}
   labels:
-{% if c_engine is defined and c_engine != '' %}  
+    app: pumba
+{% if chaos_uid is defined and chaos_uid != '' %}  
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
@@ -12,7 +13,7 @@ spec:
       labels:
         app: pumba
         com.gaiaadm.pumba: "true"
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
 {% endif %}
     spec:

--- a/chaoslib/pumba/pod_failure_by_sigkill.yml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yml
@@ -25,6 +25,15 @@
     - set_fact: 
         app_node: "{{ app_node.stdout }}"
 
+      - block: 
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+        when: "run_id is not defined or run_id == ''"        
+
     - block:
         - name: Record the application container
           shell: >
@@ -87,7 +96,7 @@
       
     - name: Wait until the pumba sig-kill job is completed
       shell: >
-        kubectl get pods -l job-name=pumba-sig-kill-{{ chaos_uid }} --no-headers -n {{ namespace }}
+        kubectl get pods -l job-name=pumba-sig-kill-{{ run_id }} --no-headers -n {{ namespace }}
         --no-headers -o custom-columns=:status.phase
       args: 
         executable: /bin/bash
@@ -119,7 +128,7 @@
 
     - name: Confirm that the pumba job is deleted successfully
       shell: >
-        kubectl get pods -l app=pumba --no-headers -n {{ namespace }}
+        kubectl get pods -l job-name=pumba-sig-kill-{{ run_id }} --no-headers -n {{ namespace }}
       args:
         executable: /bin/bash
       register: result
@@ -140,7 +149,7 @@
         
         - name: Confirm that the pumba job is not present
           shell: >
-            kubectl get pods -l app=pumba --no-headers -n {{ namespace }}
+            kubectl get pods -l job-name=pumba-sig-kill-{{ run_id }} --no-headers -n {{ namespace }}
           args:
             executable: /bin/bash
           register: result

--- a/chaoslib/pumba/pod_failure_by_sigkill.yml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yml
@@ -33,15 +33,6 @@
         - set_fact:
             run_id: "{{ rand_string.stdout | lower }}"
         when: "run_id is not defined or run_id == ''"        
-
-    - block:
-        - name: Generate a run id if not passed from the engine/experiment
-          shell: echo $(mktemp) | cut -d '.' -f 2 
-          register: rand_string   
-
-        - set_fact:
-            run_id: "{{ rand_string.stdout | lower }}"
-      when: "run_id is not defined or run_id == ''"
     
     - block:
         - name: Record the application container

--- a/chaoslib/pumba/pumba.j2
+++ b/chaoslib/pumba/pumba.j2
@@ -1,15 +1,23 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+{% if c_engine is defined and c_engine != '' %}
   name: pumba-sig-kill-{{ chaos_uid }}
+{% else %}
+  name: pumba-sig-kill
+{% endif %}
   labels: 
+{% if c_engine is defined and c_engine != '' %}  
     chaosUID: {{ chaos_uid }}
+{% endif %}
 spec:
   template:
     metadata:
       labels:
         app: pumba
+{% if c_engine is defined and c_engine != '' %}
         chaosUID: {{ chaos_uid }}
+{% endif %}
         # prevent pumba from killing itself
         com.gaiaadm.pumba: "true"
     spec:

--- a/chaoslib/pumba/pumba.j2
+++ b/chaoslib/pumba/pumba.j2
@@ -1,13 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-{% if c_engine is defined and c_engine != '' %}
-  name: pumba-sig-kill-{{ chaos_uid }}
-{% else %}
-  name: pumba-sig-kill
-{% endif %}
+  name: pumba-sig-kill-{{ run_id }}
   labels: 
-{% if c_engine is defined and c_engine != '' %}  
+    app: pumba
+{% if chaos_uid is defined and chaos_uid != '' %}  
     chaosUID: {{ chaos_uid }}
 {% endif %}
 spec:
@@ -15,7 +12,7 @@ spec:
     metadata:
       labels:
         app: pumba
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
         chaosUID: {{ chaos_uid }}
 {% endif %}
         # prevent pumba from killing itself

--- a/experiments/coredns/pod_delete/liveness-app.j2
+++ b/experiments/coredns/pod_delete/liveness-app.j2
@@ -3,7 +3,9 @@ kind: Pod
 metadata:
   labels:
     run: liveness-app
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}    
   name: liveness-app
   namespace: {{ c_ns }}
 spec:

--- a/experiments/coredns/pod_delete/liveness-app.j2
+++ b/experiments/coredns/pod_delete/liveness-app.j2
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   labels:
     run: liveness-app
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}    
   name: liveness-app

--- a/experiments/coredns/pod_delete/nginx.j2
+++ b/experiments/coredns/pod_delete/nginx.j2
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   labels:
     run: nginx
-{% if c_engine is defined and c_engine != '' %}
+{% if chaos_uid is defined and chaos_uid != '' %}
     chaosUID: {{ chaos_uid }}
 {% endif %}
   name: nginx

--- a/experiments/coredns/pod_delete/nginx.j2
+++ b/experiments/coredns/pod_delete/nginx.j2
@@ -3,7 +3,9 @@ kind: Pod
 metadata:
   labels:
     run: nginx
+{% if c_engine is defined and c_engine != '' %}
     chaosUID: {{ chaos_uid }}
+{% endif %}
   name: nginx
   namespace: {{ c_ns }}
 spec:


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

Issue it resolve: https://github.com/litmuschaos/litmus/issues/1292

**What this PR does / why we need it**:
**_This PR is for:_**

- Adding checks for chaos-uid in all jinja templates

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
