### PR TITLE
fix: resolve templates in ChaosHub not running correctly

### DIFF
--- a/chaoscenter/graphql/server/manifests/cluster/3a_agents_rbac.yaml
+++ b/chaoscenter/graphql/server/manifests/cluster/3a_agents_rbac.yaml
@@ -141,7 +141,7 @@ rules:
 
   - apiGroups: ['']
     resources: ['namespaces']
-    verbs: ['get', 'watch', 'patch', 'list']
+    verbs: ['get', 'watch', 'patch', 'list', 'create']
 
   # for tracking & getting logs of the pods created by workflow controller to implement individual steps in the workflow
   - apiGroups: ['']

--- a/chaoscenter/graphql/server/utils/misc.go
+++ b/chaoscenter/graphql/server/utils/misc.go
@@ -11,10 +11,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
-
 	"github.com/google/uuid"
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 )
 
 const GRPCErrorPrefix string = "rpc error: code = Unknown desc ="
@@ -86,8 +84,8 @@ func Split(str, before, after string) string {
 	return b[0][0 : len(b[0])-len(after)]
 }
 
-// GenerateUuid : Generate a unique string id based on google/uuid
-func GenerateUuid() string {
+// GenerateUUID : Generate a unique string id based on google/uuid
+func GenerateUUID() string {
 	id := uuid.New()
 	return base64.RawURLEncoding.EncodeToString(id[:])
 }

--- a/chaoscenter/subscriber/go.sum
+++ b/chaoscenter/subscriber/go.sum
@@ -238,6 +238,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=

--- a/chaoscenter/web/src/views/ChaosStudio/ChaosStudio.tsx
+++ b/chaoscenter/web/src/views/ChaosStudio/ChaosStudio.tsx
@@ -156,16 +156,16 @@ export default function ChaosStudioView({
        * If probeRef is not present in the manifest then return the fault name
        * where the ref is missing otherwise return undefined
        */
-      const probeWithoutAnnotation = await (
-        experimentHandler as KubernetesYamlService
-      )?.checkProbesInExperimentManifest(experiment?.manifest as KubernetesExperimentManifest);
+      const probeWithoutAnnotation = (experimentHandler as KubernetesYamlService)?.checkProbesInExperimentManifest(
+        experiment?.manifest as KubernetesExperimentManifest
+      );
 
       /**
        * Checks if probe metadata is already present in the manifest
        *
        * Returns true if probe metadata is present
        */
-      const doesProbeExists = await (experimentHandler as KubernetesYamlService)?.doesProbeMetadataExists(
+      const doesProbeExists = (experimentHandler as KubernetesYamlService)?.doesProbeMetadataExists(
         experiment?.manifest as KubernetesExperimentManifest
       );
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

ChaosHub's templates are not executed because of `internal server error`.
It's because our code references null ptr when we generate probes automatically.
this pr resolves this issue

![Screenshot 2024-03-31 at 8 26 48 PM](https://github.com/litmuschaos/litmus/assets/53862866/6c540d01-212e-4961-9678-778d3c7edc52)

FYI: [discussion in slack](https://kubernetes.slack.com/archives/CNXNB0ZTN/p1711427213471879)

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
