### PR TITLE
refactor(pod-cpu-hog): Adding the task banner in the pod-cpu-hog experiment

### DIFF
--- a/chaoslib/litmus/pod_cpu_hog/pod_cpu_hog.yml
+++ b/chaoslib/litmus/pod_cpu_hog/pod_cpu_hog.yml
@@ -3,7 +3,7 @@
 
     - block: 
 
-      - name: Select the app pod
+      - name: "[Prepare]: Select the application pod"
         shell: >
           kubectl get pod -l {{ app_label }} -n {{ app_ns }}
           -o=custom-columns=:metadata.name --no-headers
@@ -12,7 +12,7 @@
           executable: /bin/bash
         register: app_pod_name
 
-      - name: Record app pod name
+      - name: "[Prepare]: Recording the application pod name"
         set_fact:
           app_pod: "{{ app_pod_name.stdout }}"
 
@@ -21,7 +21,7 @@
     # here app_ns is the namespace of pod on which we are performing cpu chaos 
     # in genric experiments app_ns is same as app_ns
     # in openebs experiments app_ns is the namespace where openebs is installed i.e, openebs
-    - name: Identify the application node
+    - name: "[Prepare]: Identify the application node name"
       shell: >
         kubectl get pod {{ app_pod }} -n {{ app_ns }}
         --no-headers -o custom-columns=:spec.nodeName
@@ -33,7 +33,7 @@
         app_node: "{{ app_node.stdout }}"
 
     - block: 
-        - name: Generate a run id if not passed from the engine/experiment
+        - name: "[Prepare:] Generate a run id if not passed from the engine/experiment"
           shell: echo $(mktemp) | cut -d '.' -f 2 | cut -c -6
           register: rand_string   
 
@@ -43,20 +43,20 @@
 
     - block:
 
-        - name: Record the application container
+        - name: "[Prepare]: Derive the application container name"
           shell: >
             kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ app_pod }}")].spec.containers[0].name}'
           args:
             executable: /bin/bash
           register: container
   
-        - name: Record the app_container
+        - name: "[Prepare]: Record the application container name"
           set_fact:
             c_container: "{{ container.stdout }}"
   
       when: c_container is not defined or c_container == ''
 
-    - name: Obtain Container ID of the target container
+    - name: "[Prepare]: Obtain the Container ID of the target container"
       shell: >
         kubectl get pods {{ app_pod }} -n {{ app_ns }} 
         -o jsonpath='{.status.containerStatuses[?(@.name=="{{ c_container }}")].containerID}'
@@ -65,15 +65,21 @@
         executable: /bin/bash
       register: container_id
 
-    - name: Record the app_container_id
+    - name: "[Prepare]: Record the Container ID of the target container"
       set_fact:
         c_container_id: "{{ container_id.stdout }}"
 
-    - name: Wait for the specified ramp time before injecting chaos
-      wait_for: timeout="{{ ramp_time }}"
+    - block:
+
+        - debug:
+            msg: "***** Waiting for the ramp interval of {{ ramp_time }}s *****"
+
+        - name: "[Ramp]: Waiting for the specified ramp time before injecting chaos"
+          wait_for: timeout="{{ ramp_time }}"
+
       when: "ramp_time is defined and ramp_time != ''" 
  
-    - name: Patch the chaos params to cpu stress job template
+    - name: "[Prepare]: Patch the lib image to pod-cpu-hog template"
       template:
         src:  /chaoslib/litmus/pod_cpu_hog/app_cpu_stress.j2
         dest: /chaoslib/litmus/pod_cpu_hog/app_cpu_stress.yml
@@ -81,7 +87,8 @@
         cpu_stress_image: "{{ lib_image }}"
 
     ## RECORD EVENT FOR CHAOS INJECTION
-    - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+    - name: "[Event]: Generating an Event for ChaosInjection"
+      include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
       vars:
         stage: "ChaosInject"
         exp_pod_name: "{{ chaos_pod_name }}"
@@ -95,7 +102,8 @@
         
       # Pod Cpu Hog pods creation is attempted for a total of 3 times, if it is not immediately schedulable due to transient node conditions
       # If the pod-cpu-hog pod is not schedulable across these 3 tries, the experiment is failed with message indicating improper cluster state.
-    - include_tasks: /utils/common/create_chaos_pod.yml
+    - name: "[Prepare]: Including the util to create the chaos pod"
+      include_tasks: /utils/common/create_chaos_pod.yml
       vars:
         pod_ns: "{{ c_ns }}"
         c_path: "/chaoslib/litmus/pod_cpu_hog/app_cpu_stress.yml"
@@ -108,11 +116,11 @@
       when: "pod_running_status is not defined or pod_running_status != 'Running'"
  
     ## with a grace period of 2 min before cpu stress job terminate
-    - name: Calculate the total wait time for cpu stress job
+    - name: "[Wait]: Calculate the total wait time for cpu stress job"
       set_fact:
         job_wait_time: "{{ ((c_duration|int) + 120)| int }}"
 
-    - name: Wait until the cpu stress job is completed
+    - name: "[Wait]: Wait until the cpu stress job is completed"
       shell: >
         kubectl get pods -l name=app-cpu-stress-{{ run_id }} --no-headers -n {{ c_ns }}
         --no-headers -o custom-columns=:status.phase
@@ -123,19 +131,24 @@
       delay: 1
       retries: "{{ job_wait_time }}"
 
-    - name: Wait for the specified ramp time after injecting chaos
-      wait_for: timeout="{{ ramp_time }}"
+    - block:
+        - debug:
+            msg: "***** Waiting for the ramp interval of {{ ramp_time }}s *****"
+
+        - name: "[Ramp]: Waiting for the specified ramp time after injecting chaos"
+          wait_for: timeout="{{ ramp_time }}"
+
       when: "ramp_time is defined and ramp_time != ''" 
 
     - block:
 
-        - name: Tear down cpu chaos infrastructure
+        - name: "[CleanUP]: Tear down cpu chaos infrastructure"
           shell: >
             kubectl delete -f /chaoslib/litmus/pod_cpu_hog/app_cpu_stress.yml -n {{ c_ns }} 
           args:
             executable: /bin/bash
 
-        - name: Confirm that the cpu stress pod is deleted successfully
+        - name:  "[CleanUP]: Confirm that the cpu stress pod is deleted successfully"
           shell: >
             kubectl get pods -l name=app-cpu-stress-{{ run_id }} --no-headers -n {{ c_ns }}
           args:
@@ -151,14 +164,14 @@
 
     - block: 
 
-        - name: Tear down cpu chaos infrastructure, if setup
+        - name:  "[CleanUP]: Tear down cpu chaos infrastructure, if setup"
           shell: >
             kubectl delete -f /chaoslib/litmus/pod_cpu_hog/app_cpu_stress.yml -n {{ c_ns }} 
           args:
             executable: /bin/bash
           when: "chaos_pod_result.rc == 0"
         
-        - name: Confirm that the cpu stress pod is not present
+        - name:  "[CleanUP]: Confirm that the cpu stress pod is not present"
           shell: >
             kubectl get pods -l name=app-cpu-stress-{{ run_id }} --no-headers -n {{ c_ns }}
           args:

--- a/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml
+++ b/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml
@@ -24,23 +24,34 @@
         ## DETERMINE THE CHAOSLIB TASKFILES TO BE USED
         - include: pod_cpu_hog_ansible_prerequisites.yml
 
-        - include_vars:
+        - name: "[PreReq]: Including the chaos util for the {{ c_experiment }} experiment"
+          include_vars:
             file: chaosutil.yml
 
         ## GENERATE EXP RESULT NAME
-        - name: Construct chaos result name
+        - name: "[PreReq]: Constructing the chaos result name"
           set_fact:
             c_result: "{{ c_engine }}-{{ c_experiment }}"
           when: "c_engine is defined and c_engine != ''"
 
         ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
-        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+        - name: "[PreReq]: Updating the chaos result of {{ c_experiment }} experiment (SOT)"
+          include_tasks: /utils/runtime/update_chaos_result_resource.yml
           vars: 
             status: 'SOT'
             namespace: "{{ c_ns }}"
 
-        ## PRE-CHAOS APPLICATION LIVENESS CHECK
-        - name: Verify that the AUT (Application Under Test) is running 
+        ## DISPLAY APP INFORMATION 
+        - name: "[Info]: Display the application information passed via the test job"
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ a_ns }}"
+              - "Label        : {{ a_label }}"
+              - "Ramp Time    : {{ ramp_time }}"  
+
+        ## PRE-CHAOS APPLICATION STATUS CHECK
+        - name: "[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)"
           include_tasks: "/utils/common/status_app_pod.yml"
           vars:
             app_ns: "{{ a_ns }}"
@@ -49,7 +60,8 @@
             retries: 90
 
         ## RECORD EVENT FOR PRE-CHAOS CHECK
-        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        - name: "[Event]: Generating an Event for PreChaosCheck"
+          include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
           vars:
             stage: "PreChaosCheck"
             exp_pod_name: "{{ chaos_pod_name }}"
@@ -63,8 +75,8 @@
             app_ns: "{{ a_ns }}"
             app_label: "{{ a_label }}"
 
-        ## POST-CHAOS APPLICATION LIVENESS CHECK
-        - name: Verify AUT liveness post fault-injection
+        ## POST-CHAOS APPLICATION STATUS CHECK
+        - name: "[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)"
           include_tasks: "/utils/common/status_app_pod.yml"
           vars:
             app_ns: "{{ a_ns }}"
@@ -73,7 +85,8 @@
             retries: 90       
             
         ## RECORD EVENT FOR POST-CHAOS CHECK
-        - include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+        - name: "[Event]: Generating an Event for PostChaosCheck"
+          include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
           vars:
             stage: "PostChaosCheck"
             exp_pod_name: "{{ chaos_pod_name }}"
@@ -85,10 +98,20 @@
         - set_fact:
             flag: "Pass"
 
+        - name: "[Result]: Getting the final result of {{ c_experiment }} experiment"
+          debug:
+            msg: "{{ c_experiment }} experiment has been {{ flag }}ed"
+
+
     
       rescue: 
         - set_fact: 
             flag: "Fail"
+
+        - name: "[Result]: Getting the final result of {{ c_experiment }} experiment"
+          debug:
+            msg: "{{ c_experiment }} experiment has been {{ flag }}ed"
+
       
       always: 
 
@@ -96,7 +119,8 @@
         - include_tasks: /utils/runtime/getting_failure_step.yml  
 
         ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
-        - include_tasks: /utils/runtime/update_chaos_result_resource.yml
+        - name: "[The End]: Updating the chaos result of {{ c_experiment }} experiment (EOT)"
+          include_tasks: /utils/runtime/update_chaos_result_resource.yml
           vars:
             status: 'EOT'
             namespace: "{{ c_ns }}"

--- a/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_prerequisites.yml
+++ b/experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_prerequisites.yml
@@ -1,4 +1,4 @@
-- name: Identify the chaos util to be invoked 
+- name: "[PreReq] Identify the chaos util for {{ c_experiment }} experiment"
   template:
     src: chaosutil.j2
     dest: chaosutil.yml


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding the task banner in the pod-cpu-hog experiment

- This PR is depending on #1422  PR

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1423 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [x] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [x] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
