### PR TITLE
Bug-fix: using copier to copy the weightages struct

### DIFF
--- a/litmus-portal/backend/graphql-server/pkg/graphql/mutations/mutation.go
+++ b/litmus-portal/backend/graphql-server/pkg/graphql/mutations/mutation.go
@@ -1,7 +1,8 @@
 package mutations
 
 import (
-	"encoding/json"
+	"fmt"
+	"github.com/jinzhu/copier"
 	"log"
 	"strconv"
 	"time"
@@ -146,20 +147,15 @@ func LogsHandler(podLog model.PodLog, r store.StateData) (string, error) {
 }
 
 func CreateChaosWorkflow(input *model.ChaosWorkFlowInput, r store.StateData) (*model.ChaosWorkFlowResponse, error) {
-	marshalData, err := json.Marshal(input.Weightages)
-	if err != nil {
-		return &model.ChaosWorkFlowResponse{}, err
-	}
 
 	var Weightages []*database.WeightagesInput
-	if err := json.Unmarshal(marshalData, &Weightages); err != nil {
-		return &model.ChaosWorkFlowResponse{}, err
-	}
+	copier.Copy(&Weightages, &input.Weightages)
 
 	workflow_id := uuid.New().String()
 
 	newWorkflowManifest, _ := sjson.Set(input.WorkflowManifest, "metadata.labels.workflow_id", workflow_id)
 
+	fmt.Print()
 	newChaosWorkflow := database.ChaosWorkFlowInput{
 		WorkflowID:          workflow_id,
 		WorkflowManifest:    newWorkflowManifest,
@@ -175,7 +171,7 @@ func CreateChaosWorkflow(input *model.ChaosWorkFlowInput, r store.StateData) (*m
 		WorkflowRuns:        []*database.WorkflowRun{},
 	}
 
-	err = database.InsertChaosWorkflow(newChaosWorkflow)
+	err := database.InsertChaosWorkflow(newChaosWorkflow)
 	if err != nil {
 		return nil, err
 	}

--- a/litmus-portal/backend/graphql-server/pkg/graphql/mutations/mutation.go
+++ b/litmus-portal/backend/graphql-server/pkg/graphql/mutations/mutation.go
@@ -1,7 +1,6 @@
 package mutations
 
 import (
-	"fmt"
 	"github.com/jinzhu/copier"
 	"log"
 	"strconv"
@@ -155,7 +154,6 @@ func CreateChaosWorkflow(input *model.ChaosWorkFlowInput, r store.StateData) (*m
 
 	newWorkflowManifest, _ := sjson.Set(input.WorkflowManifest, "metadata.labels.workflow_id", workflow_id)
 
-	fmt.Print()
 	newChaosWorkflow := database.ChaosWorkFlowInput{
 		WorkflowID:          workflow_id,
 		WorkflowManifest:    newWorkflowManifest,


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes
Bug: Earlier it was not JSON marshalling the experiment name in weightage.
Fix: using copy struct is able to fix the bug

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
