### PR TITLE
fix: Error: failed to unmarshal chaosengine

### DIFF
--- a/litmus-portal/graphql-server/pkg/chaos-workflow/ops/operations.go
+++ b/litmus-portal/graphql-server/pkg/chaos-workflow/ops/operations.go
@@ -342,12 +342,12 @@ func processWorkflowManifest(workflow *model.ChaosWorkFlowInput, weights map[str
 	}
 
 	for i, template := range workflowManifest.Spec.Templates {
-		artifact := template.Inputs.Artifacts
-		if len(artifact) > 0 {
-			if artifact[0].Raw == nil {
+		artifacts := template.Inputs.Artifacts
+		for _, artifact := range artifacts {
+			if artifact.Raw == nil {
 				continue
 			}
-			var data = artifact[0].Raw.Data
+			var data = artifact.Raw.Data
 			if len(data) > 0 {
 				// This replacement is required because chaos engine yaml have a syntax template. example:{{ workflow.parameters.adminModeNamespace }}
 				// And it is not able the unmarshal the yamlstring to chaos engine struct
@@ -357,7 +357,7 @@ func processWorkflowManifest(workflow *model.ChaosWorkFlowInput, weights map[str
 				var meta chaosTypes.ChaosEngine
 				err := yaml.Unmarshal([]byte(data), &meta)
 				if err != nil {
-					return errors.New("failed to unmarshal chaosengine")
+					continue
 				}
 
 				if strings.ToLower(meta.Kind) == "chaosengine" {
@@ -456,12 +456,12 @@ func processCronWorkflowManifest(workflow *model.ChaosWorkFlowInput, weights map
 
 	for i, template := range cronWorkflowManifest.Spec.WorkflowSpec.Templates {
 
-		artifact := template.Inputs.Artifacts
-		if len(artifact) > 0 {
-			if artifact[0].Raw == nil {
+		artifacts := template.Inputs.Artifacts
+		for _, artifact := range artifacts {
+			if artifact.Raw == nil {
 				continue
 			}
-			var data = artifact[0].Raw.Data
+			var data = artifact.Raw.Data
 			if len(data) > 0 {
 				// This replacement is required because chaos engine yaml have a syntax template. example:{{ workflow.parameters.adminModeNamespace }}
 				// And it is not able the unmarshal the yamlstring to chaos engine struct
@@ -471,7 +471,7 @@ func processCronWorkflowManifest(workflow *model.ChaosWorkFlowInput, weights map
 				var meta chaosTypes.ChaosEngine
 				err = yaml.Unmarshal([]byte(data), &meta)
 				if err != nil {
-					return errors.New("failed to unmarshal chaosengine")
+					continue
 				}
 
 				if strings.ToLower(meta.Kind) == "chaosengine" {


### PR DESCRIPTION

I get an error when I use the following template. Error: failed to unmarshal chaosengine

> 

    - name: check-http-code
      inputs:
        parameters:
          - name: url
          - name: code
        artifacts:
          - name: check-http-code
            path: /tmp/check-http-code.py
            raw:
              data: |
                #!/bin/env python

                import time
                from urllib import response
                import urllib.request
                import urllib.parse

                url = "{{inputs.parameters.url}}"
                intcode = int("{{inputs.parameters.code}}")
                print("url:", url, "intcode", intcode)

                response = urllib.request.urlopen(url)
                time.sleep(5)
                if intcode == response.status:
                    print("check success")
                else:
                    print("ERROR: Code is", response.status)
                    exit(1)

      container:
        image: python:3.6
        command: [python]
        args: ["/tmp/check-http-code.py"]
···

It is unreasonable to display "failed to unmarshal chaosengine" when "artifact.Raw.Data" is used to store Python scripts in the workflow. 

Maybe this PR is a solution. Looking forward to your reply.

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
