### PR TITLE
Fix for Settings route for different users with different roles.

### DIFF
--- a/litmus-portal/frontend/src/components/Header/index.tsx
+++ b/litmus-portal/frontend/src/components/Header/index.tsx
@@ -15,7 +15,7 @@ import {
 // import { Message, NotificationIds } from '../../models/header';
 import useActions from '../../redux/actions';
 import * as UserActions from '../../redux/actions/user';
-import configureStore from '../../redux/configureStore';
+import configureStore, { history } from '../../redux/configureStore';
 import { RootState } from '../../redux/reducers';
 import CustomBreadCrumbs from '../BreadCrumbs';
 // import NotificationsDropdown from './NotificationDropdown';
@@ -72,6 +72,10 @@ const Header: React.FC = () => {
               selectedUserRole: member.role,
               selectedProjectName: project.name,
             });
+
+            if (member.role !== 'Owner') {
+              history.push('/');
+            }
           }
         });
       }

--- a/litmus-portal/frontend/src/containers/app/App.tsx
+++ b/litmus-portal/frontend/src/containers/app/App.tsx
@@ -92,7 +92,6 @@ const Routes: React.FC<RoutesProps> = ({ isOwner, isProjectAvailable }) => {
         />
         <Route exact path="/community" component={Community} />
         <Route exact path="/targets" component={TargetHome} />
-        <Route exact path="/settings" component={Settings} />
         <Route exact path="/target-connect" component={ConnectTargets} />
         {isOwner ? (
           <Route exact path="/settings" component={Settings} />


### PR DESCRIPTION
Signed-off-by: Vedant Shrotria <vedant.shrotria@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

**This PR will fix:**
**- User who is not an owner won't be allowed to go to settings route.**
**- If User who is not an editor or owner of a project is on settings page, will be redirected to homepage while project switching.**

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [X] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the commit for DCO to be passed.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
