### PR TITLE
Removed expiration from cluster-registration jwt

### DIFF
--- a/litmus-portal/graphql-server/pkg/cluster/cluster_jwt.go
+++ b/litmus-portal/graphql-server/pkg/cluster/cluster_jwt.go
@@ -3,20 +3,16 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"os"
-	"time"
-
 	"github.com/dgrijalva/jwt-go"
+	"os"
 )
 
 var secret = os.Getenv("JWT_SECRET")
 
 //ClusterCreateJWT generates jwt used in cluster registration
 func ClusterCreateJWT(id string) (string, error) {
-	expirationTime := time.Now().Add(12 * time.Hour)
 	claims := jwt.MapClaims{}
 	claims["cluster_id"] = id
-	claims["exp"] = expirationTime.Unix()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	tokenString, err := token.SignedString([]byte(secret))


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

- Previously the cluster registration token was set to expire after 12hrs
- Updated it to never expire until the cluster is registered

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)