### PR TITLE
Remove the force flag from pod_delete job that should not force delete

### DIFF
--- a/chaoslib/litmus/pod_delete/kill_random_pod.yml
+++ b/chaoslib/litmus/pod_delete/kill_random_pod.yml
@@ -90,7 +90,7 @@
 
     - name: "[Inject]: Killing the application pod"
       shell: |
-        kubectl delete pod -n {{ app_ns }} --grace-period=0 --wait=false {{ app_pod }}
+        kubectl delete pod -n {{ app_ns }} {{ app_pod }}
       args:
         executable: /bin/bash
       register: result


### PR DESCRIPTION
Signed-off-by: xkbarkar kristin.barkardottir@gmail.com 

**What this PR does / why we need it**:
The current FORCE flag in pod_delete experiment is pointless as pods will be force deleted either way 

**Which issue this PR fixes** *
#1507

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
