### PR TITLE
(litmus-portal): removed hardcoded litmus namespace from chaos exporter deployment and removed space at the start of the filename.

### DIFF
--- a/litmus-portal/graphql-server/manifests/cluster/2c_litmus_deployment.yaml
+++ b/litmus-portal/graphql-server/manifests/cluster/2c_litmus_deployment.yaml
@@ -55,7 +55,7 @@ metadata:
   labels:
     app: chaos-exporter
   name: chaos-exporter
-  namespace: litmus
+  namespace: #{AGENT-NAMESPACE}
 spec:
   replicas: 1
   selector:

--- a/litmus-portal/graphql-server/manifests/namespace/2b_litmus_deployment.yaml
+++ b/litmus-portal/graphql-server/manifests/namespace/2b_litmus_deployment.yaml
@@ -60,7 +60,7 @@ metadata:
   labels:
     app: chaos-exporter
   name: chaos-exporter
-  namespace: litmus
+  namespace: #{AGENT-NAMESPACE}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan@chaosnative.com>

## Proposed changes

* removed hardcoded litmus namespace from chaos exporter deployment
* removed space at the start of the filename


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
