### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
         id: getcommit
         run: |
           prsha=$(echo $response | jq '.[-1].sha'  | tr -d '"')
-          echo "::set-output name=sha::$prsha"
+          echo "sha=$prsha" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_PR_commits.outputs.data }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Proposed changes

Resolve #4114 

Update `.github/workflows/e2e.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=sha::$prsha"
```

**TO-BE**

```yaml
echo "sha=$prsha" >> $GITHUB_OUTPUT
```

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

None

## Special notes for your reviewer:

None