### PR TITLE
Added changes for making clusterIP as default endpoint for self/internal delegates

### DIFF
--- a/litmus-portal/graphql-server/pkg/cluster/handler/handler.go
+++ b/litmus-portal/graphql-server/pkg/cluster/handler/handler.go
@@ -30,7 +30,7 @@ import (
 
 // RegisterCluster creates an entry for a new cluster in DB and generates the url used to apply manifest
 func RegisterCluster(request model.RegisterClusterRequest) (*model.RegisterClusterResponse, error) {
-	endpoint, err := handlers.GetEndpoint()
+	endpoint, err := handlers.GetEndpoint(request.ClusterType)
 	if err != nil {
 		return nil, err
 	}

--- a/litmus-portal/manifests/namespace-k8s-manifest.yml
+++ b/litmus-portal/manifests/namespace-k8s-manifest.yml
@@ -612,8 +612,10 @@ spec:
               value: "namespace"
             - name: AGENT_DEPLOYMENTS
               value: "[\"app=chaos-exporter\", \"name=chaos-operator\", \"app=event-tracker\", \"app=workflow-controller\"]"
+            - name: SERVER_SERVICE_NAME
+              value: "litmusportal-server-service"
             - name: CHAOS_CENTER_UI_ENDPOINT
-              value: "http://litmusportal-frontend-service:9091"
+              value: ""
             - name: SUBSCRIBER_IMAGE
               value: "litmuschaos/litmusportal-subscriber:ci"
             - name: EVENT_TRACKER_IMAGE


### PR DESCRIPTION
Signed-off-by: Vedant Shrotria <vedant.shrotria@harness.io>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

**- These changes will make ClusterIP/ Service FQDN as default endpoint for Self/Internal agents.**

**- Also now in one case when server-service-type is NodePort and User has installed Portal in Namespaced Scope mode, then the endpoint will not be generated for external agents. User has to modify the `CHAOS_CENTER_UI_ENDPOINT` env in this case with frontend access endpoint.**

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [X] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
