### PR TITLE
Feat(Chaos-lib): Adding run-id support for the chaos libs

### DIFF
--- a/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
+++ b/chaoslib/litmus/container_kill/containerd_chaos/containerd.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: containerd-chaos
+  name: containerd-chaos-{{ run_id }}
   labels:
     chaosUID: {{ chaos_uid }}
 spec:

--- a/chaoslib/litmus/container_kill/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/litmus/container_kill/containerd_chaos/crictl-chaos.yml
@@ -26,6 +26,15 @@
     - set_fact: 
         app_node: "{{ app_node.stdout }}"
 
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+
     - name: Wait for the specified ramp time before injecting chaos
       wait_for: timeout="{{ ramp_time }}"
       when: "ramp_time is defined and ramp_time != ''"
@@ -48,7 +57,7 @@
 
     - name: Confirm that the containerd-chaos job is running on {{ app_node }} node.
       shell: >
-        kubectl get pod -l app=crictl
+        kubectl get pod -l job-name=containerd-chaos-{{ run_id }}
         --no-headers -o custom-columns=:status.phase
         -n {{ namespace }} | sort | uniq
       args:
@@ -172,7 +181,7 @@
             
         - name: Confirm that the containerd-chaos pod is deleted successfully
           shell: >
-            kubectl get pods -l app=crictl --no-headers -n {{ namespace }}
+            kubectl get pods -l job-name=containerd-chaos-{{ run_id }} --no-headers -n {{ namespace }}
           args:
             executable: /bin/bash
           register: result

--- a/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
+++ b/chaoslib/litmus/disk_fill/disk_fill_by_litmus.yml
@@ -44,6 +44,15 @@
         limit_storage_KB: "{{ lookup('vars', limit_value_storage.stdout) }}"
 
     - include_tasks: /chaoslib/litmus/disk_fill/convert_fill_percentage.yml
+    
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
 
     - name: Get the Container ID
       shell: >
@@ -86,7 +95,7 @@
     - name: Confirm that disk fill pod is running on {{ app_node }} node
       include_tasks: "/utils/common/status_app_pod.yml"
       vars:
-        app_label: "app=disk-fill"
+        app_label: "job-name=disk-fill-{{ run_id }}"
         app_ns: "{{ a_ns }}"  
         delay: 2
         retries: 90
@@ -97,7 +106,7 @@
   
     - name: Record the disk-fill pod on app node
       shell: >
-        kubectl get pods -l app=disk-fill -o jsonpath='{.items[?(@.spec.nodeName=="{{app_node}}")].metadata.name}'
+        kubectl get pods -l job-name=disk-fill-{{ run_id }} -o jsonpath='{.items[?(@.spec.nodeName=="{{app_node}}")].metadata.name}'
       args:
         executable: /bin/bash
       register: disk_fill_pod
@@ -168,7 +177,7 @@
       k8s_facts:
         kind: Job
         label_selectors:
-          - app=disk-fill
+          - job-name=disk-fill-{{ run_id }}
       register: resource_job
       until: "resource_job.resources | length < 1"
       delay: 2
@@ -189,11 +198,12 @@
           k8s_facts:
             kind: Job
             label_selectors:
-              - app=disk-fill
+              - job-name=disk-fill-{{ run_id }}
           register: resource_job
           until: "resource_job.resources | length < 1"
           delay: 2
           retries: 90   
+
       when: "disk_fill_job_result is defined"
     
     - fail:

--- a/chaoslib/litmus/disk_fill/disk_fill_job.j2
+++ b/chaoslib/litmus/disk_fill/disk_fill_job.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: disk-fill
+  name: disk-fill-{{ run_id }}
   labels:
     chaosUID: {{ chaos_uid }}
 spec:

--- a/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: node-cpu-hog-{{ chaos_uid }}
+  name: node-cpu-hog-{{ run_id }}
   labels: 
     chaosUID: {{ chaos_uid }}
 spec:

--- a/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
+++ b/chaoslib/litmus/platform/gke/node-memory-hog-job.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: node-memory-hog
+  name: node-memory-hog-{{ run_id }}
   labels: 
     chaosUID: {{ chaos_uid }}
 spec:

--- a/chaoslib/litmus/platform/gke/node_cpu_consumption.yml
+++ b/chaoslib/litmus/platform/gke/node_cpu_consumption.yml
@@ -26,6 +26,15 @@
         src:  /chaoslib/litmus/platform/gke/node-cpu-hog-job.j2
         dest: /chaoslib/litmus/platform/gke/node-cpu-hog-job.yml
 
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+  
     ## RECORD EVENT FOR CHAOS INJECTION
     - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
       vars:
@@ -50,7 +59,7 @@
     ## WAIT UNTIL THE JOB IS COMPLETED
     - name: Wait until the node cpu hog job is completed
       shell: >
-        kubectl get pods -l app=node-cpu-hog --no-headers -n {{ a_ns }}
+        kubectl get pods -l job-name=node-cpu-hog-{{ run_id }} --no-headers -n {{ a_ns }}
         --no-headers -o custom-columns=:status.phase
       args: 
         executable: /bin/bash
@@ -82,7 +91,7 @@
       k8s_facts:
         kind: Job
         label_selectors:
-          - app=node-cpu-hog
+          - job-name=node-cpu-hog-{{ run_id }}
       register: resource_job
       until: "resource_job.resources | length < 1"
       delay: 2
@@ -102,7 +111,7 @@
           k8s_facts:
             kind: Job
             label_selectors:
-              - app=node-cpu-hog
+              - job-name=node-cpu-hog-{{ run_id }}
           register: resource_job
           until: "resource_job.resources | length < 1"
           delay: 2

--- a/chaoslib/litmus/platform/gke/node_memory_consumption.yml
+++ b/chaoslib/litmus/platform/gke/node_memory_consumption.yml
@@ -12,7 +12,16 @@
     - name: Recording the node name of application pod
       set_fact:
         node_name: "{{ app_pod_name | json_query('resources[0].spec.nodeName')}}"
+        
+    - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
 
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+  
     ## RECORD EVENT FOR CHAOS INJECTION
     - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
       vars:
@@ -50,7 +59,7 @@
         kind: Pod
         namespace: "{{ a_ns }}"
         label_selectors:
-          - app=memory-hog
+          - job-name=node-memory-hog-{{ run_id }}
       register: job_pod
       until: "{{ job_pod | json_query('resources[0].status.phase') == 'Succeeded' }}"
       delay: 1
@@ -83,7 +92,7 @@
       k8s_facts:
         kind: Job
         label_selectors:
-          - app=memory-hog
+          - job-name=node-memory-hog-{{ run_id }}
       register: resource_job
       until: "resource_job.resources | length < 1"
       delay: 2
@@ -106,7 +115,7 @@
           k8s_facts:
             kind: Job
             label_selectors:
-              - app=memory-hog
+              - job-name=node-memory-hog-{{ run_id }}
           register: resource_job
           until: "resource_job.resources | length < 1"
           delay: 2

--- a/chaoslib/pumba/pod_failure_by_sigkill.yml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yml
@@ -26,6 +26,15 @@
         app_node: "{{ app_node.stdout }}"
 
     - block:
+        - name: Generate a run id if not passed from the engine/experiment
+          shell: echo $(mktemp) | cut -d '.' -f 2 
+          register: rand_string   
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+    
+    - block:
         - name: Record the application container
           shell: >
             kubectl get pods -l {{ label }} -n {{ namespace }} -o jsonpath='{.items[0].spec.containers[0].name}'
@@ -87,7 +96,7 @@
       
     - name: Wait until the pumba sig-kill job is completed
       shell: >
-        kubectl get pods -l job-name=pumba-sig-kill-{{ chaos_uid }} --no-headers -n {{ namespace }}
+        kubectl get pods -l job-name=pumba-sig-kill-{{ run_id }} --no-headers -n {{ namespace }}
         --no-headers -o custom-columns=:status.phase
       args: 
         executable: /bin/bash

--- a/chaoslib/pumba/pumba.j2
+++ b/chaoslib/pumba/pumba.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pumba-sig-kill-{{ chaos_uid }}
+  name: pumba-sig-kill-{{ run_id }}
   labels: 
     chaosUID: {{ chaos_uid }}
 spec:


### PR DESCRIPTION
Signed-off-by: Raj <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding run-id support for the chaoslibs. This helps in unique identification of the chaos job in a given namespace for the same engine. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
