### PR TITLE
chore(litmus-portal): Fix workflow name issue

### DIFF
--- a/litmus-portal/frontend/src/views/CreateWorkflow/ChooseWorkflow/index.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/ChooseWorkflow/index.tsx
@@ -43,6 +43,10 @@ const ChooseWorkflow: React.FC<ChooseWorkflowProps> = ({ isEditable }) => {
     workflowName: 'Personal Workflow Name',
     workflowDesc: 'Personal Description',
   });
+  const [prevWorkflowDetails, setPrevWorkflowData] = useState({
+    workflowName: 'Personal Workflow Name',
+    workflowDesc: 'Personal Description',
+  });
 
   const WorkflowNameChangeHandler = (
     event: React.ChangeEvent<{ value: string }>
@@ -183,6 +187,10 @@ const ChooseWorkflow: React.FC<ChooseWorkflowProps> = ({ isEditable }) => {
             <ButtonFilled
               data-cy="EditWorkflowButton"
               onClick={() => {
+                setPrevWorkflowData({
+                  workflowName: workflowDetails.workflowName,
+                  workflowDesc: workflowDetails.workflowDesc,
+                });
                 setOpen(true);
               }}
               variant="success"
@@ -210,10 +218,24 @@ const ChooseWorkflow: React.FC<ChooseWorkflowProps> = ({ isEditable }) => {
       <Modal
         data-cy="WorkflowDetailsModal"
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={() => {
+          setWorkflowData({
+            workflowName: prevWorkflowDetails.workflowName,
+            workflowDesc: prevWorkflowDetails.workflowDesc,
+          });
+          setOpen(false);
+        }}
         width="70%"
         modalActions={
-          <ButtonOutlined onClick={() => setOpen(false)}>
+          <ButtonOutlined
+            onClick={() => {
+              setWorkflowData({
+                workflowName: prevWorkflowDetails.workflowName,
+                workflowDesc: prevWorkflowDetails.workflowDesc,
+              });
+              setOpen(false);
+            }}
+          >
             &#x2715;
           </ButtonOutlined>
         }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR fixes the issue where, on closing the customize workflow modal, the new workflow name is shown despite not saving.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

