### PR TITLE
Adding is_cluster_confimed to true, once it got confirmed

### DIFF
--- a/litmus-portal/graphql-server/pkg/graphql/mutations/mutation.go
+++ b/litmus-portal/graphql-server/pkg/graphql/mutations/mutation.go
@@ -68,7 +68,7 @@ func ConfirmClusterRegistration(identity model.ClusterIdentity, r store.StateDat
 		newKey := utils.RandomString(32)
 		time := strconv.FormatInt(time.Now().Unix(), 10)
 		query := bson.D{{"cluster_id", identity.ClusterID}}
-		update := bson.D{{"$unset", bson.D{{"token", ""}}}, {"$set", bson.D{{"access_key", newKey}, {"is_registered", true}, {"updated_at", time}}}}
+		update := bson.D{{"$unset", bson.D{{"token", ""}}}, {"$set", bson.D{{"access_key", newKey}, {"is_registered", true}, {"is_cluster_confirmed", true}, {"updated_at", time}}}}
 
 		err = database.UpdateCluster(query, update)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Adding is_cluster_confimed 
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
