### PR TITLE
chore(litmus-portal): Added podGC on revert-chaos

### DIFF
--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/WorkflowTable.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/WorkflowTable.tsx
@@ -123,6 +123,9 @@ const WorkflowTable = forwardRef(
       // Else if Revert Chaos is set to true and it is not already set in the manifest
       // For Workflows
       if (revertChaos && parsedYAML.kind === 'Workflow') {
+        parsedYAML.spec.podGC = {
+          strategy: 'OnWorkflowCompletion',
+        };
         parsedYAML.spec.templates[0].steps.push([
           {
             name: 'revert-chaos',
@@ -153,6 +156,9 @@ const WorkflowTable = forwardRef(
       // Else if Revert Chaos is set to True and it is not already set in the manifest
       // For Cron Workflow
       else if (revertChaos && parsedYAML.kind === 'CronWorkflow') {
+        parsedYAML.spec.workflowSpec.podGC = {
+          strategy: 'OnWorkflowCompletion',
+        };
         parsedYAML.spec.workflowSpec.templates[0].steps.push([
           {
             name: 'revert-chaos',

--- a/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/index.tsx
+++ b/litmus-portal/frontend/src/views/CreateWorkflow/TuneWorkflow/index.tsx
@@ -509,8 +509,11 @@ const TuneWorkflow = forwardRef((_, ref) => {
       parsedManifest.kind === 'Workflow' &&
       parsedManifest.spec.templates[0].steps[
         parsedManifest.spec.templates[0].steps.length - 1
-      ][0].name === 'revert-chaos'
+      ][0].name === 'revert-chaos' &&
+      parsedManifest.spec.podGC
     ) {
+      delete parsedManifest.spec.podGC;
+
       parsedManifest.spec.templates[0].steps.pop(); // Remove the last step -> Revert Chaos
 
       parsedManifest.spec.templates.pop(); // Remove the last template -> Revert Chaos Template
@@ -522,8 +525,10 @@ const TuneWorkflow = forwardRef((_, ref) => {
       parsedManifest.kind === 'CronWorkflow' &&
       parsedManifest.spec.workflowSpec.templates[0].steps[
         parsedManifest.spec.workflowSpec.templates[0].steps.length - 1
-      ][0].name === 'revert-chaos'
+      ][0].name === 'revert-chaos' &&
+      parsedManifest.spec.workflowSpec.podGC
     ) {
+      delete parsedManifest.workflowSpec.spec.podGC;
       parsedManifest.spec.workflowSpec.templates[0].steps.pop(); // Remove the last step -> Revert Chaos
 
       parsedManifest.spec.workflowSpec.templates.pop(); // Remove the last template -> Revert Chaos Template


### PR DESCRIPTION
Signed-off-by: Amit Kumar Das <amit@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR adds:
- podGC as `OnWorkflowCompletion` when revert-chaos is enabled

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
