### PR TITLE
Feat(Openebs-pool-disk-loss): Adding event support for openebs pool disk loss experiment

### DIFF
--- a/experiments/openebs/openebs-pool-disk-loss/openebs_pool_disk_loss_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-disk-loss/openebs_pool_disk_loss_ansible_logic.yml
@@ -167,7 +167,7 @@
           stage: "PostChaosCheck"
           exp_pod_name: "{{ chaos_pod_name }}"
           engine_ns: "{{ a_ns }}"
-          message: "AUT is Running successfully"
+          message: "Disk has been reattached and AUT is Running successfully"
         when: "c_engine is defined and c_engine != ''"
     
 

--- a/experiments/openebs/openebs-pool-disk-loss/openebs_pool_disk_loss_ansible_logic.yml
+++ b/experiments/openebs/openebs-pool-disk-loss/openebs_pool_disk_loss_ansible_logic.yml
@@ -57,7 +57,7 @@
       - name: AWS authentication
         include_tasks: "/utils/cloud/aws/aws_configure.yml"
         when: "cloud_platform == 'AWS'"
-
+        
       ## PRE-CHAOS DISK LIVENESS CHECK
       - name: Verify that the disk is connected to node (pre)
         include_tasks: "/utils/cloud/gcp/status_disk.yml"
@@ -83,6 +83,15 @@
           app_label: "{{ a_label }}"      
           delay: 2
           retries: 90
+
+      ## RECORD EVENT FOR PRE-CHAOS CHECK
+      - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "PreChaosCheck"
+          exp_pod_name: "{{ chaos_pod_name }}"
+          engine_ns: "{{ a_ns }}"
+          message: "AUT is Running successfully"
+        when: "c_engine is defined and c_engine != ''"
 
       # Auxiliary application health check status
       - block:
@@ -151,6 +160,16 @@
           app_label: "{{ a_label }}"      
           delay: 2
           retries: 90
+      
+      ## RECORD EVENT FOR POST-CHAOS CHECK
+      - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        vars:
+          stage: "PostChaosCheck"
+          exp_pod_name: "{{ chaos_pod_name }}"
+          engine_ns: "{{ a_ns }}"
+          message: "AUT is Running successfully"
+        when: "c_engine is defined and c_engine != ''"
+    
 
       - block:
 
@@ -193,6 +212,9 @@
             flag: "Fail"
 
       always:
+        ## Getting failure step from experiment-pod
+        - include_tasks: /utils/runtime/getting_failure_step.yml  
+
         ## RECORD END-OF-TEST IN CHAOS RESULT CR
         - include_tasks: /utils/runtime/update_chaos_result_resource.yml
           vars:


### PR DESCRIPTION
Signed-off-by: Raj <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Adding event support for openebs pool disk loss experiment

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
