### PR TITLE
feat(actions): Add merge label and auto-merge feature in GitHub Actions

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-auto-merge - https://github.com/bobvanderlinden/probot-auto-merge
+
+reportStatus: true
+updateBranch: true
+deleteBranchAfterMerge: true
+mergeMethod: squash
+
+minApprovals:
+  COLLABORATOR: 0
+maxRequestedChanges:
+  NONE: 0
+blockingLabels:
+- DO NOT MERGE
+- WIP
+- blocked
+
+# Will merge whenever the above conditions are met, but also
+# the owner has approved or merge label was added.
+rules:
+- minApprovals:
+    OWNER: 1
+- requiredLabels:
+  - merge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,9 @@ jobs:
           EXPERIMENT_IMAGE: litmuschaos/ansible-runner
           EXPERIMENT_IMAGE_TAG: ci
           IMAGE_PULL_POLICY: IfNotPresent
+          CONTAINER_KILL_HELPER_IMAGE: litmuschaos/container-kill-helper
+          CONTAINER_KILL_HELPER_TAG: latest
+          LIB: containerd
           LITMUS_CLEANUP: true
 
       - name: Running node-cpu-hog chaos experiment
@@ -114,7 +117,8 @@ jobs:
       - name: Check the test run
         if: |
          startsWith(github.event.comment.body, '/run-e2e-pod-delete') || startsWith(github.event.comment.body, '/run-e2e-container-kill') ||
-         startsWith(github.event.comment.body, '/run-e2e-node-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-node-memory-hog')
+         startsWith(github.event.comment.body, '/run-e2e-node-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-node-memory-hog') ||
+         startsWith(github.event.comment.body, '/run-e2e-all')
         run: |
           echo ::set-env name=TEST_RUN::true
 
@@ -125,7 +129,7 @@ jobs:
           comment-id: "${{ github.event.comment.id }}"
           body: |  
             **Test Result:** All tests are passed
-          reactions: hooray
+          reactions: hooray         
 
       - name: Check for any job failed
         if: ${{ failure() }}
@@ -148,3 +152,13 @@ jobs:
           body: |
             **Test Result:** No test found
           reactions: eyes 
+
+  merge:
+    if: contains(github.event.comment.html_url, '/pull/') && startsWith(github.event.comment.body, '/merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add a merge label when all jobs are passed
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          labels: merge


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>
**What this PR does / why we need it**:

- This PR is for adding label `merge` for `/merge` on a PR comment further reading this label Github pro-bot will check if 1 approval is there or label merge is there or not. If all the requirements are fulfilled then pro-bot will merge the  Pull  Request.
- This PR also fixes the issue related to running container-kill experiment BDDs.

**Workflow:**
- for `/merge` in PR comment, it will add a merge label ref: [this-merge-example](https://github.com/uditgaurav/litmus-run-e2e/pull/6#issuecomment-645061238)

**Which issue this PR fixes** 
 - fixes https://github.com/litmuschaos/litmus/issues/1557

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?

**Special notes for your reviewer**:
- Please install [github-pro-bot](https://github.com/apps/probot-auto-merge) in this repo while merging this PR. 
