### PR TITLE
Fixed an edge case where appinfo is not present in custom workflows

### DIFF
--- a/litmus-portal/frontend/src/components/YamlEditor/Editor.tsx
+++ b/litmus-portal/frontend/src/components/YamlEditor/Editor.tsx
@@ -234,9 +234,11 @@ const YamlEditor: React.FC<YamlEditorProps> = ({
     }
     setEditorState(stateObject as any);
     const yamlData = YAML.parse(content);
-    workflow.setWorkflowDetails({
-      namespace: yamlData.metadata.namespace,
-    });
+    if (readOnly !== true) {
+      workflow.setWorkflowDetails({
+        namespace: yamlData.metadata.namespace,
+      });
+    }
   }, []);
 
   return (

--- a/litmus-portal/frontend/src/views/CreateWorkflow/CustomWorkflow/TuneWorkflow/index.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/CustomWorkflow/TuneWorkflow/index.tsx
@@ -53,11 +53,14 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
     onCompleted: (data) => {
       const parsedYaml = YAML.parse(data.getYAMLData);
       setEnv([...parsedYaml.spec.experiments[0].spec.components.env]);
-      setAppInfo({
-        appns: parsedYaml.spec.appinfo.appns,
-        applabel: parsedYaml.spec.appinfo.applabel,
-        appkind: parsedYaml.spec.appinfo.appkind,
-      });
+      if (parsedYaml.spec.appinfo !== undefined) {
+        setAppInfo({
+          appns: parsedYaml.spec.appinfo.appns,
+          applabel: parsedYaml.spec.appinfo.applabel,
+          appkind: parsedYaml.spec.appinfo.appkind,
+        });
+      }
+      setAnnotation(parsedYaml.spec.annotationCheck);
       setYaml(YAML.stringify(parsedYaml));
       setLoadingEnv(false);
     },
@@ -107,11 +110,13 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
       });
     } else {
       const parsedYaml = YAML.parse(customWorkflow.yaml as string);
-      setAppInfo({
-        appns: parsedYaml.spec.appinfo.appns,
-        applabel: parsedYaml.spec.appinfo.applabel,
-        appkind: parsedYaml.spec.appinfo.appkind,
-      });
+      if (parsedYaml.spec.appinfo !== undefined) {
+        setAppInfo({
+          appns: parsedYaml.spec.appinfo.appns,
+          applabel: parsedYaml.spec.appinfo.applabel,
+          appkind: parsedYaml.spec.appinfo.appkind,
+        });
+      }
       setAnnotation(parsedYaml.spec.annotationCheck);
       setEnv([...parsedYaml.spec.experiments[0].spec.components.env]);
       setYaml(customWorkflow.yaml as string);
@@ -162,9 +167,11 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
     });
     const parsedYaml = YAML.parse(yaml);
     parsedYaml.spec.experiments[0].spec.components.env = newEnvs;
-    parsedYaml.spec.appinfo.appns = appInfo.appns;
-    parsedYaml.spec.appinfo.applabel = appInfo.applabel;
-    parsedYaml.spec.appinfo.appkind = appInfo.appkind;
+    if (parsedYaml.spec.appinfo !== undefined) {
+      parsedYaml.spec.appinfo.appns = appInfo.appns;
+      parsedYaml.spec.appinfo.applabel = appInfo.applabel;
+      parsedYaml.spec.appinfo.appkind = appInfo.appkind;
+    }
     parsedYaml.spec.annotationCheck = annotation;
     parsedYaml.metadata.name = customWorkflow.experiment_name?.split('/')[1];
     parsedYaml.metadata.namespace =
@@ -248,7 +255,7 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
             <Typography className={classes.appInfoHeader}>
               {t('customWorkflow.tuneExperiment.appInfo')}
             </Typography>
-            {YAML.parse(yaml).spec.appinfo.appns ? (
+            {YAML.parse(yaml).spec.appinfo?.appns ? (
               <div className={classes.appInfoDiv}>
                 <Typography className={classes.appInfoText}>appns:</Typography>
                 <div className={classes.inputField}>
@@ -270,7 +277,7 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
                 </div>
               </div>
             ) : null}
-            {YAML.parse(yaml).spec.appinfo.applabel ? (
+            {YAML.parse(yaml).spec.appinfo?.applabel ? (
               <div className={classes.appInfoDiv}>
                 <Typography className={classes.appInfoText}>
                   applabel:
@@ -294,7 +301,7 @@ const TuneCustomWorkflow: React.FC<VerifyCommitProps> = ({ gotoStep }) => {
                 </div>
               </div>
             ) : null}
-            {YAML.parse(yaml).spec.appinfo.appkind ? (
+            {YAML.parse(yaml).spec.appinfo?.appkind ? (
               <div className={classes.appKind}>
                 <Typography className={classes.appInfoText}>
                   appkind:


### PR DESCRIPTION
Signed-off-by: Amit Kumar Das <amitkumar.das@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Fixed an edge case where appinfo is not present in custom workflows like ec2-terminate experiment and display the default value of annotationCheck from the YAML in UI.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
