### PR TITLE
chore(litmus-portal): Add unified modal component

### DIFF
--- a/litmus-portal/frontend/src/components/ChooseWorkflow/index.tsx
+++ b/litmus-portal/frontend/src/components/ChooseWorkflow/index.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { Typography, Modal } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import Divider from '@material-ui/core/Divider';
 import Button from '@material-ui/core/Button';
 import useStyles, { CssTextField, ColorButton } from './styles';
 import useActions from '../../redux/actions';
 import * as WorkflowActions from '../../redux/actions/workflow';
 import PredifinedWorkflows from '../PredifinedWorkflows';
+import Unimodal from '../Unimodal';
 // import { getWkfRunCount } from "../../utils";
 
 const ChooseWorkflow: React.FC = () => {
@@ -157,83 +158,71 @@ const ChooseWorkflow: React.FC = () => {
         </div>
       </div>
 
-      <Modal open={open} onClose={() => setOpen(false)}>
-        <div className={classes.modalContainer}>
-          <div className={classes.modalContainerClose}>
+      <Unimodal isOpen={open} handleClose={() => setOpen(false)} hasCloseBtn>
+        <div className={classes.modalContainerName}>
+          <Typography className={classes.modalHeading} display="inline">
+            Create your <strong>workflow name</strong>
+          </Typography>
+        </div>
+        <div className={classes.modalContainerBody}>
+          <div className={classes.inputDiv}>
+            <div className={classes.inputArea}>
+              <CssTextField
+                id="filled-workflowname-input"
+                label="Workflow name"
+                InputProps={{
+                  disableUnderline: true,
+                  classes: {
+                    input: classes.resizeName,
+                  },
+                }}
+                data-cy="inputWorkflow"
+                className={classes.textfieldworkflowname}
+                onChange={WorkflowNameChangeHandler}
+                value={workflowDetails.workflowName}
+                autoFocus
+              />
+            </div>
+            <div className={classes.inputAreaDescription}>
+              <CssTextField
+                id="filled-workflowdescription-input"
+                label="Description"
+                InputProps={{
+                  disableUnderline: true,
+                  classes: {
+                    input: classes.resize,
+                  },
+                }}
+                data-cy="inputWorkflowDescription"
+                className={classes.textfieldworkflowdescription}
+                value={workflowDetails.workflowDesc}
+                onChange={WorkflowDescriptionChangeHandler}
+                multiline
+                rows={12}
+              />
+            </div>
+          </div>
+          <div className={classes.buttons}>
             <Button
               variant="outlined"
               color="secondary"
-              className={classes.closeButton}
+              className={classes.buttonCancel}
               onClick={() => setOpen(false)}
             >
-              &#x2715;
+              Cancel
             </Button>
-          </div>
-          <div className={classes.modalContainerName}>
-            <Typography className={classes.modalHeading} display="inline">
-              Create your <strong>workflow name</strong>
-            </Typography>
-          </div>
-          <div className={classes.modalContainerBody}>
-            <div className={classes.inputDiv}>
-              <div className={classes.inputArea}>
-                <CssTextField
-                  id="filled-workflowname-input"
-                  label="Workflow name"
-                  InputProps={{
-                    disableUnderline: true,
-                    classes: {
-                      input: classes.resizeName,
-                    },
-                  }}
-                  data-cy="inputWorkflow"
-                  className={classes.textfieldworkflowname}
-                  onChange={WorkflowNameChangeHandler}
-                  value={workflowDetails.workflowName}
-                  autoFocus
-                />
-              </div>
-              <div className={classes.inputAreaDescription}>
-                <CssTextField
-                  id="filled-workflowdescription-input"
-                  label="Description"
-                  InputProps={{
-                    disableUnderline: true,
-                    classes: {
-                      input: classes.resize,
-                    },
-                  }}
-                  data-cy="inputWorkflowDescription"
-                  className={classes.textfieldworkflowdescription}
-                  value={workflowDetails.workflowDesc}
-                  onChange={WorkflowDescriptionChangeHandler}
-                  multiline
-                  rows={12}
-                />
-              </div>
-            </div>
-            <div className={classes.buttons}>
-              <Button
-                variant="outlined"
-                color="secondary"
-                className={classes.buttonCancel}
-                onClick={() => setOpen(false)}
-              >
-                Cancel
-              </Button>
 
-              <ColorButton
-                variant="contained"
-                color="primary"
-                className={classes.buttonSave}
-                onClick={() => handleSave()}
-              >
-                Save
-              </ColorButton>
-            </div>
+            <ColorButton
+              variant="contained"
+              color="primary"
+              className={classes.buttonSave}
+              onClick={() => handleSave()}
+            >
+              Save
+            </ColorButton>
           </div>
         </div>
-      </Modal>
+      </Unimodal>
     </div>
   );
 };

--- a/litmus-portal/frontend/src/components/ChooseWorkflow/styles.ts
+++ b/litmus-portal/frontend/src/components/ChooseWorkflow/styles.ts
@@ -126,22 +126,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '0.875rem',
   },
 
-  modalContainer: {
-    height: '85%',
-    width: '70%',
-    margin: '2rem auto',
-    background: theme.palette.common.white,
-    borderRadius: 3,
-    textAlign: 'center',
-    outline: 'none',
-  },
-
-  modalContainerClose: {
-    paddingLeft: theme.spacing(72),
-    paddingRight: theme.spacing(0),
-    paddingBottom: theme.spacing(0),
-  },
-
   modalContainerName: {
     paddingBottom: theme.spacing(0.625),
   },
@@ -169,20 +153,6 @@ const useStyles = makeStyles((theme) => ({
   selectionName: {
     fontFamily: 'Ubuntu',
     fontSize: '1rem',
-  },
-
-  closeButton: {
-    fontSize: '1rem',
-    fontWeight: 1000,
-    display: 'inline-block',
-    padding: `${theme.spacing(0.375)} ${theme.spacing(1.5)}`,
-    minHeight: 0,
-    minWidth: 0,
-    borderRadius: 3,
-    color: 'rgba(0, 0, 0, 0.4)',
-    border: '1px solid rgba(0, 0, 0, 0.4)',
-    marginLeft: '60%',
-    marginTop: theme.spacing(5),
   },
 
   buttonCancel: {

--- a/litmus-portal/frontend/src/components/FinishModal/index.tsx
+++ b/litmus-portal/frontend/src/components/FinishModal/index.tsx
@@ -1,7 +1,7 @@
 import Button from '@material-ui/core/Button';
-import Modal from '@material-ui/core/Modal';
 import React from 'react';
 import useStyles from './styles';
+import Unimodal from '../Unimodal';
 
 /* Icon function is used for finish modal to show mark */
 function Icon() {
@@ -41,7 +41,7 @@ const FinishModal = () => {
           variant="contained"
           color="secondary"
           data-cy="selectFinish"
-          // onClick = {}
+          onClick={handleClose}
         >
           Back to workflow
         </Button>
@@ -61,15 +61,9 @@ const FinishModal = () => {
       </Button>
 
       {/* Finish Modal is added */}
-
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
-      >
+      <Unimodal isOpen={open} handleClose={handleClose} hasCloseBtn={false}>
         {body}
-      </Modal>
+      </Unimodal>
     </div>
   );
 };

--- a/litmus-portal/frontend/src/components/FinishModal/styles.ts
+++ b/litmus-portal/frontend/src/components/FinishModal/styles.ts
@@ -2,15 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   rootContainer: {
-    marginLeft: '20rem',
-    marginRight: '20rem',
-    marginTop: '8rem',
-    marginBottom: '8rem',
-    paddingBottom: '6rem',
-    background: theme.palette.common.white,
-    borderRadius: 3,
-    textAlign: 'center',
-    outline: 'none',
+    marginBottom: '5rem',
   },
   mark: {
     marginTop: 80,

--- a/litmus-portal/frontend/src/components/ReliabilityScore/index.tsx
+++ b/litmus-portal/frontend/src/components/ReliabilityScore/index.tsx
@@ -1,4 +1,4 @@
-import { Modal, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import Center from '../../containers/layouts/Center';
@@ -12,6 +12,7 @@ import { WorkflowData, experimentMap } from '../../models/workflow';
 import { RootState } from '../../redux/reducers';
 import useActions from '../../redux/actions';
 import * as WorkflowActions from '../../redux/actions/workflow';
+import Unimodal from '../Unimodal';
 
 const ReliablityScore = () => {
   const classes = useStyles();
@@ -114,28 +115,30 @@ const ReliablityScore = () => {
                 <div className={classes.toolTipDiv}>
                   <InfoTooltip value="Text Default" />
                 </div>
-                <Modal open={open}>
-                  <div className={classes.modalContainer}>
-                    <div>
-                      <ResultTable
-                        testValue={testWeights}
-                        testNames={testNames}
-                      />
-                    </div>
-                    <hr className={classes.horizontalLineResult} />
-                    <div className={classes.gotItBtn}>
-                      <Center>
-                        <ButtonFilled
-                          handleClick={() => setOpen(false)}
-                          data-cy="gotItButton"
-                          isPrimary
-                        >
-                          <div>Got it</div>
-                        </ButtonFilled>
-                      </Center>
-                    </div>
+                <Unimodal
+                  isOpen={open}
+                  handleClose={() => setOpen(false)}
+                  hasCloseBtn={false}
+                >
+                  <div>
+                    <ResultTable
+                      testValue={testWeights}
+                      testNames={testNames}
+                    />
                   </div>
-                </Modal>
+                  <hr className={classes.horizontalLineResult} />
+                  <div className={classes.gotItBtn}>
+                    <Center>
+                      <ButtonFilled
+                        handleClick={() => setOpen(false)}
+                        data-cy="gotItButton"
+                        isPrimary
+                      >
+                        <div>Got it</div>
+                      </ButtonFilled>
+                    </Center>
+                  </div>
+                </Unimodal>
               </div>
               <div>
                 <Typography className={classes.testInfo}>

--- a/litmus-portal/frontend/src/components/ReliabilityScore/styles.ts
+++ b/litmus-portal/frontend/src/components/ReliabilityScore/styles.ts
@@ -58,19 +58,6 @@ const useStyles = makeStyles((theme) => ({
   buttonOutlineText: {
     paddingLeft: theme.spacing(1.5),
   },
-  modalContainer: {
-    marginLeft: theme.spacing(30),
-    marginRight: theme.spacing(30),
-    marginBottom: theme.spacing(10),
-    marginTop: theme.spacing(4),
-    paddingLeft: theme.spacing(3.75),
-    paddingRight: theme.spacing(3.75),
-    paddingBottom: theme.spacing(0.625),
-    background: theme.palette.common.white,
-    borderRadius: 3,
-    textAlign: 'center',
-    outline: 'none',
-  },
   testType: {
     fontSize: '1.0625rem',
     paddingRight: theme.spacing(1.25),
@@ -78,11 +65,6 @@ const useStyles = makeStyles((theme) => ({
   testResult: {
     color: theme.palette.primary.dark,
     fontSize: '1.0625rem',
-  },
-  modal: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   table: {
     marginTop: theme.spacing(2),

--- a/litmus-portal/frontend/src/components/SettingsComponents/AccountsTab/PersonalDetails/index.tsx
+++ b/litmus-portal/frontend/src/components/SettingsComponents/AccountsTab/PersonalDetails/index.tsx
@@ -1,10 +1,11 @@
-import { Button, Modal, Typography } from '@material-ui/core';
+import { Button, Typography } from '@material-ui/core';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { UserData } from '../../../../models/user';
 import { RootState } from '../../../../redux/reducers';
 import UserDetails from '../../UserManagementTab/CreateUser/UserDetails';
 import useStyles from './styles';
+import Unimodal from '../../../Unimodal';
 
 interface personaData {
   email: string;
@@ -87,37 +88,29 @@ const PersonalDetails: React.FC = () => {
           </Button>
 
           {/* Displays the modal after details are successfully edited */}
-          <Modal
-            data-cy="modal"
-            open={open}
-            aria-labelledby="simple-modal-title"
-            aria-describedby="simple-modal-description"
-            className={classes.modal}
-          >
-            <div className={classes.paper}>
-              <div className={classes.body}>
-                <img src="./icons/userLarge.svg" alt="user" />
-                <div className={classes.text}>
-                  <Typography className={classes.typo} align="center">
-                    Your personal information <strong>has been changed!</strong>
-                  </Typography>
-                </div>
-                <div className={classes.text1}>
-                  <Typography align="center" className={classes.typo1}>
-                    Changes took effect
-                  </Typography>
-                </div>
-                <Button
-                  data-cy="closeButton"
-                  variant="contained"
-                  className={classes.button}
-                  onClick={handleClose}
-                >
-                  Done
-                </Button>
+          <Unimodal isOpen={open} handleClose={handleClose} hasCloseBtn={false}>
+            <div className={classes.body}>
+              <img src="./icons/userLarge.svg" alt="user" />
+              <div className={classes.text}>
+                <Typography className={classes.typo} align="center">
+                  Your personal information <strong>has been changed!</strong>
+                </Typography>
               </div>
+              <div className={classes.text1}>
+                <Typography align="center" className={classes.typo1}>
+                  Changes took effect
+                </Typography>
+              </div>
+              <Button
+                data-cy="closeButton"
+                variant="contained"
+                className={classes.button}
+                onClick={handleClose}
+              >
+                Done
+              </Button>
             </div>
-          </Modal>
+          </Unimodal>
         </div>
       </form>
     </div>

--- a/litmus-portal/frontend/src/components/SettingsComponents/AccountsTab/PersonalDetails/styles.ts
+++ b/litmus-portal/frontend/src/components/SettingsComponents/AccountsTab/PersonalDetails/styles.ts
@@ -102,25 +102,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 
   // styles for modal and its components
-  modal: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  paper: {
-    width: '50.75rem',
-    height: '39.1875rem',
-    backgroundColor: theme.palette.background.paper,
-
-    outline: 'none',
-    borderRadius: '0.1875rem',
-  },
   body: {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: theme.spacing(15),
+    paddingBottom: '7rem',
   },
   text: {
     width: '31rem',

--- a/litmus-portal/frontend/src/components/SettingsComponents/Modals/PasswordModal/index.tsx
+++ b/litmus-portal/frontend/src/components/SettingsComponents/Modals/PasswordModal/index.tsx
@@ -1,6 +1,7 @@
-import { Button, Modal, Typography } from '@material-ui/core';
+import { Button, Typography } from '@material-ui/core';
 import React from 'react';
 import useStyles from './styles';
+import Unimodal from '../../../Unimodal';
 
 interface PasswordModalProps {
   formErr: boolean;
@@ -31,37 +32,29 @@ const PasswordModal: React.FC<PasswordModalProps> = ({ formErr, isEmpty }) => {
       >
         Change password
       </Button>
-      <Modal
-        data-cy="modal"
-        open={open}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
-        className={classes.modal}
-      >
-        <div className={classes.paper}>
-          <div className={classes.body}>
-            <img src="./icons/lock.svg" alt="lock" />
-            <div className={classes.text}>
-              <Typography className={classes.typo} align="center">
-                Your password <strong>has been changed!</strong>
-              </Typography>
-            </div>
-            <div className={classes.text1}>
-              <Typography className={classes.typo1}>
-                You can now use your new password to login to your account
-              </Typography>
-            </div>
-            <Button
-              data-cy="closeButton"
-              variant="contained"
-              className={classes.button}
-              onClick={handleClose}
-            >
-              Done
-            </Button>
+      <Unimodal isOpen={open} handleClose={handleClose} hasCloseBtn={false}>
+        <div className={classes.body}>
+          <img src="./icons/lock.svg" alt="lock" />
+          <div className={classes.text}>
+            <Typography className={classes.typo} align="center">
+              Your password <strong>has been changed!</strong>
+            </Typography>
           </div>
+          <div className={classes.text1}>
+            <Typography className={classes.typo1}>
+              You can now use your new password to login to your account
+            </Typography>
+          </div>
+          <Button
+            data-cy="closeButton"
+            variant="contained"
+            className={classes.button}
+            onClick={handleClose}
+          >
+            Done
+          </Button>
         </div>
-      </Modal>
+      </Unimodal>
     </div>
   );
 };

--- a/litmus-portal/frontend/src/components/SettingsComponents/Modals/PasswordModal/styles.ts
+++ b/litmus-portal/frontend/src/components/SettingsComponents/Modals/PasswordModal/styles.ts
@@ -1,25 +1,13 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  modal: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  paper: {
-    width: '50.75rem',
-    height: '39.1875rem',
-    backgroundColor: theme.palette.background.paper,
-
-    outline: 'none',
-    borderRadius: '0.1875rem',
-  },
   body: {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: theme.spacing(15),
+    paddingBottom: '7rem',
   },
   text: {
     width: '23.5rem',

--- a/litmus-portal/frontend/src/components/Unimodal/index.tsx
+++ b/litmus-portal/frontend/src/components/Unimodal/index.tsx
@@ -6,11 +6,12 @@ import useStyles from './styles';
 /* DelUser, NewUserModal, ResetModal need to be shifted */
 
 interface UnimodalProps {
-  children?: any;
+  children?: React.ReactNode;
   isOpen: boolean;
-  handleClose: any;
+  handleClose: () => void;
   hasCloseBtn: boolean;
   isDark?: boolean;
+  textAlign?: string;
 }
 
 const Unimodal: React.FC<UnimodalProps> = ({
@@ -19,8 +20,10 @@ const Unimodal: React.FC<UnimodalProps> = ({
   handleClose,
   hasCloseBtn,
   isDark,
+  textAlign,
 }) => {
-  const classes = useStyles();
+  const styleProps = { textAlign, isDark };
+  const classes = useStyles(styleProps);
 
   return (
     <Modal
@@ -32,15 +35,13 @@ const Unimodal: React.FC<UnimodalProps> = ({
       aria-labelledby="simple-modal-title"
       aria-describedby="simple-modal-description"
     >
-      <div
-        className={isDark ? classes.darkModalContainer : classes.modalContainer}
-      >
+      <div className={classes.modalContainer}>
         {hasCloseBtn && (
           <div className={classes.modalContainerClose}>
             <Button
               variant="outlined"
               color="secondary"
-              className={isDark ? classes.darkCloseButton : classes.closeButton}
+              className={classes.closeButton}
               onClick={handleClose}
             >
               &#x2715;

--- a/litmus-portal/frontend/src/components/Unimodal/index.tsx
+++ b/litmus-portal/frontend/src/components/Unimodal/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Modal from '@material-ui/core/Modal';
+import Button from '@material-ui/core/Button';
+import useStyles from './styles';
+
+/* WelcomeModal, PasswordModal, FinishModal, PersonalDetails, ChooseWorkflow, ReliabiltyScore, VerifyCommit */
+
+interface UnimodalProps {
+  children?: any;
+  isOpen: boolean;
+  handleClose: any;
+  hasCloseBtn: boolean;
+}
+
+const Unimodal: React.FC<UnimodalProps> = ({
+  children,
+  isOpen,
+  handleClose,
+  hasCloseBtn,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleClose}
+      disableBackdropClick
+      disableEscapeKeyDown
+    >
+      <div className={classes.modalContainer}>
+        {hasCloseBtn && (
+          <div className={classes.modalContainerClose}>
+            <Button
+              variant="outlined"
+              color="secondary"
+              className={classes.closeButton}
+              onClick={handleClose}
+            >
+              &#x2715;
+            </Button>
+          </div>
+        )}
+        {children}
+      </div>
+    </Modal>
+  );
+};
+
+export default Unimodal;

--- a/litmus-portal/frontend/src/components/Unimodal/index.tsx
+++ b/litmus-portal/frontend/src/components/Unimodal/index.tsx
@@ -3,13 +3,14 @@ import Modal from '@material-ui/core/Modal';
 import Button from '@material-ui/core/Button';
 import useStyles from './styles';
 
-/* WelcomeModal, PasswordModal, FinishModal, PersonalDetails, ChooseWorkflow, ReliabiltyScore, VerifyCommit */
+/* DelUser, NewUserModal, ResetModal need to be shifted */
 
 interface UnimodalProps {
   children?: any;
   isOpen: boolean;
   handleClose: any;
   hasCloseBtn: boolean;
+  isDark?: boolean;
 }
 
 const Unimodal: React.FC<UnimodalProps> = ({
@@ -17,6 +18,7 @@ const Unimodal: React.FC<UnimodalProps> = ({
   isOpen,
   handleClose,
   hasCloseBtn,
+  isDark,
 }) => {
   const classes = useStyles();
 
@@ -26,14 +28,19 @@ const Unimodal: React.FC<UnimodalProps> = ({
       onClose={handleClose}
       disableBackdropClick
       disableEscapeKeyDown
+      data-cy="modal"
+      aria-labelledby="simple-modal-title"
+      aria-describedby="simple-modal-description"
     >
-      <div className={classes.modalContainer}>
+      <div
+        className={isDark ? classes.darkModalContainer : classes.modalContainer}
+      >
         {hasCloseBtn && (
           <div className={classes.modalContainerClose}>
             <Button
               variant="outlined"
               color="secondary"
-              className={classes.closeButton}
+              className={isDark ? classes.darkCloseButton : classes.closeButton}
               onClick={handleClose}
             >
               &#x2715;

--- a/litmus-portal/frontend/src/components/Unimodal/styles.ts
+++ b/litmus-portal/frontend/src/components/Unimodal/styles.ts
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  modalContainer: {
+    height: '85%',
+    width: '70%',
+    margin: '2rem auto',
+    background: theme.palette.common.white,
+    borderRadius: 3,
+    textAlign: 'center',
+    outline: 'none',
+  },
+
+  modalContainerClose: {
+    paddingLeft: theme.spacing(72),
+    paddingRight: theme.spacing(0),
+    paddingBottom: theme.spacing(0),
+  },
+
+  closeButton: {
+    fontSize: '1rem',
+    fontWeight: 1000,
+    display: 'inline-block',
+    padding: `${theme.spacing(0.375)} ${theme.spacing(1.5)}`,
+    minHeight: 0,
+    minWidth: 0,
+    borderRadius: 3,
+    color: 'rgba(0, 0, 0, 0.4)',
+    border: '1px solid rgba(0, 0, 0, 0.4)',
+    marginLeft: '60%',
+    marginTop: theme.spacing(5),
+  },
+}));
+
+export default useStyles;

--- a/litmus-portal/frontend/src/components/Unimodal/styles.ts
+++ b/litmus-portal/frontend/src/components/Unimodal/styles.ts
@@ -2,11 +2,20 @@ import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   modalContainer: {
-    height: '85%',
     width: '70%',
+    padding: '1rem',
     margin: '2rem auto',
     background: theme.palette.common.white,
     borderRadius: 3,
+    textAlign: 'center',
+    outline: 'none',
+  },
+
+  darkModalContainer: {
+    width: '70%',
+    padding: '1rem',
+    margin: '2rem auto',
+    background: '#161616',
     textAlign: 'center',
     outline: 'none',
   },
@@ -27,6 +36,20 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: 3,
     color: 'rgba(0, 0, 0, 0.4)',
     border: '1px solid rgba(0, 0, 0, 0.4)',
+    marginLeft: '60%',
+    marginTop: theme.spacing(5),
+  },
+
+  darkCloseButton: {
+    fontSize: '1rem',
+    fontWeight: 1000,
+    display: 'inline-block',
+    padding: `${theme.spacing(0.375)} ${theme.spacing(1.5)}`,
+    minHeight: 0,
+    minWidth: 0,
+    borderRadius: 3,
+    color: 'rgba(255, 255, 255, 0.4)',
+    border: '1px solid rgba(255, 255, 255, 0.4)',
     marginLeft: '60%',
     marginTop: theme.spacing(5),
   },

--- a/litmus-portal/frontend/src/components/Unimodal/styles.ts
+++ b/litmus-portal/frontend/src/components/Unimodal/styles.ts
@@ -1,24 +1,20 @@
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 
-const useStyles = makeStyles((theme) => ({
-  modalContainer: {
+const useStyles = makeStyles((theme: Theme) => ({
+  modalContainer: (props: any) => ({
+    height: '85%',
     width: '70%',
     padding: '1rem',
     margin: '2rem auto',
-    background: theme.palette.common.white,
+    background: props.isDark
+      ? theme.palette.common.black
+      : theme.palette.common.white,
     borderRadius: 3,
-    textAlign: 'center',
+    textAlign: props.textAlign ? props.textAlign : 'center',
     outline: 'none',
-  },
-
-  darkModalContainer: {
-    width: '70%',
-    padding: '1rem',
-    margin: '2rem auto',
-    background: '#161616',
-    textAlign: 'center',
-    outline: 'none',
-  },
+    overflowX: 'hidden',
+    overflowY: 'auto',
+  }),
 
   modalContainerClose: {
     paddingLeft: theme.spacing(72),
@@ -26,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: theme.spacing(0),
   },
 
-  closeButton: {
+  closeButton: (props: any) => ({
     fontSize: '1rem',
     fontWeight: 1000,
     display: 'inline-block',
@@ -34,25 +30,13 @@ const useStyles = makeStyles((theme) => ({
     minHeight: 0,
     minWidth: 0,
     borderRadius: 3,
-    color: 'rgba(0, 0, 0, 0.4)',
-    border: '1px solid rgba(0, 0, 0, 0.4)',
+    color: props.isDark ? 'rgba(255, 255, 255, 0.4)' : 'rgba(0, 0, 0, 0.4)',
+    border: props.isDark
+      ? '1px solid rgba(255, 255, 255, 0.4)'
+      : '1px solid rgba(0, 0, 0, 0.4)',
     marginLeft: '60%',
     marginTop: theme.spacing(5),
-  },
-
-  darkCloseButton: {
-    fontSize: '1rem',
-    fontWeight: 1000,
-    display: 'inline-block',
-    padding: `${theme.spacing(0.375)} ${theme.spacing(1.5)}`,
-    minHeight: 0,
-    minWidth: 0,
-    borderRadius: 3,
-    color: 'rgba(255, 255, 255, 0.4)',
-    border: '1px solid rgba(255, 255, 255, 0.4)',
-    marginLeft: '60%',
-    marginTop: theme.spacing(5),
-  },
+  }),
 }));
 
 export default useStyles;

--- a/litmus-portal/frontend/src/components/VerifyCommit/index.tsx
+++ b/litmus-portal/frontend/src/components/VerifyCommit/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Link, Modal, Typography } from '@material-ui/core';
+import { Divider, Link, Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { experimentMap, WorkflowData } from '../../models/workflow';
@@ -17,6 +17,7 @@ import {
   parseYamlValidations,
 } from '../YamlEditor/Validations';
 import useStyles from './styles';
+import Unimodal from '../Unimodal';
 
 interface VerifyCommitProps {
   goto: () => void;
@@ -245,29 +246,17 @@ const VerifyCommit: React.FC<VerifyCommitProps> = ({ goto }) => {
         </div>
       </div>
 
-      <Modal open={open} onClose={handleClose}>
-        <div className={classes.modalContainer}>
-          <div className={classes.modalContainerClose}>
-            <Button
-              variant="outlined"
-              color="secondary"
-              className={classes.closeButtonStyle}
-              onClick={handleClose}
-            >
-              &#x2715;
-            </Button>
-          </div>
-          <YamlEditor
-            content={yaml}
-            filename={name}
-            yamlLink={link}
-            id={id}
-            description={description}
-            readOnly
-            optionsDisplay={false}
-          />
-        </div>
-      </Modal>
+      <Unimodal isOpen={open} handleClose={handleClose} hasCloseBtn isDark>
+        <YamlEditor
+          content={yaml}
+          filename={name}
+          yamlLink={link}
+          id={id}
+          description={description}
+          readOnly
+          optionsDisplay={false}
+        />
+      </Unimodal>
     </div>
   );
 };

--- a/litmus-portal/frontend/src/components/VerifyCommit/styles.ts
+++ b/litmus-portal/frontend/src/components/VerifyCommit/styles.ts
@@ -95,36 +95,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   buttonOutlineText: {
     padding: theme.spacing(1.5),
   },
-  modalContainer: {
-    width: '61.25rem',
-    height: '29rem',
-    marginLeft: '20%',
-    marginTop: '5.5%',
-    background: '#161616',
-    outline: 'none',
-  },
-  modalContainerClose: {
-    paddingLeft: theme.spacing(115),
-  },
   errorText: {
     fontSize: '1rem',
     color: 'red',
     marginLeft: theme.spacing(5),
-  },
-  closeButtonStyle: {
-    fontSize: '1rem',
-    fontWeight: 1000,
-    display: 'inline-block',
-    paddingTop: theme.spacing(0.375),
-    paddingBottom: theme.spacing(0.375),
-    paddingLeft: theme.spacing(1.5),
-    paddingRight: theme.spacing(1.5),
-    minHeight: 0,
-    minWidth: 0,
-    borderRadius: 3,
-    color: 'rgba(255, 255, 255, 0.4)',
-    border: '1px solid rgba(255, 255, 255, 0.4)',
-    marginTop: theme.spacing(2.5),
   },
   yamlFlex: {
     display: 'flex',

--- a/litmus-portal/frontend/src/components/WelcomeModal/index.tsx
+++ b/litmus-portal/frontend/src/components/WelcomeModal/index.tsx
@@ -1,7 +1,7 @@
-import Modal from '@material-ui/core/Modal';
 import React from 'react';
 import ModalStepper from './Stepper';
 import useStyles from './styles';
+import Unimodal from '../Unimodal';
 
 interface WelcomemodalProps {
   handleIsOpen: () => void;
@@ -24,14 +24,9 @@ const Welcomemodal: React.FC<WelcomemodalProps> = ({ handleIsOpen }) => {
 
   return (
     <div>
-      <Modal
-        open
-        onClose={handleClose}
-        disableBackdropClick
-        disableEscapeKeyDown
-      >
+      <Unimodal isOpen handleClose={handleClose} hasCloseBtn={false}>
         {body}
-      </Modal>
+      </Unimodal>
     </div>
   );
 };

--- a/litmus-portal/frontend/src/components/WelcomeModal/styles.ts
+++ b/litmus-portal/frontend/src/components/WelcomeModal/styles.ts
@@ -3,13 +3,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme: Theme) => ({
   /* CSS for Index */
   rootContainer: {
-    margin: '3rem auto',
-    width: '60%',
-    height: '85%',
-    background: theme.palette.common.white,
-    borderRadius: 3,
-    textAlign: 'center',
-    outline: 'none',
+    paddingBottom: '8.5rem',
   },
 
   /* CSS for Modal Page Component */

--- a/litmus-portal/frontend/src/components/WelcomeModal/styles.ts
+++ b/litmus-portal/frontend/src/components/WelcomeModal/styles.ts
@@ -3,7 +3,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme: Theme) => ({
   /* CSS for Index */
   rootContainer: {
-    paddingBottom: '8.5rem',
+    paddingBottom: theme.spacing(2),
   },
 
   /* CSS for Modal Page Component */


### PR DESCRIPTION
## Proposed changes
Making a unified modal component, `Unimodal`. This unified modal does not need to be styled again when it needs to be used. Only content passed inside the modal needs to be styled. Can pass flags such as `hasCloseBtn` to automatically add a close button to the top right and `isDark` to make modal background dark. Most modals have been adapted to use the unified modal. Pertaining to issue #1887 
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Special notes for your reviewer:
This does not bring about a difference in the modal responsiveness behaviour as such. That needs to be handled separately.