### PR TITLE
bump the Go image to 1.20

### DIFF
--- a/litmus-portal/authentication/Dockerfile
+++ b/litmus-portal/authentication/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.16 AS builder
+FROM golang:1.20 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH

--- a/litmus-portal/cluster-agents/event-tracker/Dockerfile
+++ b/litmus-portal/cluster-agents/event-tracker/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.16 AS builder
+FROM golang:1.20 AS builder
 
 LABEL maintainer="LitmusChaos"
 

--- a/litmus-portal/cluster-agents/subscriber/Dockerfile
+++ b/litmus-portal/cluster-agents/subscriber/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.16 AS builder
+FROM golang:1.20 AS builder
 
 LABEL maintainer="LitmusChaos"
 

--- a/litmus-portal/graphql-server/Dockerfile
+++ b/litmus-portal/graphql-server/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.16 AS builder
+FROM golang:1.20 AS builder
 
 LABEL maintainer="LitmusChaos"
 

--- a/litmus-portal/upgrade-agents/control-plane/Dockerfile
+++ b/litmus-portal/upgrade-agents/control-plane/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.16 AS builder
+FROM golang:1.20 AS builder
 
 LABEL maintainer="LitmusChaos"
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  -->

## Proposed changes
This PR bumps Go to 1.20. Go version 1.16 is old, unsupported and has known CVEs. These known vulnerabilities have been addressed in newer versions of Go.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [X] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
n/a

## Special notes for your reviewer:
