### PR TITLE
Changing MongoDB operation for a unique update of workflow collection

### DIFF
--- a/litmus-portal/backend/graphql-server/pkg/database/mongodb/operations.go
+++ b/litmus-portal/backend/graphql-server/pkg/database/mongodb/operations.go
@@ -68,7 +68,7 @@ func UpsertWorkflowRun(workflow_id string, wfRun WorkflowRun) error {
 			return err
 		}
 	}
-	
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes
Currently, workflow-collection inserts duplicate `workflow_run_id`. This commit will do a custom upsert operation.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
