### PR TITLE
(action)chore: Add github action for automerging the PR.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,10 +155,10 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "merge,!WIP,!DO NOT MERGE"
           MERGE_METHOD: "squash"
-          MERGE_FORKS: "false"
+          MERGE_FORKS: "true"
           MERGE_RETRIES: "6"
           MERGE_RETRY_SLEEP: "10000"
           UPDATE_LABELS: ""
-          UPDATE_METHOD: "rebase"
+          UPDATE_METHOD: "merge"
           MERGE_DELETE_BRANCH: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,12 +136,29 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
 
-  merge:
+  # This job will merge an equipped PR in two steps:
+  # Firstly it will add a merge label on the target PR and then it will merge the PR according to the envs provided.
+  merge:  
     if: contains(github.event.comment.html_url, '/pull/') && startsWith(github.event.comment.body, '/merge')
     runs-on: ubuntu-latest
     steps:
-      - name: Add a merge label when all jobs are passed
+      - name: Add a merge label 
         uses: actions-ecosystem/action-add-labels@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           labels: merge
+
+      # The action will automatically check if the required number of review approvals has been reached.   
+      - name: automerge      
+        uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
+        env:          
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "merge,!WIP,!DO NOT MERGE"
+          MERGE_METHOD: "squash"
+          MERGE_FORKS: "false"
+          MERGE_RETRIES: "6"
+          MERGE_RETRY_SLEEP: "10000"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"
+          MERGE_DELETE_BRANCH: true
+


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

## Details

- This PR adds GitHub actions for auto merging the equipped PRs. For merging, we need to comment `/merge` in the PR which will add a label  `merge` in the PR and then finally merge the PR according to the ENVs provided.

_Minimum Number of Approvals:_

- The action will automatically check if the required number of review approvals has been reached. If the number is not reached, it will not merge the PR. (ref. README for action details: [pascalgn/automerge-action](https://github.com/pascalgn/automerge-action#automerge-action))

- It will work according to the role of the commenter and branch protection Rule on the repository.

_Any tested PR?_

- Here is the tested PR with the action(https://github.com/uditgaurav/notes/pull/1). 

_Remove Automerge Pro Bot_

- Once we add this we don't need automerge probot in this repo. So we can remove it.