### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/monitoring/utils/metrics-exporters-with-service-monitors/kube-state-metrics/deployment.yaml
+++ b/monitoring/utils/metrics-exporters-with-service-monitors/kube-state-metrics/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         release: prometheus-stack
     spec:
       containers:
-        - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+        - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
           securityContext:
             runAsUser: 65534
           livenessProbe:

--- a/monitoring/utils/metrics-exporters/kube-state-metrics/deployment.yaml
+++ b/monitoring/utils/metrics-exporters/kube-state-metrics/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         release: prometheus-stack
     spec:
       containers:
-        - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+        - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
           securityContext:
             runAsUser: 65534
           livenessProbe:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
