### PR TITLE
Disable and Enable user from auth

### DIFF
--- a/litmus-portal/authentication/api/handlers/user_handlers.go
+++ b/litmus-portal/authentication/api/handlers/user_handlers.go
@@ -97,9 +97,9 @@ func LoginUser(service user.Service) gin.HandlerFunc {
 			return
 		}
 
-		// Checking if user is removed
-		if user.RemovedAt != nil {
-			c.JSON(utils.ErrorStatusCodes[utils.ErrUserRemoved], presenter.CreateErrorResponse(utils.ErrUserRemoved))
+		// Checking if user is deactivated
+		if user.DeactivatedAt != nil {
+			c.JSON(utils.ErrorStatusCodes[utils.ErrUserDeactivated], presenter.CreateErrorResponse(utils.ErrUserDeactivated))
 			return
 		}
 
@@ -239,15 +239,15 @@ func UpdateUserState(service user.Service) gin.HandlerFunc {
 			return
 		}
 
-		// Checking if user is already removed
-		if userRequest.IsDisable {
-			if user.RemovedAt != nil {
-				c.JSON(utils.ErrorStatusCodes[utils.ErrUserAlreadyRemoved], presenter.CreateErrorResponse(utils.ErrUserAlreadyRemoved))
+		// Checking if user is already deactivated
+		if userRequest.IsDeactivate {
+			if user.DeactivatedAt != nil {
+				c.JSON(utils.ErrorStatusCodes[utils.ErrUserAlreadyDeactivated], presenter.CreateErrorResponse(utils.ErrUserAlreadyDeactivated))
 				return
 			}
 		}
 
-		err = service.UpdateUserState(userRequest.Username, userRequest.IsDisable)
+		err = service.UpdateUserState(userRequest.Username, userRequest.IsDeactivate)
 		if err != nil {
 			log.Info(err)
 			c.JSON(utils.ErrorStatusCodes[utils.ErrServerError], presenter.CreateErrorResponse(utils.ErrServerError))

--- a/litmus-portal/authentication/api/middleware/jwt_middlware.go
+++ b/litmus-portal/authentication/api/middleware/jwt_middlware.go
@@ -16,7 +16,7 @@ func JwtMiddleware() gin.HandlerFunc {
 		const BearerSchema = "Bearer "
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
-			c.AbortWithStatusJSON(utils.ErrorStatusCodes[utils.ErrUnauthorised], presenter.CreateErrorResponse(utils.ErrUnauthorised))
+			c.AbortWithStatusJSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
 			return
 		}
 		tokenString := authHeader[len(BearerSchema):]
@@ -29,7 +29,7 @@ func JwtMiddleware() gin.HandlerFunc {
 			c.Next()
 		} else {
 			logrus.Info(err)
-			c.AbortWithStatusJSON(utils.ErrorStatusCodes[utils.ErrUnauthorised], presenter.CreateErrorResponse(utils.ErrUnauthorised))
+			c.AbortWithStatusJSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
 			return
 		}
 	}

--- a/litmus-portal/authentication/api/routes/user_router.go
+++ b/litmus-portal/authentication/api/routes/user_router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-//UserRouter creates all the required routes for user authentications purposes.
+// UserRouter creates all the required routes for user authentications purposes.
 func UserRouter(router *gin.Engine, service user.Service) {
 	router.POST("/login", handlers.LoginUser(service))
 	router.Use(middleware.JwtMiddleware())
@@ -17,4 +17,5 @@ func UserRouter(router *gin.Engine, service user.Service) {
 	router.POST("/create", handlers.CreateUser(service))
 	router.POST("/update/details", handlers.UpdateUser(service))
 	router.GET("/users", handlers.FetchUsers(service))
+	router.POST("/updatestate", handlers.UpdateUserState(service))
 }

--- a/litmus-portal/authentication/go.sum
+++ b/litmus-portal/authentication/go.sum
@@ -143,6 +143,7 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/litmus-portal/authentication/pkg/entities/user.go
+++ b/litmus-portal/authentication/pkg/entities/user.go
@@ -10,16 +10,16 @@ import (
 
 //User contains the user information
 type User struct {
-	ID        string     `bson:"_id,omitempty" json:"_id"`
-	UserName  string     `bson:"username,omitempty" json:"username"`
-	Password  string     `bson:"password,omitempty" json:"password,omitempty"`
-	Email     string     `bson:"email,omitempty" json:"email,omitempty"`
-	Name      string     `bson:"name,omitempty" json:"name,omitempty"`
-	Role      Role       `bson:"role,omitempty" json:"role"`
-	LoggedIn  bool       `bson:"logged_in,omitempty" json:"logged_in,omitempty"`
-	CreatedAt *time.Time `bson:"created_at,omitempty" json:"created_at,omitempty"`
-	UpdatedAt *time.Time `bson:"updated_at,omitempty" json:"updated_at,omitempty"`
-	RemovedAt *time.Time `bson:"removed_at,omitempty" json:"removed_at,omitempty"`
+	ID            string     `bson:"_id,omitempty" json:"_id"`
+	UserName      string     `bson:"username,omitempty" json:"username"`
+	Password      string     `bson:"password,omitempty" json:"password,omitempty"`
+	Email         string     `bson:"email,omitempty" json:"email,omitempty"`
+	Name          string     `bson:"name,omitempty" json:"name,omitempty"`
+	Role          Role       `bson:"role,omitempty" json:"role"`
+	LoggedIn      bool       `bson:"logged_in,omitempty" json:"logged_in,omitempty"`
+	CreatedAt     *time.Time `bson:"created_at,omitempty" json:"created_at,omitempty"`
+	UpdatedAt     *time.Time `bson:"updated_at,omitempty" json:"updated_at,omitempty"`
+	DeactivatedAt *time.Time `bson:"deactivated_at,omitempty" json:"deactivated_at,omitempty"`
 }
 
 // UserPassword defines structure for password related requests
@@ -29,10 +29,10 @@ type UserPassword struct {
 	NewPassword string `json:"new_password,omitempty"`
 }
 
-// UpdateUserState defines structure to disable or enable user
+// UpdateUserState defines structure to deactivate or reactivate user
 type UpdateUserState struct {
-	Username  string `json:"username"`
-	IsDisable bool   `json:"is_disable"`
+	Username     string `json:"username"`
+	IsDeactivate bool   `json:"is_deactivate"`
 }
 
 // Role states the role of the user in the portal

--- a/litmus-portal/authentication/pkg/entities/user.go
+++ b/litmus-portal/authentication/pkg/entities/user.go
@@ -22,31 +22,37 @@ type User struct {
 	RemovedAt *time.Time `bson:"removed_at,omitempty" json:"removed_at,omitempty"`
 }
 
-//UserPassword defines structure for password related requests
+// UserPassword defines structure for password related requests
 type UserPassword struct {
 	Username    string `json:"username,omitempty"`
 	OldPassword string `json:"old_password,omitempty"`
 	NewPassword string `json:"new_password,omitempty"`
 }
 
-//Role states the role of the user in the portal
+// UpdateUserState defines structure to disable or enable user
+type UpdateUserState struct {
+	Username  string `json:"username"`
+	IsDisable bool   `json:"is_disable"`
+}
+
+// Role states the role of the user in the portal
 type Role string
 
 const (
-	//RoleAdmin gives the admin permissions to a user
+	// RoleAdmin gives the admin permissions to a user
 	RoleAdmin Role = "admin"
 
 	//RoleUser gives the normal user permissions to a user
 	RoleUser Role = "user"
 )
 
-//SanitizedUser returns the user object without sensitive information
+// SanitizedUser returns the user object without sensitive information
 func (user *User) SanitizedUser() *User {
 	user.Password = ""
 	return user
 }
 
-//GetSignedJWT generates the JWT Token for the user object
+// GetSignedJWT generates the JWT Token for the user object
 func (user *User) GetSignedJWT() (string, error) {
 
 	token := jwt.New(jwt.SigningMethodHS512)

--- a/litmus-portal/authentication/pkg/user/repository.go
+++ b/litmus-portal/authentication/pkg/user/repository.go
@@ -21,7 +21,7 @@ type Repository interface {
 	UpdateUser(user *entities.User) (*entities.User, error)
 	IsAdministrator(user *entities.User) error
 	GetUsers() (*[]entities.User, error)
-	UpdateUserState(username string, isDisable bool) error
+	UpdateUserState(username string, isDeactivate bool) error
 }
 
 type repository struct {
@@ -148,16 +148,16 @@ func (r repository) IsAdministrator(user *entities.User) error {
 	return nil
 }
 
-// UpdateUserState updates the removed_at state of the user
-func (r repository) UpdateUserState(username string, isDisable bool) error {
+// UpdateUserState updates the deactivated_at state of the user
+func (r repository) UpdateUserState(username string, isDeactivate bool) error {
 	var err error
-	if isDisable == true {
+	if isDeactivate {
 		_, err = r.Collection.UpdateOne(context.Background(), bson.M{"username": username}, bson.M{"$set": bson.M{
-			"removed_at": time.Now(),
+			"deactivated_at": time.Now(),
 		}})
 	} else {
 		_, err = r.Collection.UpdateOne(context.Background(), bson.M{"username": username}, bson.M{"$set": bson.M{
-			"removed_at": nil,
+			"deactivated_at": nil,
 		}})
 	}
 

--- a/litmus-portal/authentication/pkg/user/repository.go
+++ b/litmus-portal/authentication/pkg/user/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"litmus/litmus-portal/authentication/pkg/entities"
 	"litmus/litmus-portal/authentication/pkg/utils"
+	"time"
 
 	uuid "github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
@@ -13,35 +14,46 @@ import (
 
 //Repository holds the mongo database implementation of the Service
 type Repository interface {
-	FindUser(user *entities.User) (*entities.User, error)
+	FindUser(username string) (*entities.User, error)
+	CheckPasswordHash(hash, password string) error
 	UpdatePassword(userPassword *entities.UserPassword, isAdminBeingReset bool) error
 	CreateUser(user *entities.User) (*entities.User, error)
 	UpdateUser(user *entities.User) (*entities.User, error)
 	IsAdministrator(user *entities.User) error
 	GetUsers() (*[]entities.User, error)
+	UpdateUserState(username string, isDisable bool) error
 }
 
 type repository struct {
 	Collection *mongo.Collection
 }
 
-//FindUser helps to authenticate the user
-func (r repository) FindUser(user *entities.User) (*entities.User, error) {
+// FindUser finds and returns a user if it exists
+func (r repository) FindUser(username string) (*entities.User, error) {
 	var result = entities.User{}
 	findOneErr := r.Collection.FindOne(context.TODO(), bson.M{
-		"username": user.UserName,
+		"username": username,
 	}).Decode(&result)
+
 	if findOneErr != nil {
 		return nil, findOneErr
 	}
-	err := bcrypt.CompareHashAndPassword([]byte(result.Password), []byte(user.Password))
-	if err != nil {
-		return nil, err
-	}
-	return result.SanitizedUser(), nil
+
+	return &result, nil
 }
 
-//UpdatePassword helps to update the password of the user, it acts as a resetPassword when isAdminBeingReset is set to true
+// CheckPasswordHash checks password hash and password from user input
+func (r repository) CheckPasswordHash(hash, password string) error {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+
+	if err != nil {
+		return utils.ErrWrongPassword
+	}
+
+	return nil
+}
+
+// UpdatePassword helps to update the password of the user, it acts as a resetPassword when isAdminBeingReset is set to true
 func (r repository) UpdatePassword(userPassword *entities.UserPassword, isAdminBeingReset bool) error {
 	var result = entities.User{}
 	result.UserName = userPassword.Username
@@ -69,7 +81,7 @@ func (r repository) UpdatePassword(userPassword *entities.UserPassword, isAdminB
 	return nil
 }
 
-//CreateUser creates a new user in the database
+// CreateUser creates a new user in the database
 func (r repository) CreateUser(user *entities.User) (*entities.User, error) {
 	user.ID = uuid.Must(uuid.NewRandom()).String()
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), utils.PasswordEncryptionCost)
@@ -87,7 +99,7 @@ func (r repository) CreateUser(user *entities.User) (*entities.User, error) {
 	return user.SanitizedUser(), nil
 }
 
-//UpdateUser updates user details in the database
+// UpdateUser updates user details in the database
 func (r repository) UpdateUser(user *entities.User) (*entities.User, error) {
 	if user.Password != "" {
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), utils.PasswordEncryptionCost)
@@ -105,7 +117,7 @@ func (r repository) UpdateUser(user *entities.User) (*entities.User, error) {
 	return user.SanitizedUser(), nil
 }
 
-//GetUsers fetches all the users from the database
+// GetUsers fetches all the users from the database
 func (r repository) GetUsers() (*[]entities.User, error) {
 	var Users []entities.User
 	cursor, err := r.Collection.Find(context.Background(), bson.M{})
@@ -120,7 +132,7 @@ func (r repository) GetUsers() (*[]entities.User, error) {
 	return &Users, nil
 }
 
-//IsAdministrator verifies if the passed user is an administrator
+// IsAdministrator verifies if the passed user is an administrator
 func (r repository) IsAdministrator(user *entities.User) error {
 	var result = entities.User{}
 	findOneErr := r.Collection.FindOne(context.TODO(), bson.M{
@@ -136,7 +148,27 @@ func (r repository) IsAdministrator(user *entities.User) error {
 	return nil
 }
 
-//NewRepo creates a new instance of this repository
+// UpdateUserState updates the removed_at state of the user
+func (r repository) UpdateUserState(username string, isDisable bool) error {
+	var err error
+	if isDisable == true {
+		_, err = r.Collection.UpdateOne(context.Background(), bson.M{"username": username}, bson.M{"$set": bson.M{
+			"removed_at": time.Now(),
+		}})
+	} else {
+		_, err = r.Collection.UpdateOne(context.Background(), bson.M{"username": username}, bson.M{"$set": bson.M{
+			"removed_at": nil,
+		}})
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewRepo creates a new instance of this repository
 func NewRepo(collection *mongo.Collection) Repository {
 	return &repository{
 		Collection: collection,

--- a/litmus-portal/authentication/pkg/user/service.go
+++ b/litmus-portal/authentication/pkg/user/service.go
@@ -13,7 +13,7 @@ type Service interface {
 	UpdateUser(user *entities.User) (*entities.User, error)
 	IsAdministrator(user *entities.User) error
 	GetUsers() (*[]entities.User, error)
-	UpdateUserState(username string, isDisable bool) error
+	UpdateUserState(username string, isDeactivate bool) error
 }
 
 type service struct {
@@ -55,9 +55,9 @@ func (s service) IsAdministrator(user *entities.User) error {
 	return s.repository.IsAdministrator(user)
 }
 
-// UpdateUserState updates removed_at state of the user
-func (s service) UpdateUserState(username string, isDisable bool) error {
-	return s.repository.UpdateUserState(username, isDisable)
+// UpdateUserState updates deactivated_at state of the user
+func (s service) UpdateUserState(username string, isDeactivate bool) error {
+	return s.repository.UpdateUserState(username, isDeactivate)
 }
 
 // NewService creates a new instance of this service

--- a/litmus-portal/authentication/pkg/user/service.go
+++ b/litmus-portal/authentication/pkg/user/service.go
@@ -4,51 +4,63 @@ import (
 	"litmus/litmus-portal/authentication/pkg/entities"
 )
 
-//Service creates a service for user authentication operations
+// Service creates a service for user authentication operations
 type Service interface {
-	FindUser(user *entities.User) (*entities.User, error)
+	FindUser(username string) (*entities.User, error)
+	CheckPasswordHash(hash, password string) error
 	UpdatePassword(userPassword *entities.UserPassword, isAdminBeingReset bool) error
 	CreateUser(user *entities.User) (*entities.User, error)
 	UpdateUser(user *entities.User) (*entities.User, error)
 	IsAdministrator(user *entities.User) error
 	GetUsers() (*[]entities.User, error)
+	UpdateUserState(username string, isDisable bool) error
 }
 
 type service struct {
 	repository Repository
 }
 
-//FindUser is the definition of finding an user from database
-func (s service) FindUser(user *entities.User) (*entities.User, error) {
-	return s.repository.FindUser(user)
+// FindUser is the definition of finding an user from database
+func (s service) FindUser(username string) (*entities.User, error) {
+	return s.repository.FindUser(username)
 }
 
-//UpdatePassword helps to update the password of the user, it acts as a resetPassword when isAdminBeingReset is set to true
+// CheckPasswordHash checks if hashed password matches with the input password
+func (s service) CheckPasswordHash(hash, password string) error {
+	return s.repository.CheckPasswordHash(hash, password)
+}
+
+// UpdatePassword helps to update the password of the user, it acts as a resetPassword when isAdminBeingReset is set to true
 func (s service) UpdatePassword(userPassword *entities.UserPassword, isAdminBeingReset bool) error {
 	return s.repository.UpdatePassword(userPassword, isAdminBeingReset)
 }
 
-//CreateUser creates a new user in the database
+// CreateUser creates a new user in the database
 func (s service) CreateUser(user *entities.User) (*entities.User, error) {
 	return s.repository.CreateUser(user)
 }
 
-//UpdateUser updates user details in the database
+// UpdateUser updates user details in the database
 func (s service) UpdateUser(user *entities.User) (*entities.User, error) {
 	return s.repository.UpdateUser(user)
 }
 
-//GetUsers fetches all the users from the database
+// GetUsers fetches all the users from the database
 func (s service) GetUsers() (*[]entities.User, error) {
 	return s.repository.GetUsers()
 }
 
-//IsAdministrator verifies if the passed user is an administrator
+// IsAdministrator verifies if the passed user is an administrator
 func (s service) IsAdministrator(user *entities.User) error {
 	return s.repository.IsAdministrator(user)
 }
 
-//NewService creates a new instance of this service
+// UpdateUserState updates removed_at state of the user
+func (s service) UpdateUserState(username string, isDisable bool) error {
+	return s.repository.UpdateUserState(username, isDisable)
+}
+
+// NewService creates a new instance of this service
 func NewService(r Repository) Service {
 	return &service{
 		repository: r,

--- a/litmus-portal/authentication/pkg/utils/errors.go
+++ b/litmus-portal/authentication/pkg/utils/errors.go
@@ -15,8 +15,8 @@ var (
 	ErrUserNotFound                  AppError = errors.New("user does not exists")
 	ErrWrongPassword                 AppError = errors.New("password doesn't match")
 	ErrUpdatingAdmin                 AppError = errors.New("cannot remove admin")
-	ErrUserRemoved                   AppError = errors.New("your account has been disabled")
-	ErrUserAlreadyRemoved            AppError = errors.New("user already removed")
+	ErrUserDeactivated               AppError = errors.New("your account has been deactivated")
+	ErrUserAlreadyDeactivated        AppError = errors.New("user already deactivated")
 )
 
 // ErrorStatusCodes holds the http status codes for every AppError
@@ -29,8 +29,8 @@ var ErrorStatusCodes = map[AppError]int{
 	ErrStrictPasswordPolicyViolation: 401,
 	ErrUserNotFound:                  400,
 	ErrUpdatingAdmin:                 400,
-	ErrUserRemoved:                   400,
-	ErrUserAlreadyRemoved:            400,
+	ErrUserDeactivated:               400,
+	ErrUserAlreadyDeactivated:        400,
 }
 
 // ErrorDescriptions holds detailed error description for every AppError

--- a/litmus-portal/authentication/pkg/utils/errors.go
+++ b/litmus-portal/authentication/pkg/utils/errors.go
@@ -2,7 +2,7 @@ package utils
 
 import "errors"
 
-//AppError defines general error's throughout the system
+// AppError defines general error's throughout the system
 type AppError error
 
 var (
@@ -10,26 +10,35 @@ var (
 	ErrServerError                   AppError = errors.New("server_error")
 	ErrInvalidRequest                AppError = errors.New("invalid_request")
 	ErrStrictPasswordPolicyViolation AppError = errors.New("password_policy_violation")
-	ErrUnauthorised                  AppError = errors.New("unauthorised")
+	ErrUnauthorized                  AppError = errors.New("unauthorized")
 	ErrUserExists                    AppError = errors.New("user_exists")
+	ErrUserNotFound                  AppError = errors.New("user does not exists")
+	ErrWrongPassword                 AppError = errors.New("password doesn't match")
+	ErrUpdatingAdmin                 AppError = errors.New("cannot remove admin")
+	ErrUserRemoved                   AppError = errors.New("your account has been disabled")
+	ErrUserAlreadyRemoved            AppError = errors.New("user already removed")
 )
 
-//ErrorStatusCodes holds the http status codes for every AppError
+// ErrorStatusCodes holds the http status codes for every AppError
 var ErrorStatusCodes = map[AppError]int{
 	ErrInvalidRequest:                400,
 	ErrInvalidCredentials:            401,
 	ErrServerError:                   500,
-	ErrUnauthorised:                  401,
+	ErrUnauthorized:                  401,
 	ErrUserExists:                    401,
 	ErrStrictPasswordPolicyViolation: 401,
+	ErrUserNotFound:                  400,
+	ErrUpdatingAdmin:                 400,
+	ErrUserRemoved:                   400,
+	ErrUserAlreadyRemoved:            400,
 }
 
-//ErrorDescriptions holds detailed error description for every AppError
+// ErrorDescriptions holds detailed error description for every AppError
 var ErrorDescriptions = map[AppError]string{
 	ErrServerError:                   "The authorization server encountered an unexpected condition that prevented it from fulfilling the request",
 	ErrInvalidCredentials:            "Invalid Credentials",
 	ErrInvalidRequest:                "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed",
-	ErrUnauthorised:                  "The user does not have requested authorisation to access this resource",
+	ErrUnauthorized:                  "The user does not have requested authorization to access this resource",
 	ErrUserExists:                    "This username is already assigned to another user",
 	ErrStrictPasswordPolicyViolation: "Please ensure the password is 8 characters long and has 1 digit, 1 lowercase alphabet, 1 uppercase alphabet and 1 special character",
 }


### PR DESCRIPTION
Signed-off-by: SarthakJain26 <sarthak@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue
- `/updatestatus` API allows admin users to enable or disable a user's state.
- Disabled user will not be allowed to login. 
- Separated password validation from find user utility.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
- Username was considered in `/updatestatus` API because it uses findUser utility function which accepts username as input. 
findUser is used at the time of login, therefore it accepts username instead of uid.