### PR TITLE
Removing the event tracker dependency from "last-applied-configuration" annotation

### DIFF
--- a/litmus-portal/cluster-agents/event-tracker/pkg/utils/informers.go
+++ b/litmus-portal/cluster-agents/event-tracker/pkg/utils/informers.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
+
+	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -27,34 +27,17 @@ func RunDeploymentInformer(factory informers.SharedInformerFactory) {
 			depNewObj := newObj.(*v1.Deployment)
 			depOldObj := oldObj.(*v1.Deployment)
 
-			oldManifest := depOldObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
-			newManifest := depNewObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
+			var worflowid = depNewObj.GetAnnotations()["litmuschaos.io/workflow"]
 
-			if oldManifest != "" && newManifest != "" {
-				var oldDep v1.Deployment
-				err := json.Unmarshal([]byte(oldManifest), &oldDep)
+			if depNewObj.GetResourceVersion() != depOldObj.GetResourceVersion() &&
+				!reflect.DeepEqual(depNewObj, depOldObj) &&
+				depNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" &&
+				worflowid != "" {
+				logrus.Infof("GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "Deployment", depNewObj.Name, depNewObj.Namespace)
+				err := PolicyAuditor("Deployment", depNewObj, depOldObj, worflowid)
 				if err != nil {
-					log.Print(err)
+					logrus.Error(err)
 					return
-				}
-
-				var newDep v1.Deployment
-				err = json.Unmarshal([]byte(newManifest), &newDep)
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				if depNewObj.GetResourceVersion() != depOldObj.GetResourceVersion() && !reflect.DeepEqual(newDep, oldDep) {
-					var worflowid = depNewObj.GetAnnotations()["litmuschaos.io/workflow"]
-					if depNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" && worflowid != "" {
-						log.Printf("EventType: Update \n GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "Deployment", depNewObj.Name, depNewObj.Namespace)
-						err := PolicyAuditor("Deployment", depNewObj, depOldObj, worflowid)
-						if err != nil {
-							log.Print(err)
-							return
-						}
-					}
 				}
 			}
 		},
@@ -82,37 +65,20 @@ func RunStsInformer(factory informers.SharedInformerFactory) {
 			stsNewObj := newObj.(*v1.StatefulSet)
 			stsOldObj := oldObj.(*v1.StatefulSet)
 
-			oldManifest := stsOldObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
-			newManifest := stsNewObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
+			var worflowid = stsNewObj.GetAnnotations()["litmuschaos.io/workflow"]
 
-			if oldManifest != "" && newManifest != "" {
-				var oldSts v1.StatefulSet
-				err := json.Unmarshal([]byte(oldManifest), &oldSts)
+			if stsNewObj.GetResourceVersion() != stsOldObj.GetResourceVersion() &&
+				!reflect.DeepEqual(stsNewObj, stsOldObj) &&
+				stsNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" &&
+				worflowid != "" {
+				logrus.Infof("GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "Deployment", stsNewObj.Name, stsNewObj.Namespace)
+				err := PolicyAuditor("Deployment", stsNewObj, stsOldObj, worflowid)
 				if err != nil {
-					log.Print(err)
+					logrus.Error(err)
 					return
-				}
-
-				var newSts v1.StatefulSet
-				err = json.Unmarshal([]byte(newManifest), &newSts)
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				if stsNewObj.GetResourceVersion() != stsOldObj.GetResourceVersion() && !reflect.DeepEqual(newSts, oldSts) {
-					var worflowid = stsNewObj.GetAnnotations()["litmuschaos.io/workflow"]
-					if stsNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" && worflowid != "" {
-						log.Printf("EventType: Update \n GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "StateFulSet", stsNewObj.Name, stsNewObj.Namespace)
-						err := PolicyAuditor("StateFulSet", stsNewObj, stsOldObj, worflowid)
-						if err != nil {
-							log.Print(err)
-							return
-						}
-					}
-
 				}
 			}
+
 		},
 	})
 
@@ -138,36 +104,20 @@ func RunDSInformer(factory informers.SharedInformerFactory) {
 			dsNewObj := newObj.(*v1.DaemonSet)
 			dsOldObj := newObj.(*v1.DaemonSet)
 
-			oldManifest := dsOldObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
-			newManifest := dsNewObj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]
+			var worflowid = dsNewObj.GetAnnotations()["litmuschaos.io/workflow"]
 
-			if oldManifest != "" && newManifest != "" {
-				var oldDm v1.StatefulSet
-				err := json.Unmarshal([]byte(oldManifest), &oldDm)
+			if dsNewObj.GetResourceVersion() != dsOldObj.GetResourceVersion() &&
+				!reflect.DeepEqual(dsNewObj, dsOldObj) &&
+				dsNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" &&
+				worflowid != "" {
+				logrus.Infof("GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "Deployment", dsNewObj.Name, dsNewObj.Namespace)
+				err := PolicyAuditor("Deployment", dsNewObj, dsOldObj, worflowid)
 				if err != nil {
-					log.Print(err)
+					logrus.Error(err)
 					return
-				}
-
-				var newDm v1.StatefulSet
-				err = json.Unmarshal([]byte(newManifest), &newDm)
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				if dsNewObj.GetResourceVersion() != dsOldObj.GetResourceVersion() && !reflect.DeepEqual(newDm, oldDm) {
-					var worflowid = dsNewObj.GetAnnotations()["litmuschaos.io/workflow"]
-					if dsNewObj.GetAnnotations()["litmuschaos.io/gitops"] == "true" && worflowid != "" {
-						log.Printf("EventType: Update \n GitOps Notification for workflowID: %s, ResourceType: %s, ResourceName: %s, ResourceNamespace: %s", worflowid, "DaemonSet", dsNewObj.Name, dsNewObj.Namespace)
-						err := PolicyAuditor("DaemonSet", dsNewObj, dsOldObj, worflowid)
-						if err != nil {
-							log.Print(err)
-							return
-						}
-					}
 				}
 			}
+
 		},
 	})
 

--- a/litmus-portal/cluster-agents/event-tracker/pkg/utils/utils.go
+++ b/litmus-portal/cluster-agents/event-tracker/pkg/utils/utils.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -94,7 +93,7 @@ func conditionChecker(etp litmuschaosv1.EventTrackerPolicy, newData interface{},
 					}
 				}
 			} else {
-				log.Println("no changes in the resource")
+				logrus.Println("no changes in the resource")
 			}
 		}
 	} else if etp.Spec.ConditionType == "or" {
@@ -120,7 +119,7 @@ func conditionChecker(etp litmuschaosv1.EventTrackerPolicy, newData interface{},
 					}
 				}
 			} else {
-				log.Println("no changes in the resource")
+				logrus.Println("no changes in the resource")
 			}
 		}
 	}
@@ -146,7 +145,7 @@ func PolicyAuditor(resourceType string, newObj interface{}, oldObj interface{}, 
 	}
 
 	if len(deploymentConfigList.Items) == 0 {
-		log.Print("No event-tracker policy(s) found in " + AgentNamespace + " namespace")
+		logrus.Print("No event-tracker policy(s) found in " + AgentNamespace + " namespace")
 		return nil
 	}
 
@@ -283,7 +282,7 @@ func PolicyAuditor(resourceType string, newObj interface{}, oldObj interface{}, 
 				return err
 			}
 
-			log.Print("EventTrackerPolicy updated")
+			logrus.Print("EventTrackerPolicy updated")
 		} else {
 			logrus.Println("Condition failed for resource name:", resourceName, " resource type:", resourceType)
 		}


### PR DESCRIPTION
Signed-off-by: rajdas98 <mail.rajdas@gmail.com>

<!--  Thanks for sending a pull request!  -->

* Some Kubernetes clusters don't have kubectl.kubernetes.io/last-applied-configuration annotation due to which it affects the event tracker functionality
*  Removing the event tracker dependency on "last-applied-configuration" annotation by comparing the changes of the last two object provided by the Kubernetes informer

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x's in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
