### PR TITLE
chore(litmus-portal): Fixed pre-selection from Template & toggling button for initial workflow selection

### DIFF
--- a/litmus-portal/frontend/src/components/PredifinedWorkflows/data.ts
+++ b/litmus-portal/frontend/src/components/PredifinedWorkflows/data.ts
@@ -1,6 +1,6 @@
 export default [
   {
-    workflowID: '1',
+    workflowID: 0,
     title: 'node-cpu-hog',
     urlToIcon:
       'https://hub.litmuschaos.io/api/icon/1.7.0/generic/node-cpu-hog.png',
@@ -15,7 +15,7 @@ export default [
     isCustom: false,
   },
   {
-    workflowID: '2',
+    workflowID: 1,
     title: 'node-memory-hog',
     urlToIcon:
       'https://hub.litmuschaos.io/api/icon/1.7.0/generic/node-memory-hog.png',
@@ -30,7 +30,7 @@ export default [
     isCustom: false,
   },
   {
-    workflowID: '3',
+    workflowID: 2,
     title: 'pod-cpu-hog',
     urlToIcon:
       'https://hub.litmuschaos.io/api/icon/1.7.0/generic/pod-cpu-hog.png',
@@ -45,7 +45,7 @@ export default [
     isCustom: false,
   },
   {
-    workflowID: '4',
+    workflowID: 3,
     title: 'pod-memory-hog',
     urlToIcon:
       'https://hub.litmuschaos.io/api/icon/1.7.0/generic/pod-memory-hog.png',
@@ -60,7 +60,7 @@ export default [
     isCustom: false,
   },
   {
-    workflowID: '5',
+    workflowID: 4,
     title: 'pod-delete',
     urlToIcon:
       'https://hub.litmuschaos.io/api/icon/1.7.0/generic/pod-delete.png',

--- a/litmus-portal/frontend/src/components/WorkflowCard/CardContent.tsx
+++ b/litmus-portal/frontend/src/components/WorkflowCard/CardContent.tsx
@@ -1,18 +1,28 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { preDefinedWorkflowData } from '../../models/predefinedWorkflow';
-import useStyles from './styles';
+import { RootState } from '../../redux/reducers';
 import parsed from '../../utils/yamlUtils';
+import useStyles from './styles';
 
 const CardContent: React.FC<preDefinedWorkflowData> = ({
   title,
   urlToIcon,
+  workflowID,
   provider,
   handleClick,
   description,
   chaosWkfCRDLink,
 }) => {
+  const selectedTemplateID = useSelector(
+    (state: RootState) => state.selectTemplate.selectedTemplateID
+  );
+
+  const isSelected: boolean =
+    workflowID !== undefined && workflowID === selectedTemplateID;
+
   const classes = useStyles();
 
   const [yamlText, setYamlText] = useState<string>('');
@@ -53,7 +63,14 @@ const CardContent: React.FC<preDefinedWorkflowData> = ({
 
   return (
     <div className={classes.card}>
-      <div className={classes.cardContent} onClick={handleClick}>
+      <div
+        className={`${
+          isSelected
+            ? `${classes.cardContent} ${classes.cardFocused}`
+            : classes.cardContent
+        }`}
+        onClick={handleClick}
+      >
         <div className={classes.cardAnalytics}>
           {/* {totalRuns ? (
             <span

--- a/litmus-portal/frontend/src/components/WorkflowCard/styles.ts
+++ b/litmus-portal/frontend/src/components/WorkflowCard/styles.ts
@@ -4,14 +4,14 @@ const useStyles = makeStyles((theme) => ({
   // CustomWorkflow
 
   customCard: {
-    background: theme.palette.grey[200],
+    background: theme.palette.customColors.gray,
     borderRadius: 3,
     overflow: 'hidden',
     fontSize: '0.875rem',
     margin: '0 auto',
     textAlign: 'center',
     cursor: 'pointer',
-    border: '1px solid rgba(0, 0, 0, 0.2)',
+    border: `1px solid ${theme.palette.text.hint}`,
     boxSizing: 'border-box',
   },
 
@@ -33,24 +33,29 @@ const useStyles = makeStyles((theme) => ({
     margin: theme.spacing(1),
     textAlign: 'center',
     cursor: 'pointer',
-    border: '1px solid rgba(0, 0, 0, 0.2)',
+    border: `1px solid ${theme.palette.text.hint}`,
     boxSizing: 'border-box',
     '&:hover': {
-      border: '1px solid #5B44BA',
-      boxShadow: '0px 4px 4px rgba(91, 68, 186, 0.25)',
+      border: `1px solid ${theme.palette.secondary.dark}`,
+      boxShadow: `0px 4px 4px ${theme.palette.shadow.blue}`,
     },
+  },
+
+  cardFocused: {
+    border: `1px solid ${theme.palette.secondary.dark}`,
+    boxShadow: `0px 4px 4px ${theme.palette.shadow.blue}`,
   },
 
   cardSelected: {
     background: theme.palette.background.paper,
-    boxShadow: '0px 4px 4px rgba(91, 68, 186, 0.25)',
+    boxShadow: `0px 4px 4px ${theme.palette.shadow.blue}`,
     borderRadius: 3,
     overflow: 'hidden',
     fontSize: '0.875rem',
     margin: '0 auto',
     textAlign: 'center',
     cursor: 'pointer',
-    border: '1px solid #5B44BA',
+    border: `1px solid ${theme.palette.secondary.dark}`,
     boxSizing: 'border-box',
   },
 

--- a/litmus-portal/frontend/src/components/WorkflowStepper/index.tsx
+++ b/litmus-portal/frontend/src/components/WorkflowStepper/index.tsx
@@ -118,7 +118,6 @@ const CustomStepper = () => {
     (state: RootState) => state.workflowData
   );
   const {
-    id,
     yaml,
     weights,
     description,
@@ -130,6 +129,10 @@ const CustomStepper = () => {
   const selectedProjectID = useSelector(
     (state: RootState) => state.userData.selectedProjectID
   );
+  const isDisable = useSelector(
+    (state: RootState) => state.selectTemplate.isDisable
+  );
+
   const workflow = useActions(WorkflowActions);
   const [invalidYaml, setinValidYaml] = React.useState(false);
   const steps = getSteps();
@@ -309,7 +312,7 @@ const CustomStepper = () => {
                 <ButtonFilled
                   handleClick={() => handleNext()}
                   isPrimary
-                  isDisabled={id.length === 0}
+                  isDisabled={isDisable}
                 >
                   <div>
                     Next

--- a/litmus-portal/frontend/src/models/predefinedWorkflow.ts
+++ b/litmus-portal/frontend/src/models/predefinedWorkflow.ts
@@ -10,9 +10,9 @@ export interface preDefinedWorkflowData {
   provider?: string;
   description?: string;
   totalRuns?: number;
-  workflowID?: string;
+  workflowID?: number;
   CallbackOnSelectWorkflow?: SelectWorkflowCallBackType;
-  selectedID?: string;
+  selectedID?: number;
   isCustom?: boolean;
 }
 

--- a/litmus-portal/frontend/src/models/redux/template.ts
+++ b/litmus-portal/frontend/src/models/redux/template.ts
@@ -1,0 +1,18 @@
+export interface TemplateData {
+  selectedTemplateID: number;
+  isDisable: boolean;
+}
+
+export enum TemplateSelectionActions {
+  SELECT_TEMPLATE = 'SELECT_TEMPLATE',
+}
+
+interface TemplateSelectionActionType<T, P> {
+  type: T;
+  payload: P;
+}
+
+export type TemplateSelectionAction = TemplateSelectionActionType<
+  typeof TemplateSelectionActions.SELECT_TEMPLATE,
+  TemplateData
+>;

--- a/litmus-portal/frontend/src/pages/HomePage/index.tsx
+++ b/litmus-portal/frontend/src/pages/HomePage/index.tsx
@@ -19,20 +19,27 @@ import {
 } from '../../models/graphql/user';
 import useActions from '../../redux/actions';
 import * as TabActions from '../../redux/actions/tabs';
+import * as TemplateSelectionActions from '../../redux/actions/template';
 import * as UserActions from '../../redux/actions/user';
 import { history } from '../../redux/configureStore';
 import { RootState } from '../../redux/reducers';
 import useStyles from './style';
 
-const CreateWorkflowCard = () => {
+const CreateWorkflowCard: React.FC = () => {
   const { t } = useTranslation();
   const classes = useStyles();
+  const template = useActions(TemplateSelectionActions);
+
+  const handleCreateWorkflow = () => {
+    template.selectTemplate({ selectedTemplateID: 0, isDisable: true });
+    history.push('/create-workflow');
+  };
 
   return (
     <Card
       elevation={3}
       className={classes.createWorkflowCard}
-      onClick={() => history.push('/create-workflow')}
+      onClick={handleCreateWorkflow}
       data-cy="createWorkflow"
     >
       <CardActionArea>
@@ -48,8 +55,9 @@ const CreateWorkflowCard = () => {
   );
 };
 
-const HomePage = () => {
+const HomePage: React.FC = () => {
   const [isOpen, setIsOpen] = useState<boolean>(true);
+
   const userData = useSelector((state: RootState) => state.userData);
   const classes = useStyles();
   const { t } = useTranslation();

--- a/litmus-portal/frontend/src/redux/actions/template.ts
+++ b/litmus-portal/frontend/src/redux/actions/template.ts
@@ -1,0 +1,14 @@
+import {
+  TemplateData,
+  TemplateSelectionAction,
+  TemplateSelectionActions,
+} from '../../models/redux/template';
+
+export const selectTemplate = (data: TemplateData): TemplateSelectionAction => {
+  return {
+    type: TemplateSelectionActions.SELECT_TEMPLATE,
+    payload: data,
+  };
+};
+
+export default selectTemplate;

--- a/litmus-portal/frontend/src/redux/reducers/index.ts
+++ b/litmus-portal/frontend/src/redux/reducers/index.ts
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import { Node } from '../../models/graphql/workflowData';
 import { CommunityData } from '../../models/redux/analytics';
 import { TabState } from '../../models/redux/tabs';
+import { TemplateData } from '../../models/redux/template';
 import { UserData } from '../../models/redux/user';
 import { WorkflowData } from '../../models/redux/workflow';
 import * as analyticsReducer from './analytics';
 import * as nodeSelectionReducer from './nodeSelection';
 import * as tabsReducer from './tabs';
+import * as templateReducer from './template';
 import * as userReducer from './user';
 import * as workflowReducer from './workflow';
 
@@ -16,6 +18,7 @@ export interface RootState {
   workflowData: WorkflowData;
   selectedNode: Node;
   tabNumber: TabState;
+  selectTemplate: TemplateData;
 }
 
 export default () =>
@@ -25,4 +28,5 @@ export default () =>
     ...workflowReducer,
     ...nodeSelectionReducer,
     ...tabsReducer,
+    ...templateReducer,
   });

--- a/litmus-portal/frontend/src/redux/reducers/template.ts
+++ b/litmus-portal/frontend/src/redux/reducers/template.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  TemplateData,
+  TemplateSelectionAction,
+  TemplateSelectionActions,
+} from '../../models/redux/template';
+import createReducer from './createReducer';
+
+const initialState: TemplateData = {
+  selectedTemplateID: 0,
+  isDisable: true,
+};
+
+export const selectTemplate = createReducer<TemplateData>(initialState, {
+  [TemplateSelectionActions.SELECT_TEMPLATE](
+    state: TemplateData,
+    action: TemplateSelectionAction
+  ) {
+    return {
+      ...state,
+      ...action.payload,
+    };
+  },
+});
+
+export default selectTemplate;

--- a/litmus-portal/frontend/src/theme/index.tsx
+++ b/litmus-portal/frontend/src/theme/index.tsx
@@ -32,6 +32,9 @@ declare module '@material-ui/core/styles/createPalette' {
     input: {
       disabled: string;
     };
+    shadow: {
+      blue: string;
+    };
     editorBackground: string;
   }
   // allow configuration using `createMuiTheme`
@@ -46,6 +49,9 @@ declare module '@material-ui/core/styles/createPalette' {
     };
     input?: {
       disabled?: string;
+    };
+    shadow?: {
+      blue: string;
     };
     editorBackground?: string;
   }
@@ -86,6 +92,9 @@ function customTheme(options: ThemeOptions) {
       },
       input: {
         disabled: '#e2e2e1',
+      },
+      shadow: {
+        blue: 'rgba(91, 68, 186, 0.25)',
       },
       customColors: {
         white: (opacity: number): string => {

--- a/litmus-portal/frontend/src/views/ChaosWorkflows/Templates/index.tsx
+++ b/litmus-portal/frontend/src/views/ChaosWorkflows/Templates/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PredifinedWorkflows from '../../../components/PredifinedWorkflows';
 import workflowData from '../../../components/PredifinedWorkflows/data';
+import useActions from '../../../redux/actions';
+import * as TemplateSelectionActions from '../../../redux/actions/template';
 import { history } from '../../../redux/configureStore';
 import parsed from '../../../utils/yamlUtils';
 import useStyles from './styles';
@@ -8,10 +10,20 @@ import useStyles from './styles';
 const Templates = () => {
   const classes = useStyles();
 
+  const template = useActions(TemplateSelectionActions);
   const testNames: string[] = [];
   const testWeights: number[] = [];
 
+  // Setting initial selected template ID to 0
+  template.selectTemplate({ selectedTemplateID: 0, isDisable: true });
+
   const selectWorkflow = (index: number) => {
+    // Updating template ID to the selected one
+    template.selectTemplate({
+      selectedTemplateID: index,
+      isDisable: false,
+    });
+
     fetch(workflowData[index].chaosWkfCRDLink)
       .then((data) => {
         data.text().then((yamlText) => {

--- a/litmus-portal/frontend/src/views/CreateWorkflow/ChooseWorkflow/index.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/ChooseWorkflow/index.tsx
@@ -1,21 +1,33 @@
 import { Typography } from '@material-ui/core';
 import Divider from '@material-ui/core/Divider';
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import ButtonFilled from '../../../components/Button/ButtonFilled';
 import ButtonOutline from '../../../components/Button/ButtonOutline';
 import PredifinedWorkflows from '../../../components/PredifinedWorkflows';
 import workflowsList from '../../../components/PredifinedWorkflows/data';
 import Unimodal from '../../../containers/layouts/Unimodal';
 import useActions from '../../../redux/actions';
+import * as TemplateSelectionActions from '../../../redux/actions/template';
 import * as WorkflowActions from '../../../redux/actions/workflow';
+import { RootState } from '../../../redux/reducers';
 import useStyles, { CssTextField } from './styles';
+
 // import { getWkfRunCount } from "../../utils";
 
 const ChooseWorkflow: React.FC = () => {
   const classes = useStyles();
+
   const workflow = useActions(WorkflowActions);
+  const template = useActions(TemplateSelectionActions);
+  const isDisable = useSelector(
+    (state: RootState) => state.selectTemplate.isDisable
+  );
+  const selectedTemplateID = useSelector(
+    (state: RootState) => state.selectTemplate.selectedTemplateID
+  );
+
   const [open, setOpen] = React.useState(false);
-  const [visible, setVisible] = React.useState(true);
   const [workflowDetails, setWorkflowData] = useState({
     workflowName: 'Personal Workflow Name',
     workflowDesc: 'Personal Description',
@@ -65,8 +77,9 @@ const ChooseWorkflow: React.FC = () => {
     });
   }, []);
 
+  // Sets workflow details based on user clicks
   const selectWorkflow = (index: number) => {
-    setVisible(false);
+    template.selectTemplate({ selectedTemplateID: index, isDisable: false });
     const timeStampBasedWorkflowName: string = `argowf-chaos-${
       workflowsList[index].title
     }-${Math.round(new Date().getTime() / 1000)}`;
@@ -88,6 +101,28 @@ const ChooseWorkflow: React.FC = () => {
       setOpen(true);
     }
   };
+
+  // Set pre-highlighter for initial render based on isDisable field
+  useEffect(() => {
+    const index = selectedTemplateID;
+
+    const timeStampBasedWorkflowName: string = `argowf-chaos-${
+      workflowsList[index].title
+    }-${Math.round(new Date().getTime() / 1000)}`;
+    workflow.setWorkflowDetails({
+      name: timeStampBasedWorkflowName,
+      link: workflowsList[index].chaosWkfCRDLink,
+      id: workflowsList[index].workflowID,
+      yaml: 'none',
+      description: workflowsList[index].description,
+      isCustomWorkflow: workflowsList[index].isCustom,
+    });
+
+    setWorkflowData({
+      workflowName: timeStampBasedWorkflowName,
+      workflowDesc: workflowsList[index].description,
+    });
+  }, [isDisable]);
 
   return (
     <div>
@@ -116,7 +151,7 @@ const ChooseWorkflow: React.FC = () => {
                 setOpen(true);
               }}
               isPrimary={false}
-              isDisabled={visible}
+              isDisabled={isDisable}
             >
               <div>Edit workflow name</div>
             </ButtonFilled>


### PR DESCRIPTION
Signed-off-by: Sayan Mondal <sayan.mondal@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR:
1. Fixes pre selection of workflow card when returning back from template
2. Adds a button toggle er global state
3. Doesn't tamper with workflow ID when creating a new schedule
4. Adds few colors to themes that were not earlier included

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [X] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the commit for DCO to be passed.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
