### PR TITLE
[chore]: Show an error popup when a user enters an invalid info

### DIFF
--- a/chaoscenter/web/src/controllers/CreateNewToken/CreateNewToken.tsx
+++ b/chaoscenter/web/src/controllers/CreateNewToken/CreateNewToken.tsx
@@ -20,8 +20,7 @@ export default function CreateNewTokenController(props: CreateNewTokenController
   const { mutate: createNewTokenMutation, isLoading } = useCreateApiTokenMutation(
     {},
     {
-      onSuccess: data => {
-        data.accessToken;
+      onSuccess: () => {
         apiTokensRefetch();
         showSuccess(getString('tokenCreateSuccessMessage'));
       }

--- a/chaoscenter/web/src/strings/strings.en.yaml
+++ b/chaoscenter/web/src/strings/strings.en.yaml
@@ -48,6 +48,7 @@ allExecutions: All Executions
 allFaultsExecuted: All your faults executed without any issue
 allRuns: All Runs
 alreadyExists: '{{value}} already exists'
+alreadyExistsID: Entered id '{{value}}' already exists
 apiTokens: API Tokens
 appKind: App Kind
 appKindName: app_kind

--- a/chaoscenter/web/src/strings/types.ts
+++ b/chaoscenter/web/src/strings/types.ts
@@ -51,6 +51,7 @@ export interface StringsMap {
   'allFaultsExecuted': unknown
   'allRuns': unknown
   'alreadyExists': PrimitiveObject<'value'>
+  'alreadyExistsID': PrimitiveObject<'value'>
   'apiTokens': unknown
   'appKind': unknown
   'appKindName': unknown

--- a/chaoscenter/web/src/views/AccountPasswordChange/AccountPasswordChange.tsx
+++ b/chaoscenter/web/src/views/AccountPasswordChange/AccountPasswordChange.tsx
@@ -1,5 +1,5 @@
 import { FontVariation } from '@harnessio/design-system';
-import { Button, ButtonVariation, Container, FormInput, Layout, Text } from '@harnessio/uicore';
+import { Button, ButtonVariation, Container, FormInput, Layout, Text, useToaster } from '@harnessio/uicore';
 import React from 'react';
 import { Icon } from '@harnessio/icons';
 import { Form, Formik } from 'formik';
@@ -28,6 +28,7 @@ interface AccountPasswordChangeFormProps {
 export default function AccountPasswordChangeView(props: AccountPasswordChangeViewProps): React.ReactElement {
   const { handleClose, updatePasswordMutation, updatePasswordMutationLoading, username } = props;
   const { getString } = useStrings();
+  const { showError } = useToaster();
 
   function isSubmitButtonDisabled(values: AccountPasswordChangeFormProps): boolean {
     if (values.oldPassword === '' || values.newPassword === '' || values.reEnterNewPassword === '') {
@@ -56,7 +57,8 @@ export default function AccountPasswordChangeView(props: AccountPasswordChangeVi
           }
         },
         {
-          onSuccess: () => handleClose()
+          onSuccess: () => handleClose(),
+          onError: () => showError(getString('passwordsDoNotMatch'))
         }
       );
   }

--- a/chaoscenter/web/src/views/AccountPasswordChange/AccountPasswordChange.tsx
+++ b/chaoscenter/web/src/views/AccountPasswordChange/AccountPasswordChange.tsx
@@ -57,8 +57,8 @@ export default function AccountPasswordChangeView(props: AccountPasswordChangeVi
           }
         },
         {
-          onSuccess: () => handleClose(),
-          onError: () => showError(getString('passwordsDoNotMatch'))
+          onError: () => showError(getString('passwordsDoNotMatch')),
+          onSuccess: () => handleClose()
         }
       );
   }

--- a/chaoscenter/web/src/views/Environments/EnvironmentList/CreateEnvironment.tsx
+++ b/chaoscenter/web/src/views/Environments/EnvironmentList/CreateEnvironment.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonVariation, CardSelect, Container, FormInput, Layout, Text } from '@harnessio/uicore';
+import { Button, ButtonVariation, CardSelect, Container, FormInput, Layout, Text, useToaster } from '@harnessio/uicore';
 import { FontVariation, Color } from '@harnessio/design-system';
 import { Form, Formik } from 'formik';
 import React from 'react';
@@ -48,6 +48,7 @@ export default function CreateEnvironment({
 }: CreateEnvironmentProps): React.ReactElement {
   const { getString } = useStrings();
   const scope = getScope();
+  const { showError } = useToaster();
   const initialValues: CreateEnvironmentData = {
     id: editable ? environmentID ?? '' : '',
     name: editable ? existingEnvironment?.name ?? '' : '',
@@ -87,6 +88,7 @@ export default function CreateEnvironment({
                       }
                     }
                   })
+                  .catch(() => showError(getString('alreadyExistsID', { value: data.id })))
                   .then(() => closeModal())
               : mutation.updateEnvironment &&
                 environmentID &&
@@ -154,12 +156,7 @@ export default function CreateEnvironment({
                       variation={ButtonVariation.SECONDARY}
                       text={getString('cancel')}
                     />
-                    <Button
-                      type="submit"
-                      variation={ButtonVariation.PRIMARY}
-                      text={getString('save')}
-                      onClick={() => formikProps.handleSubmit()}
-                    />
+                    <Button type="submit" variation={ButtonVariation.PRIMARY} text={getString('save')} />
                   </Layout.Horizontal>
                 </Layout.Vertical>
               </Form>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

- Show an error popup when a user enters an existing environment_id.
![image](https://github.com/litmuschaos/litmus/assets/53862866/c5f9b8c5-e420-4951-a442-a12485016b6a)

- Show an error popup when a user enters an incorrect password in the UpdatePassword.
![image](https://github.com/litmuschaos/litmus/assets/53862866/fc3f6cfd-61fe-487d-a46f-8cd34fecc260)

Issue No. #4143 
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
