### PR TITLE
Added partialFilter in workflow name indexing

### DIFF
--- a/litmus-portal/graphql-server/pkg/database/mongodb/init.go
+++ b/litmus-portal/graphql-server/pkg/database/mongodb/init.go
@@ -130,7 +130,9 @@ func (m *MongoClient) initAllCollection() {
 			Keys: bson.M{
 				"workflow_name": 1,
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetPartialFilterExpression(bson.D{{
+				"isRemoved", false,
+			}}),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Amit Kumar Das <amit@chaosnative.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Fixes issue #3417 
This will fix the issue for the following case:
If a workflow is deleted and user creates a new workflow with the same name, it will not throw a duplicate workflow name error.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
