### PR TITLE
Update install-chaos-faults duration

### DIFF
--- a/chaoscenter/web/src/views/ExperimentBuilderTemplateSelection/blankCanvasTemplate.ts
+++ b/chaoscenter/web/src/views/ExperimentBuilderTemplateSelection/blankCanvasTemplate.ts
@@ -64,7 +64,11 @@ function kubernetesBlankCanvasTemplate(
             name: '',
             image: `${imageRegistry.repo}/k8s:2.11.0`,
             command: ['sh', '-c'],
-            args: ['kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && sleep 30']
+            args: [
+                'kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && ' +
+                'faultCount=$(ls /tmp/ | grep -E "\.ya?ml$" | wc -l) && ' +
+                'until [[ $(kubectl get -f /tmp/ --no-headers | wc -l) -eq $faultCount ]]; do sleep 1; echo "Waiting for ChaosExperiment CR Ready..." ; done; echo "ChaosExperiment CR Ready"'
+            ]
           }
         },
         {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

![스크린샷 2024-07-29 오전 1 00 01](https://github.com/user-attachments/assets/b063682c-15a7-4f49-a96c-797aad695dd2)

Previously, even though all ChaosExperiment CRs were created, the delay time of install-chaos-faults was long because it slept for an additional 30 seconds.

To solve this problem, I counted the number of yaml files under the /tmp directory and assigned them to a variable. Next, I added an action to repeatedly check whether the number of CRs searched through `kubectl get -f /tmp/ --no-headers | wc -l` is same as the variable value.

![스크린샷 2024-07-29 오전 1 02 39](https://github.com/user-attachments/assets/d78fb1a9-6ebf-46d8-ac10-84789a8859df)

This operation can shorten the install-chaos-fault execution time.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
