### PR TITLE
fixing application dashboard crash on saving after panel group name update with existing panel association

### DIFF
--- a/litmus-portal/graphql-server/pkg/analytics/handler/handler.go
+++ b/litmus-portal/graphql-server/pkg/analytics/handler/handler.go
@@ -250,12 +250,11 @@ func UpdateDashBoard(dashboard model.UpdateDBInput, chaosQueryUpdate bool) (stri
 
 	if !chaosQueryUpdate {
 		var (
-			newPanelGroups                = make([]dbSchemaAnalytics.PanelGroup, len(dashboard.PanelGroups))
-			panelsToCreate                []*dbSchemaAnalytics.Panel
-			panelsToUpdate                []*dbSchemaAnalytics.Panel
-			newApplicationMetadataMap     []dbSchemaAnalytics.ApplicationMetadata
-			updatedDashboardPanelIDs      []string
-			updatedDashboardPanelGroupIDs []string
+			newPanelGroups            = make([]dbSchemaAnalytics.PanelGroup, len(dashboard.PanelGroups))
+			panelsToCreate            []*dbSchemaAnalytics.Panel
+			panelsToUpdate            []*dbSchemaAnalytics.Panel
+			newApplicationMetadataMap []dbSchemaAnalytics.ApplicationMetadata
+			updatedDashboardPanelIDs  []string
 		)
 
 		for _, applicationMetadata := range dashboard.ApplicationMetadataMap {
@@ -283,7 +282,6 @@ func UpdateDashBoard(dashboard model.UpdateDBInput, chaosQueryUpdate bool) (stri
 				panelGroupID = uuid.New().String()
 			} else {
 				panelGroupID = panelGroup.PanelGroupID
-				updatedDashboardPanelGroupIDs = append(updatedDashboardPanelGroupIDs, panelGroup.PanelGroupID)
 			}
 
 			newPanelGroups[i].PanelGroupID = panelGroupID
@@ -366,7 +364,7 @@ func UpdateDashBoard(dashboard model.UpdateDBInput, chaosQueryUpdate bool) (stri
 
 			for _, panel := range tempPanels {
 
-				if !utils.ContainsString(updatedDashboardPanelIDs, panel.PanelID) || !utils.ContainsString(updatedDashboardPanelGroupIDs, panelGroup.PanelGroupID) {
+				if !utils.ContainsString(updatedDashboardPanelIDs, panel.PanelID) {
 
 					var promQueriesInPanelToBeDeleted []*dbSchemaAnalytics.PromQuery
 					err := copier.Copy(&promQueriesInPanelToBeDeleted, &panel.PromQueries)


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan@chaosnative.com>

## Proposed changes

fixing application dashboard crash on saving after updating panel group name with existing panels - by removing panel group update check on ids as it was removing the panel and changing its panel group id after updating it correctly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes

Screenshots:

<img width="1132" alt="Screenshot 2021-09-16 at 12 31 25 PM" src="https://user-images.githubusercontent.com/50652677/133565597-93dd5a89-79c7-4cb0-a4b0-4f6cb0f2bd48.png">
- existing panels removed and group id changed to previous id after update

<img width="1145" alt="Screenshot 2021-09-16 at 12 31 43 PM" src="https://user-images.githubusercontent.com/50652677/133565616-ab10aafe-ee14-4d5a-900b-33193943bac5.png">
- panel group name updated with new group id

<img width="635" alt="Screenshot 2021-09-16 at 12 32 35 PM" src="https://user-images.githubusercontent.com/50652677/133565639-5be8d1fc-b1e1-4a55-852d-ebe274557af3.png">
- panels missing for new panel group due to group id mismatch and panel removal based on `is_removed` field's value