### PR TITLE
Added query to fetch dashboard details from hub

### DIFF
--- a/litmus-portal/graphql-server/go.sum
+++ b/litmus-portal/graphql-server/go.sum
@@ -643,9 +643,6 @@ github.com/litmuschaos/chaos-operator v0.0.0-20210224131102-ca6a465ed348/go.mod 
 github.com/litmuschaos/chaos-scheduler v0.0.0-20210607090343-9952190ad032 h1:Nza94oOqOsao8eFWC19iFviS8XsxS2eVk7Q0a9WDKBE=
 github.com/litmuschaos/chaos-scheduler v0.0.0-20210607090343-9952190ad032/go.mod h1:7EO6kbZKeJGKzkchgQepCxywvqNFNvNHW0G+u9923AY=
 github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
-github.com/litmuschaos/litmus v0.0.0-20210629090039-c52ae1dd1a59 h1:GWS8zZhtvNdkErjFBf+DOwCFWyxrA+PtD6d/Phpr7Bc=
-github.com/litmuschaos/litmus v0.0.0-20210701050610-ea493016c718 h1:S3y2G2bS+LGBOssMCIx0AhlU3NT4b9VEAnW82GyW1Wo=
-github.com/litmuschaos/litmus v0.0.0-20210701090803-5bc389617186 h1:64ieMA5FaRBiTQPgvV3CF1F0otSu2PWVzYjonLNLHbQ=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
 github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f/go.mod h1:JpH9J1c9oX6otFSgdUHwUBUizmKlrMjxWnIAjff4m04=

--- a/litmus-portal/graphql-server/graph/analytics.graphqls
+++ b/litmus-portal/graphql-server/graph/analytics.graphqls
@@ -303,3 +303,8 @@ type WorkflowRunStatsResponse {
   workflow_run_succeeded_percentage: Float!
   workflow_run_failed_percentage: Float!
 }
+
+type PortalDashboardData {
+    name: String!
+    dashboard_data: String!
+}

--- a/litmus-portal/graphql-server/graph/generated/generated.go
+++ b/litmus-portal/graphql-server/graph/generated/generated.go
@@ -340,6 +340,11 @@ type ComplexityRoot struct {
 		WorkflowRunID func(childComplexity int) int
 	}
 
+	PortalDashboardData struct {
+		DashboardData func(childComplexity int) int
+		Name          func(childComplexity int) int
+	}
+
 	Project struct {
 		CreatedAt func(childComplexity int) int
 		ID        func(childComplexity int) int
@@ -388,6 +393,7 @@ type ComplexityRoot struct {
 		ListManifestTemplate        func(childComplexity int, projectID string) int
 		ListProjects                func(childComplexity int) int
 		ListWorkflow                func(childComplexity int, workflowInput model.ListWorkflowsInput) int
+		PortalDashboardData         func(childComplexity int, projectID string, hubName string) int
 		UsageQuery                  func(childComplexity int, query model.UsageQuery) int
 		Users                       func(childComplexity int) int
 	}
@@ -750,6 +756,7 @@ type QueryResolver interface {
 	GetPromLabelNamesAndValues(ctx context.Context, series *model.PromSeriesInput) (*model.PromSeriesResponse, error)
 	GetPromSeriesList(ctx context.Context, dsDetails *model.DsDetails) (*model.PromSeriesListResponse, error)
 	ListDashboard(ctx context.Context, projectID string) ([]*model.ListDashboardResponse, error)
+	PortalDashboardData(ctx context.Context, projectID string, hubName string) ([]*model.PortalDashboardData, error)
 	GetGitOpsDetails(ctx context.Context, projectID string) (*model.GitConfigResponse, error)
 	ListManifestTemplate(ctx context.Context, projectID string) ([]*model.ManifestTemplate, error)
 	GetTemplateManifestByID(ctx context.Context, templateID string) (*model.ManifestTemplate, error)
@@ -2411,6 +2418,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PodLogResponse.WorkflowRunID(childComplexity), true
 
+	case "PortalDashboardData.dashboard_data":
+		if e.complexity.PortalDashboardData.DashboardData == nil {
+			break
+		}
+
+		return e.complexity.PortalDashboardData.DashboardData(childComplexity), true
+
+	case "PortalDashboardData.name":
+		if e.complexity.PortalDashboardData.Name == nil {
+			break
+		}
+
+		return e.complexity.PortalDashboardData.Name(childComplexity), true
+
 	case "Project.created_at":
 		if e.complexity.Project.CreatedAt == nil {
 			break
@@ -2796,6 +2817,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ListWorkflow(childComplexity, args["workflowInput"].(model.ListWorkflowsInput)), true
+
+	case "Query.PortalDashboardData":
+		if e.complexity.Query.PortalDashboardData == nil {
+			break
+		}
+
+		args, err := ec.field_Query_PortalDashboardData_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.PortalDashboardData(childComplexity, args["project_id"].(string), args["hub_name"].(string)), true
 
 	case "Query.UsageQuery":
 		if e.complexity.Query.UsageQuery == nil {
@@ -4543,7 +4576,11 @@ type WorkflowRunStatsResponse {
   workflow_run_succeeded_percentage: Float!
   workflow_run_failed_percentage: Float!
 }
-`, BuiltIn: false},
+
+type PortalDashboardData {
+    name: String!
+    dashboard_data: String!
+}`, BuiltIn: false},
 	&ast.Source{Name: "graph/image_registry.graphqls", Input: `type imageRegistry {
     image_registry_name: String!
     image_repo_name: String!
@@ -5087,6 +5124,8 @@ type Query {
   GetPromSeriesList(ds_details: dsDetails): promSeriesListResponse! @authorized
 
   ListDashboard(project_id: String!): [listDashboardResponse] @authorized
+
+  PortalDashboardData (project_id: String!, hub_name: String!) : [PortalDashboardData!]! @authorized
 
   # Git Ops
   getGitOpsDetails(project_id: String!): GitConfigResponse! @authorized
@@ -6311,6 +6350,28 @@ func (ec *executionContext) field_Query_ListWorkflow_args(ctx context.Context, r
 		}
 	}
 	args["workflowInput"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_PortalDashboardData_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["project_id"]; ok {
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["hub_name"]; ok {
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["hub_name"] = arg1
 	return args, nil
 }
 
@@ -14465,6 +14526,74 @@ func (ec *executionContext) _PodLogResponse_log(ctx context.Context, field graph
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _PortalDashboardData_name(ctx context.Context, field graphql.CollectedField, obj *model.PortalDashboardData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PortalDashboardData",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PortalDashboardData_dashboard_data(ctx context.Context, field graphql.CollectedField, obj *model.PortalDashboardData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PortalDashboardData",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DashboardData, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Project_id(ctx context.Context, field graphql.CollectedField, obj *model.Project) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16106,6 +16235,67 @@ func (ec *executionContext) _Query_ListDashboard(ctx context.Context, field grap
 	res := resTmp.([]*model.ListDashboardResponse)
 	fc.Result = res
 	return ec.marshalOlistDashboardResponse2ᚕᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐListDashboardResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_PortalDashboardData(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_PortalDashboardData_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().PortalDashboardData(rctx, args["project_id"].(string), args["hub_name"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Authorized == nil {
+				return nil, errors.New("directive authorized is not implemented")
+			}
+			return ec.directives.Authorized(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, err
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*model.PortalDashboardData); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/litmuschaos/litmus/litmus-portal/graphql-server/graph/model.PortalDashboardData`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.PortalDashboardData)
+	fc.Result = res
+	return ec.marshalNPortalDashboardData2ᚕᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐPortalDashboardDataᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_getGitOpsDetails(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -27555,6 +27745,38 @@ func (ec *executionContext) _PodLogResponse(ctx context.Context, sel ast.Selecti
 	return out
 }
 
+var portalDashboardDataImplementors = []string{"PortalDashboardData"}
+
+func (ec *executionContext) _PortalDashboardData(ctx context.Context, sel ast.SelectionSet, obj *model.PortalDashboardData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, portalDashboardDataImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PortalDashboardData")
+		case "name":
+			out.Values[i] = ec._PortalDashboardData_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "dashboard_data":
+			out.Values[i] = ec._PortalDashboardData_dashboard_data(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var projectImplementors = []string{"Project"}
 
 func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *model.Project) graphql.Marshaler {
@@ -27987,6 +28209,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_ListDashboard(ctx, field)
+				return res
+			})
+		case "PortalDashboardData":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_PortalDashboardData(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			})
 		case "getGitOpsDetails":
@@ -30763,6 +30999,57 @@ func (ec *executionContext) marshalNPodLogResponse2ᚖgithubᚗcomᚋlitmuschaos
 		return graphql.Null
 	}
 	return ec._PodLogResponse(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPortalDashboardData2githubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐPortalDashboardData(ctx context.Context, sel ast.SelectionSet, v model.PortalDashboardData) graphql.Marshaler {
+	return ec._PortalDashboardData(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPortalDashboardData2ᚕᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐPortalDashboardDataᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.PortalDashboardData) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPortalDashboardData2ᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐPortalDashboardData(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNPortalDashboardData2ᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐPortalDashboardData(ctx context.Context, sel ast.SelectionSet, v *model.PortalDashboardData) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PortalDashboardData(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNProject2githubᚗcomᚋlitmuschaosᚋlitmusᚋlitmusᚑportalᚋgraphqlᚑserverᚋgraphᚋmodelᚐProject(ctx context.Context, sel ast.SelectionSet, v model.Project) graphql.Marshaler {

--- a/litmus-portal/graphql-server/graph/model/models_gen.go
+++ b/litmus-portal/graphql-server/graph/model/models_gen.go
@@ -437,6 +437,11 @@ type PodLogResponse struct {
 	Log           string `json:"log"`
 }
 
+type PortalDashboardData struct {
+	Name          string `json:"name"`
+	DashboardData string `json:"dashboard_data"`
+}
+
 type Project struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`

--- a/litmus-portal/graphql-server/graph/schema.graphqls
+++ b/litmus-portal/graphql-server/graph/schema.graphqls
@@ -309,6 +309,8 @@ type Query {
 
   ListDashboard(project_id: String!): [listDashboardResponse] @authorized
 
+  PortalDashboardData (project_id: String!, hub_name: String!) : [PortalDashboardData!]! @authorized
+
   # Git Ops
   getGitOpsDetails(project_id: String!): GitConfigResponse! @authorized
 

--- a/litmus-portal/graphql-server/graph/schema.resolvers.go
+++ b/litmus-portal/graphql-server/graph/schema.resolvers.go
@@ -427,7 +427,9 @@ func (r *queryResolver) ListDashboard(ctx context.Context, projectID string) ([]
 
 func (r *queryResolver) PortalDashboardData(ctx context.Context, projectID string, hubName string) ([]*model.PortalDashboardData, error) {
 	err := authorization.ValidateRole(ctx, projectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor, model.MemberRoleViewer}, usermanagement.AcceptedInvitation)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return analyticsHandler.GetPortalDashboardData(projectID, hubName)
 }
 

--- a/litmus-portal/graphql-server/graph/schema.resolvers.go
+++ b/litmus-portal/graphql-server/graph/schema.resolvers.go
@@ -426,6 +426,8 @@ func (r *queryResolver) ListDashboard(ctx context.Context, projectID string) ([]
 }
 
 func (r *queryResolver) PortalDashboardData(ctx context.Context, projectID string, hubName string) ([]*model.PortalDashboardData, error) {
+	err := authorization.ValidateRole(ctx, projectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor, model.MemberRoleViewer}, usermanagement.AcceptedInvitation)
+	if err != nil { return nil, err }
 	return analyticsHandler.GetPortalDashboardData(projectID, hubName)
 }
 

--- a/litmus-portal/graphql-server/graph/schema.resolvers.go
+++ b/litmus-portal/graphql-server/graph/schema.resolvers.go
@@ -425,6 +425,10 @@ func (r *queryResolver) ListDashboard(ctx context.Context, projectID string) ([]
 	return analyticsHandler.QueryListDashboard(projectID)
 }
 
+func (r *queryResolver) PortalDashboardData(ctx context.Context, projectID string, hubName string) ([]*model.PortalDashboardData, error) {
+	return analyticsHandler.GetPortalDashboardData(projectID, hubName)
+}
+
 func (r *queryResolver) GetGitOpsDetails(ctx context.Context, projectID string) (*model.GitConfigResponse, error) {
 	return gitOpsHandler.GetGitOpsDetailsHandler(ctx, projectID)
 }

--- a/litmus-portal/graphql-server/pkg/analytics/handler/handler.go
+++ b/litmus-portal/graphql-server/pkg/analytics/handler/handler.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"sort"
 	"strconv"
@@ -27,6 +29,10 @@ import (
 	dbOperationsWorkflow "github.com/litmuschaos/litmus/litmus-portal/graphql-server/pkg/database/mongodb/workflow"
 	dbSchemaWorkflow "github.com/litmuschaos/litmus/litmus-portal/graphql-server/pkg/database/mongodb/workflow"
 	"github.com/litmuschaos/litmus/litmus-portal/graphql-server/utils"
+)
+
+const (
+	defaultPath = "/tmp/version/"
 )
 
 var AnalyticsCache = utils.NewCache()
@@ -1402,4 +1408,32 @@ func GetHeatMapData(workflow_id string, project_id string, year int) ([]*model.H
 		week += 1
 	}
 	return result, nil
+}
+
+// GetPortalDashboardData gets the portal dashboard data from the ChaosHub
+func GetPortalDashboardData(projectID string, hubname string) ([]*model.PortalDashboardData, error) {
+	DashboardDirectoryPath := defaultPath + projectID + "/" + hubname + "/monitoring/dashboards/litmus-portal"
+	var PortalDashboards []*model.PortalDashboardData
+	var PortalDashboardData analytics.PortalDashboard
+	files, err := ioutil.ReadDir(DashboardDirectoryPath)
+	if err != nil {
+		return PortalDashboards, err
+	}
+	for _, file := range files {
+		dashboardData, err := ioutil.ReadFile(DashboardDirectoryPath + "/" + file.Name())
+		if err != nil {
+			dashboardData = []byte("")
+		}
+		err = json.Unmarshal(dashboardData, &PortalDashboardData)
+		if err != nil {
+			return nil, err
+		}
+		dashboard, _ := json.Marshal(PortalDashboardData)
+		data := &model.PortalDashboardData{
+			Name:          file.Name(),
+			DashboardData: string(dashboard),
+		}
+		PortalDashboards = append(PortalDashboards, data)
+	}
+	return PortalDashboards, nil
 }

--- a/litmus-portal/graphql-server/pkg/analytics/types.go
+++ b/litmus-portal/graphql-server/pkg/analytics/types.go
@@ -61,3 +61,39 @@ type PromSeriesResponse struct {
 	Series      string        `json:"series"`
 	LabelValues []*LabelValue `json:"labelValues"`
 }
+
+//Portal Dashboard Types
+type PortalDashboard struct {
+	DashboardID               string `json:"dashboardID"`
+	Name                      string `json:"name"`
+	Information               string `json:"information"`
+	ChaosEventQueryTemplate   string `json:"chaosEventQueryTemplate"`
+	ChaosVerdictQueryTemplate string `json:"chaosVerdictQueryTemplate"`
+	PanelGroupMap             []struct {
+		GroupName string   `json:"groupName"`
+		Panels    []string `json:"panels"`
+	} `json:"panelGroupMap"`
+	PanelGroups []struct {
+		PanelGroupName string `json:"panel_group_name"`
+		Panels         []struct {
+			PanelName    string `json:"panel_name"`
+			PanelOptions struct {
+				Points   bool `json:"points"`
+				Grids    bool `json:"grids"`
+				LeftAxis bool `json:"left_axis"`
+			} `json:"panel_options"`
+			YAxisLeft   string `json:"y_axis_left"`
+			YAxisRight  string `json:"y_axis_right"`
+			XAxisDown   string `json:"x_axis_down"`
+			Unit        string `json:"unit"`
+			PromQueries []struct {
+				PromQueryName string `json:"prom_query_name"`
+				Legend        string `json:"legend"`
+				Resolution    string `json:"resolution"`
+				Minstep       string `json:"minstep"`
+				Line          bool   `json:"line"`
+				CloseArea     bool   `json:"close_area"`
+			} `json:"prom_queries"`
+		} `json:"panels"`
+	} `json:"panelGroups"`
+}

--- a/litmus-portal/graphql-server/pkg/myhub/myhub.go
+++ b/litmus-portal/graphql-server/pkg/myhub/myhub.go
@@ -52,12 +52,6 @@ func AddMyHub(ctx context.Context, myhub model.CreateMyHub, projectID string) (*
 		SSHPrivateKey: myhub.SSHPrivateKey,
 	}
 
-	// Cloning the repository at a path from myhub link structure.
-	err = myHubOps.GitClone(cloneHub)
-	if err != nil {
-		return nil, err
-	}
-
 	// Initialize a UID for new Hub.
 	uuid := uuid.New()
 	newHub := &dbSchemaMyHub.MyHub{
@@ -83,6 +77,11 @@ func AddMyHub(ctx context.Context, myhub model.CreateMyHub, projectID string) (*
 	err = dbOperationsMyHub.CreateMyHub(ctx, newHub)
 	if err != nil {
 		log.Print("ERROR", err)
+		return nil, err
+	}
+	// Cloning the repository at a path from myhub link structure.
+	err = myHubOps.GitClone(cloneHub)
+	if err != nil {
 		return nil, err
 	}
 

--- a/litmus-portal/graphql-server/pkg/myhub/myhub.go
+++ b/litmus-portal/graphql-server/pkg/myhub/myhub.go
@@ -73,15 +73,16 @@ func AddMyHub(ctx context.Context, myhub model.CreateMyHub, projectID string) (*
 		LastSyncedAt:  strconv.FormatInt(time.Now().Unix(), 10),
 	}
 
+	// Cloning the repository at a path from myhub link structure.
+	err = myHubOps.GitClone(cloneHub)
+	if err != nil {
+		return nil, err
+	}
+
 	// Adding the new hub into database with the given username.
 	err = dbOperationsMyHub.CreateMyHub(ctx, newHub)
 	if err != nil {
 		log.Print("ERROR", err)
-		return nil, err
-	}
-	// Cloning the repository at a path from myhub link structure.
-	err = myHubOps.GitClone(cloneHub)
-	if err != nil {
 		return nil, err
 	}
 

--- a/litmus-portal/graphql-server/pkg/myhub/myhub.go
+++ b/litmus-portal/graphql-server/pkg/myhub/myhub.go
@@ -52,6 +52,12 @@ func AddMyHub(ctx context.Context, myhub model.CreateMyHub, projectID string) (*
 		SSHPrivateKey: myhub.SSHPrivateKey,
 	}
 
+	// Cloning the repository at a path from myhub link structure.
+	err = myHubOps.GitClone(cloneHub)
+	if err != nil {
+		return nil, err
+	}
+
 	// Initialize a UID for new Hub.
 	uuid := uuid.New()
 	newHub := &dbSchemaMyHub.MyHub{
@@ -71,12 +77,6 @@ func AddMyHub(ctx context.Context, myhub model.CreateMyHub, projectID string) (*
 		CreatedAt:     strconv.FormatInt(time.Now().Unix(), 10),
 		UpdatedAt:     strconv.FormatInt(time.Now().Unix(), 10),
 		LastSyncedAt:  strconv.FormatInt(time.Now().Unix(), 10),
-	}
-
-	// Cloning the repository at a path from myhub link structure.
-	err = myHubOps.GitClone(cloneHub)
-	if err != nil {
-		return nil, err
 	}
 
 	// Adding the new hub into database with the given username.


### PR DESCRIPTION
Signed-off-by: Amit Kumar Das <amit@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR adds:
- GQL Query to fetch dashboard details from hub

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
Sample Output:
`
{
        "name": "node_metrics.json",
        "dashboard_data": "{\"dashboardID\":\"generic_node_metrics\",\"name\":\"Node metrics\",\"information\":\"This dashboard visualizes Node level CPU, memory, disk and IO utilization metrics interleaved with chaos events.\",\"chaosEventQueryTemplate\":\"litmuschaos_awaited_experiments{job=\\\"chaos-exporter\\\"}\",\"chaosVerdictQueryTemplate\":\"litmuschaos_experiment_verdict{job=\\\"chaos-exporter\\\"}\",\"panelGroupMap\":[{\"groupName\":\"CPU Utilization Metrics\",\"panels\":[\"Chaos-Node-CPU Utilization\"]},{\"groupName\":\"Memory Utilization Metrics\",\"panels\":[\"Chaos-Node-Memory Utilization\"]},{\"groupName\":\"Disk Usage Metrics\",\"panels\":[\"Chaos-Node-Disk I/O Usage R/W\",\"Chaos-Node-Disk I/O Usage Times\"]},{\"groupName\":\"Network Usage Metrics\",\"panels\":[\"Chaos-Node-Network Traffic Bytes\",\"Chaos-Node-Network Traffic Packets\"]}],\"panelGroups\":[{\"panel_group_name\":\"CPU Usage Metrics\",\"panels\":[{\"panel_name\":\"Chaos-Node-CPU Utilization\",\"panel_options\":{\"points\":false,\"grids\":true,\"left_axis\":true},\"y_axis_left\":\"Cores\",\"y_axis_right\":\"CHAOS\",\"x_axis_down\":\"Time\",\"unit\":\"%\",\"prom_queries\":[{\"prom_query_name\":\"instance:node_cpu_utilisation:rate1m*100\",\"legend\":\"{{instance}}\",\"resolution\":\"1/2\",\"minstep\":\"5\",\"line\":true,\"close_area\":false}]}]},{\"panel_group_name\":\"Memory Usage Metrics\",\"panels\":[{\"panel_name\":\"Chaos-Node-Memory Utilization\",\"panel_options\":{\"points\":false,\"grids\":true,\"left_axis\":true},\"y_axis_left\":\"Memory\",\"y_axis_right\":\"CHAOS\",\"x_axis_down\":\"Time\",\"unit\":\"%\",\"prom_queries\":[{\"prom_query_name\":\"instance:node_memory_utilisation:ratio*100\",\"legend\":\"{{instance}}\",\"resolution\":\"1/2\",\"minstep\":\"5\",\"line\":true,\"close_area\":false}]}]},{\"panel_group_name\":\"Disk Usage Metrics\",\"panels\":[{\"panel_name\":\"Chaos-Node-Disk I/O Usage R/W\",\"panel_options\":{\"points\":false,\"grids\":true,\"left_axis\":true},\"y_axis_left\":\"bytes read (-) / write (+)\",\"y_axis_right\":\"CHAOS\",\"x_axis_down\":\"Time\",\"unit\":\"KiB\",\"prom_queries\":[{\"prom_query_name\":\"node_disk_read_bytes_total\",\"legend\":\"{{instance}} - {{device}} - Successfully read bytes\",\"resolution\":\"1/2\",\"minstep\":\"5\",\"line\":true,\"close_area\":false},{\"prom_query_name\":\"node_disk_written_bytes_total\",\"legend\":\"{{instance}} - {{device}} - Successfully written bytes\",\"resolution\":\"1/2\",\"minstep\":\"5\",\"line\":true,\"close_area\":false}]},{\"panel_name\":\"Chaos-Node-Disk I/O Usage Times\",\"panel_options\":{\"points\":false,\"grids\":true,\"left_axis\":true},\"y_axis_left\":\"time\",\"y_axis_right\":\"CHAOS\",\"x_axis_down\":\"Time\",\"unit\":\"ms\",\"prom_queries\":[{\"prom_query_name\":\"node_disk_io_time_seconds_total\",\"legend\":\"{{instance}} - {{device}} - Time spent doing I/Os\",\"resolution\":\"1/2\",\"minstep\":\"5\",\"line\":true,\"close_area\":false}]}]}]}"
      },
`