### PR TITLE
Bug-fix: Replacing string to space in error condition

### DIFF
--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -24,7 +24,7 @@ func MarshalGQLData(gqlData interface{}) (string, error) {
 // generate gql mutation payload for workflow event
 func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent) ([]byte, error) {
 	clusterID := `{cluster_id: \"` + cid + `\", access_key: \"` + accessKey + `\"}`
-	// process event data
+	
 	for id, event := range wfEvent.Nodes {
 		event.Message = strings.Replace(event.Message, `"`, ``, -1)
 		wfEvent.Nodes[id] = event

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -2,6 +2,7 @@ package gql
 
 import (
 	"encoding/json"
+	"log"
 	"strconv"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 
 // process event data into proper format acceptable by gql
 func MarshalGQLData(gqlData interface{}) (string, error) {
+	log.Print(gqlData)
 	data, err := json.Marshal(gqlData)
 	if err != nil {
 		return "", err
@@ -21,10 +23,18 @@ func MarshalGQLData(gqlData interface{}) (string, error) {
 	return processed, nil
 }
 
+
 // generate gql mutation payload for workflow event
 func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent) ([]byte, error) {
 	clusterID := `{cluster_id: \"` + cid + `\", access_key: \"` + accessKey + `\"}`
 	// process event data
+	for id, event := range wfEvent.Nodes {
+		if event.Phase == "Error" {
+			event.Message = strings.Replace(event.Message, `"`, ` `, -1)
+			wfEvent.Nodes[id] = event
+		}
+	}
+
 	processed, err := MarshalGQLData(wfEvent)
 	if err != nil {
 		return nil, err

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -2,7 +2,6 @@ package gql
 
 import (
 	"encoding/json"
-	"log"
 	"strconv"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 
 // process event data into proper format acceptable by gql
 func MarshalGQLData(gqlData interface{}) (string, error) {
-	log.Print(gqlData)
 	data, err := json.Marshal(gqlData)
 	if err != nil {
 		return "", err
@@ -30,7 +28,7 @@ func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent)
 	// process event data
 	for id, event := range wfEvent.Nodes {
 		if event.Phase == "Error" {
-			event.Message = strings.Replace(event.Message, `"`, ` `, -1)
+			event.Message = strings.Replace(event.Message, `"`, ``, -1)
 			wfEvent.Nodes[id] = event
 		}
 	}

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -24,7 +24,7 @@ func MarshalGQLData(gqlData interface{}) (string, error) {
 // generate gql mutation payload for workflow event
 func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent) ([]byte, error) {
 	clusterID := `{cluster_id: \"` + cid + `\", access_key: \"` + accessKey + `\"}`
-	
+
 	for id, event := range wfEvent.Nodes {
 		event.Message = strings.Replace(event.Message, `"`, ``, -1)
 		wfEvent.Nodes[id] = event

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -26,10 +26,8 @@ func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent)
 	clusterID := `{cluster_id: \"` + cid + `\", access_key: \"` + accessKey + `\"}`
 	// process event data
 	for id, event := range wfEvent.Nodes {
-		if event.Phase == "Error" {
-			event.Message = strings.Replace(event.Message, `"`, ``, -1)
-			wfEvent.Nodes[id] = event
-		}
+		event.Message = strings.Replace(event.Message, `"`, ``, -1)
+		wfEvent.Nodes[id] = event
 	}
 
 	processed, err := MarshalGQLData(wfEvent)

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -21,7 +21,6 @@ func MarshalGQLData(gqlData interface{}) (string, error) {
 	return processed, nil
 }
 
-
 // generate gql mutation payload for workflow event
 func GenerateWorkflowPayload(cid, accessKey string, wfEvent types.WorkflowEvent) ([]byte, error) {
 	clusterID := `{cluster_id: \"` + cid + `\", access_key: \"` + accessKey + `\"}`


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Subscriber is not able to parse an error string
eg: 			
```
"message": "pods \"argowf-chaos-pod-delete-1602350414-2208157228\" is forbidden: error looking up service account litmus/argo-chaos: serviceaccount \"argo-chaos\" not found"
```
Replacing it with space

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
