### PR TITLE
Added complete chaos result to workflow data

### DIFF
--- a/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/util.go
@@ -31,6 +31,7 @@ func getChaosData(engineName, engineNS string, chaosClient *v1alpha12.Litmuschao
 		if err != nil {
 			return nil, err
 		}
+		cd.ChaosResult = expRes
 		cd.ProbeSuccessPercentage = expRes.Status.ExperimentStatus.ProbeSuccessPercentage
 		cd.FailStep = expRes.Status.ExperimentStatus.FailStep
 		cd.ExperimentPod = crd.Status.Experiments[0].ExpPod

--- a/litmus-portal/cluster-agents/subscriber/pkg/types/event.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/types/event.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+
 // workflow data
 type WorkflowEvent struct {
 	WorkflowID        string          `json:"-"`
@@ -29,15 +31,16 @@ type Node struct {
 
 // chaos data
 type ChaosData struct {
-	EngineUID              string `json:"engineUID"`
-	EngineName             string `json:"engineName"`
-	Namespace              string `json:"namespace"`
-	ExperimentName         string `json:"experimentName"`
-	ExperimentStatus       string `json:"experimentStatus"`
-	LastUpdatedAt          string `json:"lastUpdatedAt"`
-	ExperimentVerdict      string `json:"experimentVerdict"`
-	ExperimentPod          string `json:"experimentPod"`
-	RunnerPod              string `json:"runnerPod"`
-	ProbeSuccessPercentage string `json:"probeSuccessPercentage"`
-	FailStep               string `json:"failStep"`
+	EngineUID              string                `json:"engineUID"`
+	EngineName             string                `json:"engineName"`
+	Namespace              string                `json:"namespace"`
+	ExperimentName         string                `json:"experimentName"`
+	ExperimentStatus       string                `json:"experimentStatus"`
+	LastUpdatedAt          string                `json:"lastUpdatedAt"`
+	ExperimentVerdict      string                `json:"experimentVerdict"`
+	ExperimentPod          string                `json:"experimentPod"`
+	RunnerPod              string                `json:"runnerPod"`
+	ProbeSuccessPercentage string                `json:"probeSuccessPercentage"`
+	FailStep               string                `json:"failStep"`
+	ChaosResult            *v1alpha1.ChaosResult `json:"chaosResult"`
 }


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

This PR adds a new field called `chaosResult` in the `chaosData` section of the workflow nodes(chaos steps) which contains the complete chaos result cr for the particular experiment

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)