### PR TITLE
Hide 'Cluster-Wide' Access in namespace scoped ChaosCentre

### DIFF
--- a/chaoscenter/web/src/components/KubernetesChaosInfrastructureDeploymentCards/DeploymentScopeCards.tsx
+++ b/chaoscenter/web/src/components/KubernetesChaosInfrastructureDeploymentCards/DeploymentScopeCards.tsx
@@ -52,7 +52,11 @@ export function DeploymentScope({
   return (
     <FormikCollapsableSelect<DeploymentScopeItem>
       name="deploymentScope"
-      items={isInfraPresent ? deploymentScopeDataNs : deploymentScopeData}
+      items={
+        isInfraPresent || deploymentScope === DeploymentScopeOptions.NAMESPACE
+          ? deploymentScopeDataNs
+          : deploymentScopeData
+      }
       selected={deploymentScopeData[deploymentScopeData.findIndex(card => card.type === deploymentScope)]}
       onChange={onChange}
       type={CollapsableSelectType.CardView}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes
Fixes #4612 
When the ChaosCentre is namespace scoped 'Cluster-Wide access' is hidden.
![image](https://github.com/litmuschaos/litmus/assets/69910615/3d4793c6-2aad-4369-b7ed-efa76f6d965e)


## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
