### PR TITLE
feat(ansible-verbosity):  Getting failure step on the basis of verbosity level

### DIFF
--- a/utils/runtime/getting_failure_step.yml
+++ b/utils/runtime/getting_failure_step.yml
@@ -1,9 +1,19 @@
 - block:
 
+    - name: Getting offset if the ansible verbosity is less than or equals to one
+      set_fact: 
+        offset: 1
+      when: ansible_verbosity <= 1
+
+    - name: Getting offset if the ansible verbosity is greater than one
+      set_fact:
+        offset: 2
+      when: ansible_verbosity > 1
+
     ## Getting failure step from experiment-pod
     - name: Getting failure step from experiment pod
       shell: >
-        kubectl logs {{ chaos_pod_name }} -n {{ a_ns }} | grep "FAILED!" -B 1 | head -1 | awk -F "Step:" '{print $2}'
+        kubectl logs {{ chaos_pod_name }} -n {{ a_ns }} | grep "FAILED!" -B {{ offset }} | head -1 | awk -F "Step:" '{print $2}'
       register: fail_step
       args: 
         executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- set the offset on the basis of verbosity level to get the failure step

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
