### PR TITLE
(chore)governance: add maria as a maintainer (litmus deployment focused)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,8 +14,10 @@
 "Chandan Kumar",@chandankumar4,MayaData
 "Jayesh Kumar",@k8s-dev,Self
 "Karthik Satchitanand",@ksatchit,MayaData
+"Maria Kotlyarevskaya",@Jasstkn,Dino Systems
 "Sumit Nagal",@sumitnagal,Intuit
 "Uma Mukkara",@umamukkara,MayaData
+
 
 #Reviewers
 "Amit Bhatt",@amitbhatt818,MayaData


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The litmus governance is being updated to a SIG model where each area (comprising one or more sub-projects / repos) will be maintained by a SIG lead, who will maintain those repos

- While this revamp will be made soon via a series of upcoming PRs (the SIGs formation is in progress at this point), this PR adds Maria Kotlyarevskaya who is keenly interested in leading the "Deployment SIG"  and maintaining the associated repos, into the existing maintainers list. 

- Maria has multiple useful PRs on the helm repos and is an active community member on the litmus slack channel and is committed to the long-term success of Litmus chaos engineering project. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Once the SIGs and their respective leads are identified, the maintainers will be mapped against these in the MAINTAINERs file. 
