### PR TITLE
Feat: Added feature to display previos values of users fullname and e…

### DIFF
--- a/litmus-portal/frontend/src/components/Header/ProfileDropDown.tsx
+++ b/litmus-portal/frontend/src/components/Header/ProfileDropDown.tsx
@@ -10,12 +10,15 @@ import { ButtonFilled, Icon, TextButton } from 'litmus-ui';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { GET_USER_INFO } from '../../graphql';
-import { CurrentUserDetails } from '../../models/graphql/user';
+import { GET_USER } from '../../graphql';
+import {
+  CurrentUserDetails,
+  CurrentUserDedtailsVars,
+} from '../../models/graphql/user';
 import useActions from '../../redux/actions';
 import * as TabActions from '../../redux/actions/tabs';
 import { history } from '../../redux/configureStore';
-import { getUserEmail, getUsername, logout } from '../../utils/auth';
+import { getUsername, logout } from '../../utils/auth';
 import { getProjectID, getProjectRole } from '../../utils/getSearchParams';
 import { userInitials } from '../../utils/userInitials';
 import useStyles from './styles';
@@ -31,18 +34,15 @@ const ProfileDropdown: React.FC = () => {
   // Get username from JWT
   const username = getUsername();
 
-  // Get the userEmail from JWT
-  const userEmailToken = getUserEmail();
-
   const projectID = getProjectID();
   const projectRole = getProjectRole();
 
-  const [userEmail, setuserEmail] = useState<string>(userEmailToken);
+  const [userEmail, setuserEmail] = useState<string>('');
 
   // Run query to get the data in case it is not present in the JWT
-  useQuery<CurrentUserDetails>(GET_USER_INFO, {
-    skip: userEmail !== undefined && userEmail !== '',
+  useQuery<CurrentUserDetails, CurrentUserDedtailsVars>(GET_USER, {
     variables: { username },
+    fetchPolicy: 'cache-and-network',
     onCompleted: (data) => {
       setuserEmail(data.getUser.email);
     },

--- a/litmus-portal/frontend/src/views/Settings/AccountsTab/PersonalDetails/index.tsx
+++ b/litmus-portal/frontend/src/views/Settings/AccountsTab/PersonalDetails/index.tsx
@@ -30,10 +30,6 @@ const PersonalDetails: React.FC = () => {
   const [loading, setLoading] = React.useState(false);
   // Query to get user details
   const [memberDetails, setMemberDetails] = useState<CurrentUserData>();
-  // const { data: dataA } = useQuery<CurrentUserDetails, CurrentUserDedtailsVars>(
-  //   GET_USER,
-  //   { variables: { username } }
-  // );
 
   const { data: dataA } = useQuery<CurrentUserDetails, CurrentUserDedtailsVars>(
     GET_USER,
@@ -74,12 +70,11 @@ const PersonalDetails: React.FC = () => {
   const handleNameChange = (e: any) => {
     const { value } = e.target;
     if (value !== '') {
-      // if(e.target.value.charAt(0)===' ' ?e.target.value.substr(1):e.target.value){
       const str =
         e.target.value.charAt(0) === ' '
           ? e.target.value.substr(1)
           : e.target.value;
-      // }
+
       setPersonaData({
         fullName: str,
         userName: personaData.userName,
@@ -95,12 +90,11 @@ const PersonalDetails: React.FC = () => {
   const handleEmailChange = (e: any) => {
     const { value } = e.target;
     if (value !== '') {
-      // if(e.target.value.charAt(0)===' ' ?e.target.value.substr(1):e.target.value){
       const str =
         e.target.value.charAt(0) === ' '
           ? e.target.value.substr(1)
           : e.target.value;
-      // }
+
       setPersonaData({
         fullName: personaData.fullName,
         userName: personaData.userName,


### PR DESCRIPTION
…mail set in accounts tab

To discuss-
1) box at top right doesnt load new email when changed immediately

2) both values must be set and then save button gets activated

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue:

[issue: ](https://github.com/litmuschaos/litmus/issues/3158)

Changes are made to display full name and user email 

To handle empty string , the handleNameChange and handleEmailChange will strip "space" automatically while user updates values

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:

To enable save button both values i.e. full name and email must be set . Previously it was limited to full name only  