### PR TITLE
Force subscriber disconnection when already connected

### DIFF
--- a/chaoscenter/subscriber/pkg/requests/webhook.go
+++ b/chaoscenter/subscriber/pkg/requests/webhook.go
@@ -69,7 +69,7 @@ func (req *subscriberRequests) AgentConnect(infraData map[string]string) {
 	for {
 		_, message, err := c.ReadMessage()
 		if err != nil {
-			logrus.WithError(err).Fatal("Failed to read message")
+			logrus.WithError(err).Panic("Failed to read message")
 		}
 
 		var r types.RawData
@@ -87,6 +87,7 @@ func (req *subscriberRequests) AgentConnect(infraData map[string]string) {
 		}
 		if r.Payload.Errors != nil {
 			logrus.Error("Error response from the server : ", string(message))
+      panicWhen("ALREADY CONNECTED", message)
 			continue
 		}
 
@@ -94,6 +95,12 @@ func (req *subscriberRequests) AgentConnect(infraData map[string]string) {
 		if err != nil {
 			logrus.WithError(err).Error("Error on processing request")
 		}
+	}
+}
+
+func panicWhen(errorMessage string, message []byte) {
+	if strings.Contains(string(message), errorMessage) {
+		logrus.Panic("Server error: ", errorMessage)
 	}
 }
 

--- a/chaoscenter/subscriber/pkg/requests/webhook.go
+++ b/chaoscenter/subscriber/pkg/requests/webhook.go
@@ -87,7 +87,7 @@ func (req *subscriberRequests) AgentConnect(infraData map[string]string) {
 		}
 		if r.Payload.Errors != nil {
 			logrus.Error("Error response from the server : ", string(message))
-      panicWhen("ALREADY CONNECTED", message)
+			panicWhen("ALREADY CONNECTED", message)
 			continue
 		}
 


### PR DESCRIPTION


## Proposed changes

On a scenario with multiple infrastructures connecting to a "main" chaoscenter/portal, we can have websocket disconnection cases. In those scenarios the subscribers exists with -1 code and pod is restarted, but fails to restablish connection because server responds ALREADY_CONNECTED.

We are proposing to changes

### Subscriber
1) should disconnect with panic, so ws connection (which is defered) can be called. 
2) should exit when receives a ALREADY CONNECTED message from the server, since it should retry

## Portal/chaosCenter
2) Should close previous channel and return ALREADY connected error. That will trigger ctc.Done() and cleanup in-memory map with connected infras, so a subscriber restart will be able to connect again.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
