### PR TITLE
Update Dockerfile of litmus-portal frontend for OpenShift 

### DIFF
--- a/chaoscenter/web/Dockerfile
+++ b/chaoscenter/web/Dockerfile
@@ -8,9 +8,11 @@ COPY ./entrypoint.sh /opt
 
 WORKDIR /opt/chaos
 
-RUN chown 65534:65534 -R /opt/chaos
-RUN chown 65534:65534 -R /var/log/nginx
-RUN chown 65534:65534 -R /etc/nginx
+# Update the permission of group to 0(root) to make it Openshift friendly
+# as Openshift runs container with an arbitrary uid that in the root group
+RUN chown 65534:0 -R /opt/chaos && \
+    chown 65534:0 -R /var/log/nginx && \
+    chown 65534:0 -R /etc/nginx
 
 USER 65534
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Update litmus-portal frontend Dockerfile to be more Openshift friendly.
- Update the chown command so that the GID of the folders/files is at 0 since Openshift will by default use a random UID but is part of the root group.
- Combine the 3 RUN for chown command into a single one to reduce number of layers

Link to the issues:
- https://github.com/litmuschaos/litmus/issues/3882
- https://github.com/litmuschaos/litmus-helm/issues/343

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [X] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the commit for DCO to be passed.
- [X] Lint and unit tests pass locally with my changes
- [NA] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added necessary documentation (if appropriate)

## Special notes for your reviewer:
I combined the 3 RUN line into a single one to reduce number of layers. If you don't like it I can reverse this change.