### PR TITLE
Added workflow re-run feature

### DIFF
--- a/litmus-portal/graphql-server/graph/generated/generated.go
+++ b/litmus-portal/graphql-server/graph/generated/generated.go
@@ -208,6 +208,7 @@ type ComplexityRoot struct {
 		GitopsNotifer       func(childComplexity int, clusterInfo model.ClusterIdentity, workflowID string) int
 		NewClusterEvent     func(childComplexity int, clusterEvent model.ClusterEventInput) int
 		PodLog              func(childComplexity int, log model.PodLog) int
+		ReRunChaosWorkFlow  func(childComplexity int, workflowID string) int
 		RemoveInvitation    func(childComplexity int, member model.MemberInput) int
 		SaveMyHub           func(childComplexity int, myhubInput model.CreateMyHub, projectID string) int
 		SendInvitation      func(childComplexity int, member model.MemberInput) int
@@ -473,6 +474,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	UserClusterReg(ctx context.Context, clusterInput model.ClusterInput) (*model.ClusterRegResponse, error)
 	CreateChaosWorkFlow(ctx context.Context, input model.ChaosWorkFlowInput) (*model.ChaosWorkFlowResponse, error)
+	ReRunChaosWorkFlow(ctx context.Context, workflowID string) (string, error)
 	CreateUser(ctx context.Context, user model.CreateUserInput) (*model.User, error)
 	UpdateUser(ctx context.Context, user model.UpdateUserInput) (string, error)
 	DeleteChaosWorkflow(ctx context.Context, workflowid string) (bool, error)
@@ -1420,6 +1422,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.PodLog(childComplexity, args["log"].(model.PodLog)), true
+
+	case "Mutation.reRunChaosWorkFlow":
+		if e.complexity.Mutation.ReRunChaosWorkFlow == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_reRunChaosWorkFlow_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ReRunChaosWorkFlow(childComplexity, args["workflowID"].(string)), true
 
 	case "Mutation.removeInvitation":
 		if e.complexity.Mutation.RemoveInvitation == nil {
@@ -3614,8 +3628,9 @@ type Mutation {
 	userClusterReg(clusterInput: ClusterInput!): clusterRegResponse! @authorized
 
 	#It is used to create chaosworkflow
-	createChaosWorkFlow(input: ChaosWorkFlowInput!): ChaosWorkFlowResponse!
-		@authorized
+	createChaosWorkFlow(input: ChaosWorkFlowInput!): ChaosWorkFlowResponse! @authorized
+
+	reRunChaosWorkFlow(workflowID: String!): String! @authorized
 
 	createUser(user: CreateUserInput!): User! @authorized
 
@@ -4011,6 +4026,20 @@ func (ec *executionContext) field_Mutation_podLog_args(ctx context.Context, rawA
 		}
 	}
 	args["log"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_reRunChaosWorkFlow_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["workflowID"]; ok {
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["workflowID"] = arg0
 	return args, nil
 }
 
@@ -7668,6 +7697,67 @@ func (ec *executionContext) _Mutation_createChaosWorkFlow(ctx context.Context, f
 	res := resTmp.(*model.ChaosWorkFlowResponse)
 	fc.Result = res
 	return ec.marshalNChaosWorkFlowResponse2ᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐChaosWorkFlowResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_reRunChaosWorkFlow(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_reRunChaosWorkFlow_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().ReRunChaosWorkFlow(rctx, args["workflowID"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Authorized == nil {
+				return nil, errors.New("directive authorized is not implemented")
+			}
+			return ec.directives.Authorized(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, err
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(string); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_createUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -18901,6 +18991,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "createChaosWorkFlow":
 			out.Values[i] = ec._Mutation_createChaosWorkFlow(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "reRunChaosWorkFlow":
+			out.Values[i] = ec._Mutation_reRunChaosWorkFlow(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/litmus-portal/graphql-server/graph/schema.graphqls
+++ b/litmus-portal/graphql-server/graph/schema.graphqls
@@ -274,8 +274,9 @@ type Mutation {
 	userClusterReg(clusterInput: ClusterInput!): clusterRegResponse! @authorized
 
 	#It is used to create chaosworkflow
-	createChaosWorkFlow(input: ChaosWorkFlowInput!): ChaosWorkFlowResponse!
-		@authorized
+	createChaosWorkFlow(input: ChaosWorkFlowInput!): ChaosWorkFlowResponse! @authorized
+
+	reRunChaosWorkFlow(workflowID: String!): String! @authorized
 
 	createUser(user: CreateUserInput!): User! @authorized
 

--- a/litmus-portal/graphql-server/graph/schema.resolvers.go
+++ b/litmus-portal/graphql-server/graph/schema.resolvers.go
@@ -38,6 +38,10 @@ func (r *mutationResolver) CreateChaosWorkFlow(ctx context.Context, input model.
 	return wf_handler.CreateChaosWorkflow(ctx, &input, store.Store)
 }
 
+func (r *mutationResolver) ReRunChaosWorkFlow(ctx context.Context, workflowID string) (string, error) {
+	return wf_handler.ReRunWorkflow(workflowID)
+}
+
 func (r *mutationResolver) CreateUser(ctx context.Context, user model.CreateUserInput) (*model.User, error) {
 	return usermanagement.CreateUser(ctx, user)
 }


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

Added workflow re-run feature in backend, that allows running a one-time workflow again without re-creating a new schedule manually.

closes #2467 

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)