### PR TITLE
[litmus-portal]Updating to use kubernetes patch instead of get-update in subscriber for updating cm and secret

### DIFF
--- a/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/graphql"
-	"github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/types"
+	atype "github.com/litmuschaos/litmus/litmus-portal/cluster-agents/subscriber/pkg/types"
 
 	yaml_converter "github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
@@ -295,7 +295,7 @@ func addCustomLabels(obj *unstructured.Unstructured, customLabels map[string]str
 }
 
 // ClusterOperations handles cluster operations
-func ClusterOperations(clusterAction types.Action) (*unstructured.Unstructured, error) {
+func ClusterOperations(clusterAction atype.Action) (*unstructured.Unstructured, error) {
 
 	// Converting JSON to YAML and store it in yamlStr variable
 	yamlStr, err := yaml_converter.JSONToYAML([]byte(clusterAction.K8SManifest))

--- a/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
@@ -165,13 +165,13 @@ func ClusterRegister(accessKey string) (bool, error) {
 		return false, err
 	}
 
-	is_cluster_confirmed, _, err := IsClusterConfirmed()
+	isClusterConfirmed, _, err := IsClusterConfirmed()
 	if err != nil {
 		return false, err
 	}
 
 	configMapPatch:= map[string]bool {
-		"data": is_cluster_confirmed,
+		"data": isClusterConfirmed,
 	}
 	configMapPatchOutput, err:= json.Marshal(configMapPatch)
 	if err != nil {

--- a/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
+++ b/litmus-portal/cluster-agents/subscriber/pkg/k8s/operations.go
@@ -159,14 +159,19 @@ func IsClusterConfirmed() (bool, string, error) {
 }
 
 // ClusterRegister function creates litmus-portal config map in the litmus namespace
-func ClusterRegister(clusterData map[string]string) (bool, error) {
+func ClusterRegister(accessKey string) (bool, error) {
 	clientset, err:= GetGenericK8sClient()
 	if err != nil {
 		return false, err
 	}
 
-	configMapPatch:= map[string]interface{}{
-		"data": clusterData,
+	is_cluster_confirmed, _, err := IsClusterConfirmed()
+	if err != nil {
+		return false, err
+	}
+
+	configMapPatch:= map[string]bool {
+		"data": is_cluster_confirmed,
 	}
 	configMapPatchOutput, err:= json.Marshal(configMapPatch)
 	if err != nil {
@@ -178,10 +183,10 @@ func ClusterRegister(clusterData map[string]string) (bool, error) {
 		return false, err
 	}
 
-	logrus.Info(AgentConfigName+" has been updated")
+	logrus.Info("%s has been patched",AgentConfigName)
 
-	secretPatch:= map[string]interface{}{
-		"stringData":clusterData,
+	secretPatch:= map[string]string{
+		"stringData": accessKey,
 	}
 	secretPatchOutput, err:= json.Marshal(secretPatch)
 	if err != nil {
@@ -192,7 +197,7 @@ func ClusterRegister(clusterData map[string]string) (bool, error) {
 		return false,err
 	}
 
-	logrus.Info(AgentSecretName+" has been updated")
+	logrus.Infof("%s has been patched", AgentSecretName)
 
 	return true, nil
 	

--- a/litmus-portal/cluster-agents/subscriber/subscriber.go
+++ b/litmus-portal/cluster-agents/subscriber/subscriber.go
@@ -114,7 +114,7 @@ func init() {
 			clusterData["ACCESS_KEY"] = clusterConfirmInterface.Data.ClusterConfirm.NewAccessKey
 			clusterData["IS_CLUSTER_CONFIRMED"] = "true"
 
-			_, err = k8s.ClusterRegister(clusterData)
+			_, err = k8s.ClusterRegister(clusterData["ACCESS_KEY"],clusterData["IS_CLUSTER_CONFIRMED"])
 			if err != nil {
 				logrus.Fatal(err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

The ClusterRegister function in the litmus/litmus-portal/cluster-agents/subscriber/pkg/k8s
/operations.go has been modified to use kubernetes patch instead of update in subscriber for updating cm and secret


This solves the issue #3944

I have made use of the json.Marshal for the clusterData and have used it in Patch(MergePatchType) for both configMap and Secret patch.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
