### PR TITLE
chore(litmus-portal): Change AddExperimentModal to use RadioButton

### DIFF
--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/AddExperimentModal.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/AddExperimentModal.tsx
@@ -1,15 +1,15 @@
+import { RadioGroup, Typography, useTheme } from '@material-ui/core';
 import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  OutlinedInput,
-  Select,
-  Typography,
-} from '@material-ui/core';
-import { ButtonFilled, ButtonOutlined, Modal } from 'litmus-ui';
-import React from 'react';
+  ButtonFilled,
+  ButtonOutlined,
+  Modal,
+  LitmusCard,
+  RadioButton,
+  Search,
+} from 'litmus-ui';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useStyles, { MenuProps } from './styles';
+import useStyles from './styles';
 
 interface ChartName {
   ChaosName: string;
@@ -42,6 +42,19 @@ const AddExperimentModal: React.FC<AddExperimentModalProps> = ({
 }) => {
   const classes = useStyles();
   const { t } = useTranslation();
+  const { palette } = useTheme();
+  const [search, setSearch] = useState<string | null>(null);
+
+  const filteredExperiments = allExperiments.filter((exp: ChartName) => {
+    if (search === null) return exp;
+    if (
+      exp.ChaosName.toLowerCase().includes(search.toLowerCase()) ||
+      exp.ExperimentName.toLowerCase().includes(search.toLowerCase())
+    )
+      return exp;
+    return null;
+  });
+
   return (
     <Modal
       open={addExpModal}
@@ -70,28 +83,42 @@ const AddExperimentModal: React.FC<AddExperimentModalProps> = ({
           {t('createWorkflow.tuneWorkflow.selectAvailableExp')} {hubName} .{' '}
           {t('createWorkflow.tuneWorkflow.afterSelect')}
         </Typography>
-        <FormControl variant="outlined" className={classes.formControl}>
-          <InputLabel id="demo-simple-select-label" className={classes.label}>
-            {t('createWorkflow.tuneWorkflow.selectExp')}
-          </InputLabel>
-          <Select
-            labelId="demo-simple-select-label"
-            value={selectedExp}
-            onChange={onSelectChange}
-            label="Cluster Status"
-            MenuProps={MenuProps}
-            input={<OutlinedInput labelWidth={150} />}
-          >
-            {allExperiments.map((exp: ChartName) => (
-              <MenuItem
+        <br />
+        <Search
+          data-cy="agentSearch"
+          id="input-with-icon-textfield"
+          placeholder="Search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+
+        <br />
+        <br />
+        <div className={classes.radioList}>
+          <RadioGroup value={selectedExp} onChange={onSelectChange}>
+            {filteredExperiments.map((exp: ChartName) => (
+              <LitmusCard
+                width="100%"
+                height="5rem"
                 key={`${exp.ChaosName}/${exp.ExperimentName}`}
-                value={`${exp.ChaosName}/${exp.ExperimentName}`}
+                borderColor={
+                  selectedExp === `${exp.ChaosName}/${exp.ExperimentName}`
+                    ? palette.primary.main
+                    : palette.border.main
+                }
+                className={classes.experimentCard}
               >
-                {exp.ChaosName}/{exp.ExperimentName}
-              </MenuItem>
+                <RadioButton value={`${exp.ChaosName}/${exp.ExperimentName}`}>
+                  <div id="body">
+                    <Typography className={classes.experimentName}>
+                      {exp.ChaosName}/{exp.ExperimentName}
+                    </Typography>
+                  </div>
+                </RadioButton>
+              </LitmusCard>
             ))}
-          </Select>
-        </FormControl>
+          </RadioGroup>
+        </div>
         <ButtonFilled
           onClick={() => {
             handleDone();

--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/AddExperimentModal.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/AddExperimentModal.tsx
@@ -93,7 +93,6 @@ const AddExperimentModal: React.FC<AddExperimentModalProps> = ({
         />
 
         <br />
-        <br />
         <div className={classes.radioList}>
           <RadioGroup value={selectedExp} onChange={onSelectChange}>
             {filteredExperiments.map((exp: ChartName) => (

--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/styles.ts
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/styles.ts
@@ -161,6 +161,25 @@ const useStyles = makeStyles((theme) => ({
   dropText: {
     fontSize: '1.2rem',
   },
+  radioList: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    height: '20rem',
+    overflowY: 'auto',
+  },
+  experimentCard: {
+    backgroundColor: theme.palette.cards.background,
+    lineHeight: '5rem', // Making the div content vertically aligned
+    padding: theme.spacing(0, 5),
+    margin: theme.spacing(1, 0),
+    width: '40rem',
+    display: 'flex',
+  },
+  experimentName: {
+    fontSize: '1rem',
+  },
 }));
 
 export default useStyles;

--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/styles.ts
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/styles.ts
@@ -162,6 +162,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '1.2rem',
   },
   radioList: {
+    paddingTop: '1.5rem',
     width: '100%',
     display: 'flex',
     flexDirection: 'column',


### PR DESCRIPTION
## Proposed changes

This PR changes `AddExperimentModal` to use RadioButton instead of Select and also adds in search for easier selection.

### Screenshots
![Screenshot 2021-04-19 at 1 33 55 PM](https://user-images.githubusercontent.com/51132453/115203722-5e18c980-a115-11eb-8da6-f3033758fb54.png)
![Screenshot 2021-04-19 at 1 34 12 PM](https://user-images.githubusercontent.com/51132453/115203737-61ac5080-a115-11eb-870b-055183f11aeb.png)

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

