### PR TITLE
Updated pod logs to fetch argo and experiment logs independently

### DIFF
--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/subscriptions.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/subscriptions.go
@@ -93,7 +93,7 @@ func ClusterConnect(clusterData map[string]string) {
 				continue
 			}
 			// send pod logs
-			logrus.Print("LOG REQUEST ", podRequest)
+			logrus.Print("LOG REQUEST ", r.Payload.Data.ClusterConnect.Action.ExternalData.(string))
 			SendPodLogs(clusterData, podRequest)
 		} else if strings.Index("create update delete get", strings.ToLower(r.Payload.Data.ClusterConnect.Action.RequestType)) >= 0 {
 			logrus.Print("WORKFLOW REQUEST ", r.Payload.Data.ClusterConnect.Action)

--- a/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/gql/util.go
@@ -2,14 +2,13 @@ package gql
 
 import (
 	"encoding/json"
-	"github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 
-	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/cluster/objects"
-
 	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/cluster/logs"
+	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/cluster/objects"
 	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 // process event data into proper format acceptable by gql


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

## Proposed changes

This PR updates the pod logs feature to query argo and experiment pods dependently.
fixes #2813

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)