### PR TITLE
Adding readOnlyRootFilesystem to true for servers

### DIFF
--- a/litmus-portal/cluster-k8s-manifest.yml
+++ b/litmus-portal/cluster-k8s-manifest.yml
@@ -578,13 +578,24 @@ spec:
             [
               "while [[ $(curl -sw '%{http_code}' http://mongo-service:27017 -o /dev/null) -ne 200 ]]; do sleep 5; echo 'Waiting for the MongoDB to be ready...'; done; echo 'Connection with MongoDB established'",
             ]
+      volumes:
+        - name: gitops-storage
+          emptyDir: {}
+        - name: hub-storage
+          emptyDir: {}
       containers:
         - name: graphql-server
           image: litmuschaos/litmusportal-server:ci
+          volumeMounts:
+            - mountPath: /tmp/gitops
+              name: gitops-storage
+            - mountPath: /data/tmp
+              name: hub-storage
           securityContext:
             runAsUser: 2000
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
           envFrom:
             - configMapRef:
                 name: litmus-portal-admin-config
@@ -699,6 +710,7 @@ spec:
             runAsUser: 2000
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
           envFrom:
             - configMapRef:
                 name: litmus-portal-admin-config

--- a/litmus-portal/namespaced-k8s-template.yml
+++ b/litmus-portal/namespaced-k8s-template.yml
@@ -559,13 +559,24 @@ spec:
             [
               "while [[ $(curl -sw '%{http_code}' http://mongo-service:27017 -o /dev/null) -ne 200 ]]; do sleep 5; echo 'Waiting for the MongoDB to be ready...'; done; echo 'Connection with MongoDB established'",
             ]
+      volumes:
+        - name: gitops-storage
+          emptyDir: {}
+        - name: hub-storage
+          emptyDir: {}
       containers:
         - name: graphql-server
           image: litmuschaos/litmusportal-server:ci
+          volumeMounts:
+            - mountPath: /tmp/gitops
+              name: gitops-storage
+            - mountPath: /data/tmp
+              name: hub-storage
           securityContext:
             runAsUser: 2000
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
           envFrom:
             - configMapRef:
                 name: litmus-portal-admin-config
@@ -676,6 +687,7 @@ spec:
             runAsUser: 2000
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
           envFrom:
             - configMapRef:
                 name: litmus-portal-admin-config


### PR DESCRIPTION
Signed-off-by: rajdas98 <mail.rajdas@gmail.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Adding readOnlyRootFilesystem to true for servers

Note: Mongo and frontend can't be run as read-only.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
