### PR TITLE
update(pod-delete): Adding type casting in pod-delete experiment

### DIFF
--- a/chaoslib/litmus/pod_delete/kill_random_pod.yml
+++ b/chaoslib/litmus/pod_delete/kill_random_pod.yml
@@ -107,13 +107,13 @@
         retries: 90   
       when: "type is defined and type != ''"
 
-    when: "chaosDiffTimeStamp is not defined or (chaosDiffTimeStamp is defined and chaosDiffTimeStamp < c_duration)"
+    when: "chaosDiffTimeStamp is not defined or (chaosDiffTimeStamp is defined and chaosDiffTimeStamp|int < c_duration|int)"
 
   # chaos_status tracking the status of chaos, If it is active means chaos is in progress
   # If it is terminate means chaos is ended.
   - name: "[Mark]: Setting chaos_status to terminate"
     set_fact:
       chaos_status: "terminate"
-    when: "chaosDiffTimeStamp is defined and chaosDiffTimeStamp >= c_duration"
+    when: "chaosDiffTimeStamp is defined and chaosDiffTimeStamp|int >= c_duration|int"
 
   when: "chaos_status is not defined or (chaos_status is defined and chaos_status == 'active')"


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding type casting in pod-delete experiment

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
