### PR TITLE
Changing backend docker images to registry.access.redhat.com/ubi8/ubi-minimal:8.4

### DIFF
--- a/litmus-portal/authentication/Dockerfile
+++ b/litmus-portal/authentication/Dockerfile
@@ -15,15 +15,16 @@ RUN go env
 RUN CGO_ENABLED=0 go build -o /output/server -v ./api/
 
 # DEPLOY STAGE
-FROM alpine:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 LABEL maintainer="LitmusChaos"
 
 COPY --from=builder /output/server /
 
-RUN addgroup -S litmus && adduser -S -G litmus 1001
-USER 1001
+ENV USER_UID=1001
 
-CMD ["./server"]
+ENTRYPOINT ["./server"]
+
+USER ${USER_UID}
 
 EXPOSE 3000

--- a/litmus-portal/cluster-agents/event-tracker/Dockerfile
+++ b/litmus-portal/cluster-agents/event-tracker/Dockerfile
@@ -16,13 +16,14 @@ RUN go env
 RUN CGO_ENABLED=0 go build -o /output/event-tracker -v
 
 # DEPLOY STAGE
-FROM alpine:3.12.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 LABEL maintainer="LitmusChaos"
 
 COPY --from=builder /output/event-tracker /
 
-RUN addgroup -S litmus && adduser -S -G litmus 1001
-USER 1001
+ENV USER_UID=1001
 
-CMD ["./event-tracker"]
+ENTRYPOINT ["./event-tracker"]
+
+USER ${USER_UID}

--- a/litmus-portal/cluster-agents/subscriber/Dockerfile
+++ b/litmus-portal/cluster-agents/subscriber/Dockerfile
@@ -16,13 +16,14 @@ RUN go env
 RUN CGO_ENABLED=0 go build -o /output/subscriber -v
 
 # DEPLOY STAGE
-FROM alpine:3.12.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 LABEL maintainer="LitmusChaos"
 
 COPY --from=builder /output/subscriber /
 
-RUN addgroup -S litmus && adduser -S -G litmus 1001 
-USER 1001
+ENV USER_UID=1001
 
-CMD ["./subscriber"]
+ENTRYPOINT ["./subscriber"]
+
+USER ${USER_UID}

--- a/litmus-portal/graphql-server/Dockerfile
+++ b/litmus-portal/graphql-server/Dockerfile
@@ -15,17 +15,18 @@ ENV GOOS=${TARGETOS} \
 RUN go env
 RUN CGO_ENABLED=0 go build -o /output/server -v
 
-## DEPLOY STAGE
-FROM alpine:latest
+# DEPLOY STAGE
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 LABEL maintainer="LitmusChaos"
 
 COPY --from=builder /output/server /
 COPY --from=builder /gql-server/manifests/. /manifests
 
-RUN addgroup -S litmus && adduser -S -G litmus 1001 
-USER 1001
+ENV USER_UID=1001
 
-CMD ["./server"]
+ENTRYPOINT ["./server"]
+
+USER ${USER_UID}
 
 EXPOSE 8080


### PR DESCRIPTION
Changing backend docker images to registry.access.redhat.com/ubi8/ubi-minimal:8.4

Signed-off-by: Raj Das <raj@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
