### PR TITLE
Added Message field to Workflow-Run execution data

### DIFF
--- a/litmus-portal/backend/subscriber/pkg/cluster/events/workflow.go
+++ b/litmus-portal/backend/subscriber/pkg/cluster/events/workflow.go
@@ -90,6 +90,7 @@ func workflowEventHandler(obj interface{}, eventType string, stream chan types.W
 			FinishedAt: StrConvTime(nodeStatus.FinishedAt.Unix()),
 			Children:   nodeStatus.Children,
 			ChaosExp:   cd,
+			Message:    nodeStatus.Message,
 		}
 		nodes[nodeStatus.ID] = details
 	}
@@ -101,6 +102,7 @@ func workflowEventHandler(obj interface{}, eventType string, stream chan types.W
 		Name:              workflowObj.ObjectMeta.Name,
 		CreationTimestamp: StrConvTime(workflowObj.ObjectMeta.CreationTimestamp.Unix()),
 		Phase:             string(workflowObj.Status.Phase),
+		Message:           workflowObj.Status.Message,
 		StartedAt:         StrConvTime(workflowObj.Status.StartedAt.Unix()),
 		FinishedAt:        StrConvTime(workflowObj.Status.FinishedAt.Unix()),
 		Nodes:             nodes,

--- a/litmus-portal/backend/subscriber/pkg/types/event.go
+++ b/litmus-portal/backend/subscriber/pkg/types/event.go
@@ -9,6 +9,7 @@ type WorkflowEvent struct {
 	Name              string          `json:"name"`
 	CreationTimestamp string          `json:"creationTimestamp"`
 	Phase             string          `json:"phase"`
+	Message           string          `json:"message"`
 	StartedAt         string          `json:"startedAt"`
 	FinishedAt        string          `json:"finishedAt"`
 	Nodes             map[string]Node `json:"nodes"`
@@ -18,6 +19,7 @@ type WorkflowEvent struct {
 type Node struct {
 	Name       string     `json:"name"`
 	Phase      string     `json:"phase"`
+	Message    string     `json:"message"`
 	StartedAt  string     `json:"startedAt"`
 	FinishedAt string     `json:"finishedAt"`
 	Children   []string   `json:"children"`


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

- Added message field to the workflow-run execution data
- This field will contain messages regarding the workflow status (required for workflow errors)

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)