### PR TITLE
Adding flag.Parse() and struct for clusteconfim mutation response

### DIFF
--- a/litmus-portal/backend/subscriber/pkg/types/types.go
+++ b/litmus-portal/backend/subscriber/pkg/types/types.go
@@ -23,9 +23,9 @@ type Data struct {
 }
 
 type ClusterConfirm struct {
-	IsClusterConfirmed bool `json:isClusterConfirmed`
-	NewClusterKey string `json:newClusterKey`
-	ClusterID string `json:cluster_id`
+	IsClusterConfirmed bool   `json:isClusterConfirmed`
+	NewClusterKey      string `json:newClusterKey`
+	ClusterID          string `json:cluster_id`
 }
 
 type ClusterConnect struct {

--- a/litmus-portal/backend/subscriber/pkg/types/types.go
+++ b/litmus-portal/backend/subscriber/pkg/types/types.go
@@ -18,7 +18,14 @@ type Payload struct {
 }
 
 type Data struct {
+	ClusterConfirm ClusterConfirm `json:"clusterConfirm"`
 	ClusterConnect ClusterConnect `json:"clusterConnect"`
+}
+
+type ClusterConfirm struct {
+	IsClusterConfirmed bool `json:isClusterConfirmed`
+	NewClusterKey string `json:newClusterKey`
+	ClusterID string `json:cluster_id`
 }
 
 type ClusterConnect struct {

--- a/litmus-portal/backend/subscriber/subscriber.go
+++ b/litmus-portal/backend/subscriber/subscriber.go
@@ -48,7 +48,7 @@ func init() {
 
 		if responseInterface.Data.ClusterConfirm.IsClusterConfirmed == true {
 			log.Println("cluster confirmed")
-			clusterData["KEY"] =  responseInterface.Data.ClusterConfirm.NewClusterKey
+			clusterData["KEY"] = responseInterface.Data.ClusterConfirm.NewClusterKey
 			cluster.ClusterRegister(clusterData)
 		} else {
 			log.Fatal("Cluster not confirmed")

--- a/litmus-portal/backend/subscriber/subscriber.go
+++ b/litmus-portal/backend/subscriber/subscriber.go
@@ -6,9 +6,9 @@ import (
 	"github.com/litmuschaos/litmus/litmus-portal/backend/subscriber/pkg/cluster"
 	"github.com/litmuschaos/litmus/litmus-portal/backend/subscriber/pkg/gql"
 	"github.com/litmuschaos/litmus/litmus-portal/backend/subscriber/pkg/k8s"
+	"github.com/litmuschaos/litmus/litmus-portal/backend/subscriber/pkg/types"
 	"log"
 	"os"
-	"strings"
 )
 
 var (
@@ -23,6 +23,7 @@ var (
 
 func init() {
 	k8s.KubeConfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.Parse()
 
 	var isConfirmed bool
 	isConfirmed, newKey, err = cluster.IsClusterConfirmed(clusterData)
@@ -39,15 +40,15 @@ func init() {
 			log.Fatal(err)
 		}
 
-		var responseInterface map[string]map[string]map[string]interface{}
+		var responseInterface types.Payload
 		err = json.Unmarshal(bodyText, &responseInterface)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if responseInterface["data"]["clusterConfirm"]["isClusterConfirmed"] == true {
+		if responseInterface.Data.ClusterConfirm.IsClusterConfirmed == true {
 			log.Println("cluster confirmed")
-			clusterData["KEY"] = strings.TrimSpace(responseInterface["data"]["clusterConfirm"]["newClusterKey"].(string))
+			clusterData["KEY"] =  responseInterface.Data.ClusterConfirm.NewClusterKey
 			cluster.ClusterRegister(clusterData)
 		} else {
 			log.Fatal("Cluster not confirmed")


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Changes:
1. Adding flag.Parse() (Now it will work both as incluster and outcluster)
2. Adding a struct for the response of `clusterconfirm` mutation

Issue- https://github.com/litmuschaos/litmus/issues/1903
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
