### PR TITLE
fix typos

### DIFF
--- a/chaoscenter/authentication/api/docs/swagger.json
+++ b/chaoscenter/authentication/api/docs/swagger.json
@@ -151,7 +151,7 @@
         },
         "/decline_invitation": {
             "post": {
-                "description": "Deecline invitation to a project.",
+                "description": "Decline invitation to a project.",
                 "consumes": [
                     "application/json"
                 ],

--- a/chaoscenter/authentication/api/docs/swagger.yaml
+++ b/chaoscenter/authentication/api/docs/swagger.yaml
@@ -247,7 +247,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Deecline invitation to a project.
+      description: Decline invitation to a project.
       produces:
       - application/json
       responses:

--- a/chaoscenter/authentication/api/handlers/rest/project_handler.go
+++ b/chaoscenter/authentication/api/handlers/rest/project_handler.go
@@ -500,7 +500,7 @@ func AcceptInvitation(service services.ApplicationService) gin.HandlerFunc {
 // DeclineInvitation 		godoc
 //
 //	@Summary		Decline invitation.
-//	@Description	Deecline invitation to a project.
+//	@Description	Decline invitation to a project.
 //	@Tags			ProjectRouter
 //	@Accept			json
 //	@Produce		json


### PR DESCRIPTION
I found a typo on the "/decline_invitation" route description in few places.

- Rather than "Decline" what was present was "Deecline".
