### PR TITLE
fix(crds): Removing maxProperties field from openapi validator for chaosengine

### DIFF
--- a/docs/chaos-scheduler-v1.13.0.yaml
+++ b/docs/chaos-scheduler-v1.13.0.yaml
@@ -226,7 +226,6 @@ spec:
                                     method:
                                       type: object
                                       minProperties: 1
-                                      maxProperties: 1
                                       properties:
                                         get:
                                           type: object

--- a/docs/litmus-namespaced-scope/litmus-namespaced-crds.yaml
+++ b/docs/litmus-namespaced-scope/litmus-namespaced-crds.yaml
@@ -153,7 +153,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/docs/litmus-operator-ci.yaml
+++ b/docs/litmus-operator-ci.yaml
@@ -280,7 +280,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/docs/litmus-operator-latest.yaml
+++ b/docs/litmus-operator-latest.yaml
@@ -280,7 +280,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/docs/litmus-operator-v1.13.0-crd-v1.yaml
+++ b/docs/litmus-operator-v1.13.0-crd-v1.yaml
@@ -285,7 +285,6 @@ spec:
                                   method:
                                     type: object
                                     minProperties: 1
-                                    maxProperties: 1
                                     properties:
                                       get:
                                         type: object

--- a/docs/litmus-operator-v1.13.0.yaml
+++ b/docs/litmus-operator-v1.13.0.yaml
@@ -280,7 +280,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/litmus-portal/graphql-server/manifests/cluster/2a_litmus_crds.yaml
+++ b/litmus-portal/graphql-server/manifests/cluster/2a_litmus_crds.yaml
@@ -153,7 +153,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/litmus-portal/litmus-portal-crds.yml
+++ b/litmus-portal/litmus-portal-crds.yml
@@ -220,7 +220,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

-  Removing maxProperties field from the openapi validator of chaosengine crd. 

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
