### PR TITLE
(litmus-portal): Minor bug fixes for analytics on litmus portal.

### DIFF
--- a/litmus-portal/frontend/src/views/Home/PassedVsFailed/index.tsx
+++ b/litmus-portal/frontend/src/views/Home/PassedVsFailed/index.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import Paper from '@material-ui/core/Paper';
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import { Avatar } from '@material-ui/core';
-import CheckCircleSharpIcon from '@material-ui/icons/CheckCircleSharp';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 import CancelSharpIcon from '@material-ui/icons/CancelSharp';
+import CheckCircleSharpIcon from '@material-ui/icons/CheckCircleSharp';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useStyles from './styles';
 
@@ -48,7 +48,7 @@ const PassedVsFailed: React.FC<PassedVsFailedProps> = ({ passed, failed }) => {
           <Box width={`${passedValue}%`} className={classes.passedBox}>
             {/* Render an empty div if props is not
             passed */}
-            {passedValue === 0 ? (
+            {passedValue < 11 ? (
               <div />
             ) : (
               <Avatar className={classes.passedIcon}>
@@ -59,7 +59,7 @@ const PassedVsFailed: React.FC<PassedVsFailedProps> = ({ passed, failed }) => {
           <Box width={`${failedValue}%`} className={classes.failedBox}>
             {/* Render an empty div if props is not
             passed */}
-            {failedValue === 0 ? (
+            {failedValue < 11 ? (
               <div />
             ) : (
               <Avatar className={classes.failedIcon}>

--- a/litmus-portal/frontend/src/views/Home/ResilienceScoreComparisonPlot/index.tsx
+++ b/litmus-portal/frontend/src/views/Home/ResilienceScoreComparisonPlot/index.tsx
@@ -1,7 +1,4 @@
 /* eslint-disable max-len */
-import React, { useEffect } from 'react';
-import Plotly from 'plotly.js';
-import createPlotlyComponent from 'react-plotly.js/factory';
 import {
   FormControl,
   IconButton,
@@ -10,14 +7,17 @@ import {
   Select,
   Tooltip,
 } from '@material-ui/core';
-import AssessmentOutlinedIcon from '@material-ui/icons/AssessmentOutlined';
-import { useTranslation } from 'react-i18next';
 import { useTheme } from '@material-ui/core/styles';
-import useStyles from './style';
-import Score from './Score';
-import { history } from '../../../redux/configureStore';
+import AssessmentOutlinedIcon from '@material-ui/icons/AssessmentOutlined';
+import Plotly from 'plotly.js';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import createPlotlyComponent from 'react-plotly.js/factory';
 import useActions from '../../../redux/actions';
 import * as TabActions from '../../../redux/actions/tabs';
+import { history } from '../../../redux/configureStore';
+import Score from './Score';
+import useStyles from './style';
 
 const Plot = createPlotlyComponent(Plotly);
 
@@ -80,10 +80,10 @@ const ResilienceScoreComparisonPlot: React.FC<ResilienceScoreComparisonPlotProps
       dataY = yData.Monthly;
     }
     const colors = [
-      palette.error.dark,
-      palette.primary.dark,
-      palette.warning.main,
       palette.secondary.main,
+      palette.warning.main,
+      palette.primary.dark,
+      palette.error.dark,
     ];
     const lineSize = [3, 3, 3, 3];
     const data = [];

--- a/litmus-portal/frontend/src/views/Home/ReturningHome/index.tsx
+++ b/litmus-portal/frontend/src/views/Home/ReturningHome/index.tsx
@@ -2,30 +2,30 @@
 /* eslint-disable no-loop-func */
 /* eslint-disable max-len */
 /* eslint-disable no-console */
-import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
-import moment from 'moment';
-import * as _ from 'lodash';
 import { Paper, Typography } from '@material-ui/core';
+import * as _ from 'lodash';
+import moment from 'moment';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useStyles from './style';
+import { useSelector } from 'react-redux';
+import Loader from '../../../components/Loader';
+import QuickActionCard from '../../../components/QuickActionCard';
 import { WORKFLOW_LIST_DETAILS } from '../../../graphql';
 import { ExecutionData } from '../../../models/graphql/workflowData';
-import { RootState } from '../../../redux/reducers';
-import PassedVsFailed from '../PassedVsFailed';
-import TotalWorkflows from '../TotalWorkflows';
-import AverageResilienceScore from '../AverageResilienceScore';
-import QuickActionCard from '../../../components/QuickActionCard';
-import { Message } from '../../../models/header';
-import ResilienceScoreComparisonPlot from '../ResilienceScoreComparisonPlot';
-import RecentActivity from '../RecentActivity';
-import Loader from '../../../components/Loader';
 import {
   WeightageMap,
   WorkflowList,
   WorkflowListDataVars,
 } from '../../../models/graphql/workflowListData';
+import { Message } from '../../../models/header';
+import { RootState } from '../../../redux/reducers';
+import AverageResilienceScore from '../AverageResilienceScore';
+import PassedVsFailed from '../PassedVsFailed';
+import RecentActivity from '../RecentActivity';
+import ResilienceScoreComparisonPlot from '../ResilienceScoreComparisonPlot';
+import TotalWorkflows from '../TotalWorkflows';
+import useStyles from './style';
 
 interface DataPresentCallBackType {
   (dataPresent: boolean): void;
@@ -93,7 +93,6 @@ const ReturningHome: React.FC<ReturningHomeProps> = ({
     WORKFLOW_LIST_DETAILS,
     {
       variables: { projectID: userData.selectedProjectID, workflowIDs: [] },
-      fetchPolicy: 'cache-and-network',
     }
   );
 


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan.gupta@mayadata.io>

## Proposed changes

Minor analytics bug fix.

The bugs:

1. Icons showing on passed vs failed component beyond 10% too which was to be removed as per @ajeshbaby 's review.
2. Due to fetch policy sometimes the query for analytics data was not getting triggered.
3. Red and green colour are reserved for use after only 2 lines available on workflow comparison graph on the home screen with other theme colours.

The fix:
1. Updated condition for the conditional rendering of icons.
2. Removed fetch policy override to default to network query rather than Apollo cache.
3. Changed order of colours on comparison graph colour array, pushing red and green colours to the end.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- None.

## Special notes for your reviewer:
Minor bug-fix PR.