### PR TITLE
[ Fix ] : Gitops trigger in Save, Delete, and Update Experiment

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_fuzz_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_fuzz_test.go
@@ -131,7 +131,7 @@ func FuzzUpdateChaosExperiment(f *testing.F) {
 			ExperimentType: &model.AllExperimentType[0],
 		}, &experimentType, nil).Once()
 		mockServices.ChaosExperimentService.On("ProcessExperimentUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
+		mockServices.GitOpsService.On("UpsertExperimentToGit", ctx, mock.Anything, mock.Anything).Return(nil).Once()
 		store := store.NewStore()
 		res, err := mockServices.ChaosExperimentHandler.UpdateChaosExperiment(ctx, targetStruct.experiment, targetStruct.projectID, store)
 		if err != nil {

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_test.go
@@ -117,6 +117,7 @@ func TestChaosExperimentHandler_SaveChaosExperiment(t *testing.T) {
 				mockServices.ChaosExperimentService.On("ProcessExperiment", mock.Anything, request2, mock.Anything, mock.Anything).Return(request2, &experimentType, nil).Once()
 
 				mockServices.ChaosExperimentService.On("ProcessExperimentUpdate", request2, mock.Anything, mock.Anything, mock.Anything, false, mock.Anything, mock.Anything).Return(nil).Once()
+				mockServices.GitOpsService.On("UpsertExperimentToGit", ctx, mock.Anything, request2).Return(nil).Once()
 			},
 			wantErr: false,
 		},
@@ -195,6 +196,8 @@ func TestChaosExperimentHandler_SaveChaosExperiment(t *testing.T) {
 				mockServices.ChaosExperimentService.On("ProcessExperiment", mock.Anything, request2, mock.Anything, mock.Anything).Return(request2, &experimentType, nil).Once()
 
 				mockServices.ChaosExperimentService.On("ProcessExperimentUpdate", request2, mock.Anything, mock.Anything, mock.Anything, false, mock.Anything, mock.Anything).Return(nil).Once()
+
+				mockServices.GitOpsService.On("UpsertExperimentToGit", ctx, mock.Anything, request2).Return(nil).Once()
 			},
 		},
 	}
@@ -272,6 +275,7 @@ func TestChaosExperimentHandler_DeleteChaosExperiment(t *testing.T) {
 				mockServices.MongodbOperator.On("Get", mock.Anything, mongodb.ChaosExperimentRunsCollection, mock.Anything).Return(singleResult, nil).Once()
 
 				mockServices.ChaosExperimentRunService.On("ProcessExperimentRunDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+				mockServices.GitOpsService.On("DeleteExperimentFromGit", ctx, mock.Anything, mock.Anything).Return(nil).Once()
 			},
 			wantErr: false,
 		},
@@ -321,6 +325,7 @@ func TestChaosExperimentHandler_DeleteChaosExperiment(t *testing.T) {
 				mockServices.MongodbOperator.On("Get", mock.Anything, mongodb.ChaosExperimentCollection, mock.Anything).Return(singleResult, nil).Once()
 				mockServices.MongodbOperator.On("Get", mock.Anything, mongodb.ChaosExperimentRunsCollection, mock.Anything).Return(singleResult, nil).Once()
 				mockServices.ChaosExperimentRunService.On("ProcessExperimentRunDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("")).Once()
+				mockServices.GitOpsService.On("DeleteExperimentFromGit", ctx, mock.Anything, mock.Anything).Return(nil).Once()
 			},
 			wantErr: true,
 		},
@@ -374,6 +379,8 @@ func TestChaosExperimentHandler_UpdateChaosExperiment(t *testing.T) {
 				mockServices.MongodbOperator.On("CountDocuments", ctx, mongodb.ChaosExperimentCollection, mock.Anything, mock.Anything).Return(int64(0), nil).Once()
 				mockServices.ChaosExperimentService.On("ProcessExperiment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(request, &experimentType, nil).Once()
 				mockServices.ChaosExperimentService.On("ProcessExperimentUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+				mockServices.GitOpsService.On("UpsertExperimentToGit", ctx, mock.Anything, request).Return(nil).Once()
+
 			},
 			wantErr: false,
 		},
@@ -412,6 +419,8 @@ func TestChaosExperimentHandler_UpdateChaosExperiment(t *testing.T) {
 				mockServices.ChaosExperimentService.On("ProcessExperiment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(request, &experimentType, nil).Once()
 
 				mockServices.ChaosExperimentService.On("ProcessExperimentUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("experiment update failed")).Once()
+
+				mockServices.GitOpsService.On("UpsertExperimentToGit", ctx, mock.Anything, request).Return(nil).Once()
 			},
 			wantErr: true,
 		},

--- a/chaoscenter/graphql/server/pkg/gitops/model/mocks/service.go
+++ b/chaoscenter/graphql/server/pkg/gitops/model/mocks/service.go
@@ -46,7 +46,7 @@ func (g *GitOpsService) GetGitOpsDetails(ctx context.Context, projectID string) 
 
 // UpsertWorkflowToGit provides a mock function with given fields: ctx, experiment
 func (g *GitOpsService) UpsertExperimentToGit(ctx context.Context, projectID string, experiment *model.ChaosExperimentRequest) error {
-	args := g.Called(ctx, experiment)
+	args := g.Called(ctx, projectID, experiment)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes
Fixes #4434. This PR adds the checks for gitops update in following handlers
1. SaveChaosExperiment
2. CreateChaosExperiment
3. UpdateChaosExperiment

I think we need to discuss this a little bit more: whether we want the gitops to be triggered while just saving the chaosExperiment or also when a new experiment is scheduled to be running
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
