### PR TITLE
Update pod-network-latency Docs FOR JITTER env

### DIFF
--- a/mkdocs/docs/experiments/categories/pods/pod-network-latency.md
+++ b/mkdocs/docs/experiments/categories/pods/pod-network-latency.md
@@ -150,7 +150,7 @@
         <td> JITTER </td>
         <td> The network jitter value in ms </td>
         <td> Default 0, provide numeric value only </td>
-      </tr>
+      </tr> 
       <tr>
         <td> CONTAINER_RUNTIME  </td>
         <td> container runtime interface for the cluster</td>

--- a/mkdocs/docs/experiments/categories/pods/pod-network-latency.md
+++ b/mkdocs/docs/experiments/categories/pods/pod-network-latency.md
@@ -139,14 +139,17 @@
       <tr>
         <td> TARGET_CONTAINER  </td>
         <td> Name of container which is subjected to network latency </td>
-        <td> Optional </td>
         <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
       </tr>
       <tr>
         <td> NETWORK_LATENCY </td>
         <td> The latency/delay in milliseconds </td>
-        <td> Optional </td>
         <td> Default 2000, provide numeric value only </td>
+      </tr>
+      <tr>
+        <td> JITTER </td>
+        <td> The network jitter value in ms </td>
+        <td> Default 0, provide numeric value only </td>
       </tr>
       <tr>
         <td> CONTAINER_RUNTIME  </td>
@@ -183,7 +186,7 @@
         <td> The Percentage of total pods to target  </td>
         <td> Defaults to 0 (corresponds to 1 replica), provide numeric value only </td>
       </tr> 
-    <tr>
+      <tr>
         <td> LIB </td>
         <td> The chaos lib used to inject the chaos </td>
         <td> Default value: litmus, supported values: pumba and litmus </td>


### PR DESCRIPTION
## Proposed changes
- Adds `JITTER` to the list of envs of pod-network-latency experiment

## Which Issue Does This PR Fixes
fixes #3617

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)