### PR TITLE
Added rbac for mutations

### DIFF
--- a/litmus-portal/graphql-server/graph/schema.resolvers.go
+++ b/litmus-portal/graphql-server/graph/schema.resolvers.go
@@ -34,6 +34,11 @@ import (
 )
 
 func (r *mutationResolver) UserClusterReg(ctx context.Context, clusterInput model.ClusterInput) (*model.ClusterRegResponse, error) {
+	err := authorization.ValidateRole(ctx, clusterInput.ProjectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor}, usermanagement.AcceptedInvitation)
+	if err != nil {
+		return nil, err
+	}
+
 	return clusterHandler.ClusterRegister(clusterInput)
 }
 
@@ -272,14 +277,29 @@ func (r *mutationResolver) UpdateGitOps(ctx context.Context, config model.GitCon
 }
 
 func (r *mutationResolver) CreateDataSource(ctx context.Context, datasource *model.DSInput) (*model.DSResponse, error) {
+	err := authorization.ValidateRole(ctx, *datasource.ProjectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor}, usermanagement.AcceptedInvitation)
+	if err != nil {
+		return nil, err
+	}
+
 	return analyticsHandler.CreateDataSource(datasource)
 }
 
 func (r *mutationResolver) CreateDashBoard(ctx context.Context, dashboard *model.CreateDBInput) (*model.ListDashboardResponse, error) {
+	err := authorization.ValidateRole(ctx, dashboard.ProjectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor}, usermanagement.AcceptedInvitation)
+	if err != nil {
+		return nil, err
+	}
+
 	return analyticsHandler.CreateDashboard(dashboard)
 }
 
 func (r *mutationResolver) UpdateDataSource(ctx context.Context, datasource model.DSInput) (*model.DSResponse, error) {
+	err := authorization.ValidateRole(ctx, *datasource.ProjectID, []model.MemberRole{model.MemberRoleOwner, model.MemberRoleEditor}, usermanagement.AcceptedInvitation)
+	if err != nil {
+		return nil, err
+	}
+
 	return analyticsHandler.UpdateDataSource(datasource)
 }
 


### PR DESCRIPTION
Signed-off-by: SarthakJain26 <sarthak@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Added rbac for following mutations:
- `UserClusterReg`
- `CreateDataSource`
- `CreateDashBoard`
- `UpdateDataSource`

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
- Rbac is added only for the mutations where projectID is passed in the request body

## TODO
- Add Rbac for other mutations where project ID is not passed by adding custom queries.