### PR TITLE
Adding nginx config as a separated configmap to make it more configurable

### DIFF
--- a/litmus-portal/cluster-k8s-manifest.yml
+++ b/litmus-portal/cluster-k8s-manifest.yml
@@ -520,7 +520,7 @@ data:
             proxy_pass "http://litmusportal-server-service:9002/";
         }
 
-        location /ws/{
+        location /ws/ {
             proxy_set_header   Upgrade              $http_upgrade;
             proxy_set_header   Connection           "Upgrade";
             proxy_set_header   Host                 $host;

--- a/litmus-portal/cluster-k8s-manifest.yml
+++ b/litmus-portal/cluster-k8s-manifest.yml
@@ -469,6 +469,68 @@ data:
   DB_PASSWORD: "1234"
   VERSION: "ci"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litmusportal-frontend-nginx-configuration
+  namespace: litmus
+data:
+  default.conf: |
+    server {
+        listen       8080;
+        server_name  localhost;
+        #charset koi8-r;
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri /index.html;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+
+        location /auth/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9003/";
+        }
+
+        location /api/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+
+        location /ws/{
+            proxy_set_header   Upgrade              $http_upgrade;
+            proxy_set_header   Connection           "Upgrade";
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -498,6 +560,14 @@ spec:
                 configMapKeyRef:
                   name: litmus-portal-admin-config
                   key: AGENT_SCOPE
+          volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: litmusportal-frontend-nginx-configuration
 ---
 apiVersion: v1
 kind: Service

--- a/litmus-portal/namespaced-k8s-template.yml
+++ b/litmus-portal/namespaced-k8s-template.yml
@@ -476,6 +476,68 @@ data:
   DB_PASSWORD: "1234"
   VERSION: "ci"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litmusportal-frontend-nginx-configuration
+  namespace: litmus
+data:
+  default.conf: |
+    server {
+        listen       8080;
+        server_name  localhost;
+        #charset koi8-r;
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri /index.html;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+
+        location /auth/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9003/";
+        }
+
+        location /api/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+
+        location /ws/{
+            proxy_set_header   Upgrade              $http_upgrade;
+            proxy_set_header   Connection           "Upgrade";
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -504,6 +566,14 @@ spec:
                 configMapKeyRef:
                   name: litmus-portal-admin-config
                   key: AGENT_SCOPE
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: litmusportal-frontend-nginx-configuration
 ---
 apiVersion: v1
 kind: Service

--- a/litmus-portal/namespaced-k8s-template.yml
+++ b/litmus-portal/namespaced-k8s-template.yml
@@ -527,7 +527,7 @@ data:
             proxy_pass "http://litmusportal-server-service:9002/";
         }
 
-        location /ws/{
+        location /ws/ {
             proxy_set_header   Upgrade              $http_upgrade;
             proxy_set_header   Connection           "Upgrade";
             proxy_set_header   Host                 $host;

--- a/litmus-portal/platforms/okteto/litmus-portal-dev-manifest-template.yml
+++ b/litmus-portal/platforms/okteto/litmus-portal-dev-manifest-template.yml
@@ -476,6 +476,68 @@ data:
   DB_PASSWORD: "1234"
   VERSION: "ci"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litmusportal-frontend-nginx-configuration
+  namespace: litmus
+data:
+  default.conf: |
+    server {
+        listen       8080;
+        server_name  localhost;
+        #charset koi8-r;
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri /index.html;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+
+        location /auth/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9003/";
+        }
+
+        location /api/ {
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+
+        location /ws/{
+            proxy_set_header   Upgrade              $http_upgrade;
+            proxy_set_header   Connection           "Upgrade";
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
+            proxy_pass "http://litmusportal-server-service:9002/";
+        }
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -502,6 +564,20 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          env:
+            - name: AGENT_SCOPE
+              valueFrom:
+                configMapKeyRef:
+                  name: litmus-portal-admin-config
+                  key: AGENT_SCOPE
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: litmusportal-frontend-nginx-configuration
 ---
 apiVersion: v1
 kind: Service

--- a/litmus-portal/platforms/okteto/litmus-portal-dev-manifest-template.yml
+++ b/litmus-portal/platforms/okteto/litmus-portal-dev-manifest-template.yml
@@ -527,7 +527,7 @@ data:
             proxy_pass "http://litmusportal-server-service:9002/";
         }
 
-        location /ws/{
+        location /ws/ {
             proxy_set_header   Upgrade              $http_upgrade;
             proxy_set_header   Connection           "Upgrade";
             proxy_set_header   Host                 $host;


### PR DESCRIPTION
Signed-off-by: rajdas98 <mail.rajdas@gmail.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Currently, the server addresses are hardcoded in the frontend docker image, so that it is hard to configure the endpoints. Adding nginx config as a separate configmap and mount it with the frontend deployment.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
