### PR TITLE
(chore)roadmap: move features from in-progress to completed items

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 ## LITMUS ROADMAP
 
-This document captures only a high level backlogs. For detailed list of backlogs, see [issues list](https://github.com/litmuschaos/litmus/issues) and [current milestones](https://github.com/litmuschaos/litmus/milestones). 
+This document captures only the high level roadmap items. For the detailed backlog, see [issues list](https://github.com/litmuschaos/litmus/issues) and [current milestones](https://github.com/litmuschaos/litmus/milestones). 
 
 ### Completed
 
@@ -8,6 +8,9 @@ This document captures only a high level backlogs. For detailed list of backlogs
 -   Chaos Operator to orchestrate chaos experiments
 -   Off the shelf / ready chaos experiments for general Kubernetes chaos
 -   Per-experiment minimal RBAC permissions definition
+-   Helm3 charts for Litmus Chaos (operator, chaos charts)
+-   Support for Kubernetes events for chaos experiments
+-   Support for admin mode (centralized chaos management) 
 -   Centralized Hub for chaos experiments
 -   Documentation (user & developer guides)
 -   Gitlab e2e pipeline for chaos experiments
@@ -19,10 +22,7 @@ This document captures only a high level backlogs. For detailed list of backlogs
 
 -   Off the shelf chaos-integrated grafana dashboards for OpenEBS, Kafka, Cassandra [#1280](https://github.com/litmuschaos/litmus/issues/1280)
 -   Support for scheduled (continuous/background) chaos with halt/resume [#1223](https://github.com/litmuschaos/litmus/issues/1223)
--   Support for Kubernetes events for chaos experiments [#1264](https://github.com/litmuschaos/litmus/issues/1244) [#1243](https://github.com/litmuschaos/litmus/issues/1243)
--   Support for hard chaos abort via pre-stop hooks [#1284](https://github.com/litmuschaos/litmus/issues/1284)
--   Support for admin mode (separate namespace for chaos resources, with opt-in/out option for specific experiments in applications) [#1219](https://github.com/litmuschaos/litmus/issues/1219)
--   Helm3 charts for Litmus Chaos (operator, chaos charts)[#1221](https://github.com/litmuschaos/litmus/issues/1221)
+-   Support for complete chaos abort via pre-stop hooks [#1284](https://github.com/litmuschaos/litmus/issues/1284)
 -   Scaffold tools to generate experiment templates in python, golang [#1259](https://github.com/litmuschaos/litmus/issues/1259)
 -   Support for user defined chaos experiment result definition (ex:json blob as chaos result) [#1254](https://github.com/litmuschaos/litmus/issues/1254)
 -   Pod level resource chaos libraries (memory, disk stress) [#877](https://github.com/litmuschaos/litmus/issues/877)


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Updates the roadmap completed items based on 1.2/1.2.1/1.2.2 deliverables. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
