### PR TITLE
Adding named ports and labels to chaos exporter deployments for monitoring automation

### DIFF
--- a/litmus-portal/graphql-server/manifests/cluster/2c_litmus_deployment.yaml
+++ b/litmus-portal/graphql-server/manifests/cluster/2c_litmus_deployment.yaml
@@ -42,19 +42,20 @@ spec:
             - name: CHAOS_RUNNER_IMAGE
               value: #{LITMUS-CHAOS-RUNNER}
             - name: WATCH_NAMESPACE
-              value: ""
+              value: ''
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "chaos-operator"
+              value: 'chaos-operator'
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: chaos-exporter
+    release: prometheus-stack
   name: chaos-exporter
   namespace: #{AGENT-NAMESPACE}
 spec:
@@ -66,12 +67,19 @@ spec:
     metadata:
       labels:
         app: chaos-exporter
+        release: prometheus-stack
     spec:
       #{nodeselector}
       containers:
         - image: #{LITMUS-CHAOS-EXPORTER}
           imagePullPolicy: Always
           name: chaos-exporter
+          ports:
+            - containerPort: 8080
+              name: tcp
+          env:
+            - name: TSDB_SCRAPE_INTERVAL
+              value: '10'
       serviceAccountName: litmus-cluster-scope
 ---
 apiVersion: v1

--- a/litmus-portal/graphql-server/manifests/namespace/2b_litmus_deployment.yaml
+++ b/litmus-portal/graphql-server/manifests/namespace/2b_litmus_deployment.yaml
@@ -53,13 +53,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "chaos-operator"
+              value: 'chaos-operator'
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: chaos-exporter
+    release: prometheus-stack
   name: chaos-exporter
   namespace: #{AGENT-NAMESPACE}
 spec:
@@ -71,13 +72,19 @@ spec:
     metadata:
       labels:
         app: chaos-exporter
+        release: prometheus-stack
     spec:
       #{nodeselector}
       containers:
         - image: #{LITMUS-CHAOS-EXPORTER}
           imagePullPolicy: Always
           name: chaos-exporter
+          ports:
+            - containerPort: 8080
+              name: tcp
           env:
+            - name: TSDB_SCRAPE_INTERVAL
+              value: '10'
             - name: WATCH_NAMESPACE
               value: #{AGENT-NAMESPACE}
       serviceAccountName: litmus-namespace-scope


### PR DESCRIPTION
## Proposed changes

* Adding named ports for service monitors
* Adding prometheus labels for pod monitors

## Types of changes

- [x] Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)