### PR TITLE
Updated workflow status to failed for stopped chaosengines

### DIFF
--- a/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/util.go
@@ -41,6 +41,9 @@ func getChaosData(engineName, engineNS string, chaosClient *v1alpha12.Litmuschao
 		cd.ExperimentName = crd.Status.Experiments[0].Name
 		cd.LastUpdatedAt = strconv.FormatInt(crd.Status.Experiments[0].LastUpdateTime.Unix(), 10)
 		cd.ExperimentVerdict = crd.Status.Experiments[0].Verdict
+	} else if strings.ToLower(string(crd.Status.EngineStatus)) == "stopped" {
+		cd.ExperimentVerdict = "Stopped"
+		cd.ExperimentStatus = "Stopped"
 	} else {
 		cd = nil
 	}

--- a/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/workflow.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/cluster/events/workflow.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
@@ -102,10 +103,11 @@ func workflowEventHandler(obj interface{}, eventType string, stream chan types.W
 			ChaosExp:   cd,
 			Message:    nodeStatus.Message,
 		}
-		if cd != nil && cd.ExperimentVerdict == "Fail" {
+		if cd != nil && (strings.ToLower(cd.ExperimentVerdict) == "fail" || strings.ToLower(cd.ExperimentVerdict) == "stopped") {
 			experimentFail = 1
 			details.Phase = "Failed"
 			details.Message = "Chaos Experiment Failed"
+			cd.ExperimentVerdict = "Fail"
 		}
 		nodes[nodeStatus.ID] = details
 	}


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

This PR modifies the subscriber to update the workflow and experiment status to `failed` when the chaos engine status is `stopped`

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
