### PR TITLE
[Security] added 'eq' operation when querying entitiy

### DIFF
--- a/chaoscenter/authentication/pkg/project/repository.go
+++ b/chaoscenter/authentication/pkg/project/repository.go
@@ -210,7 +210,7 @@ func (r repository) CreateProject(project *entities.Project) error {
 
 // AddMember adds a new member into the project whose projectID is passed
 func (r repository) AddMember(projectID string, member *entities.Member) error {
-	query := bson.D{{"_id", projectID}}
+	query := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 	update := bson.D{{"$push", bson.D{
 		{"members", member},
 	}}}
@@ -228,7 +228,7 @@ func (r repository) AddMember(projectID string, member *entities.Member) error {
 
 // RemoveInvitation removes member or cancels the invitation
 func (r repository) RemoveInvitation(projectID string, userID string, invitation entities.Invitation) error {
-	query := bson.D{{"_id", projectID}}
+	query := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 	update := bson.D{
 		{"$pull", bson.D{
 			{"members", bson.D{
@@ -301,7 +301,7 @@ func (r repository) UpdateInvite(projectID string, userID string, invitation ent
 
 // UpdateProjectName :Updates Name of the project
 func (r repository) UpdateProjectName(projectID string, projectName string) error {
-	query := bson.D{{"_id", projectID}}
+	query := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 	update := bson.D{{"$set", bson.M{"name": projectName}}}
 
 	_, err := r.Collection.UpdateOne(context.TODO(), query, update)
@@ -319,7 +319,7 @@ func (r repository) UpdateMemberRole(projectID string, userID string, role *enti
 			bson.D{{"elem.user_id", userID}},
 		},
 	})
-	query := bson.D{{"_id", projectID}}
+	query := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 	update := bson.D{{"$set", bson.M{"members.$[elem].role": role}}}
 
 	_, err := r.Collection.UpdateOne(context.TODO(), query, update, opts)
@@ -436,7 +436,7 @@ func (r repository) GetOwnerProjects(ctx context.Context, userID string) ([]*ent
 
 // GetProjectOwners takes projectID and returns the owners
 func (r repository) GetProjectOwners(projectID string) ([]*entities.Member, error) {
-	filter := bson.D{{"_id", projectID}}
+	filter := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 
 	var project struct {
 		Members []*entities.Member `bson:"members"`

--- a/chaoscenter/authentication/pkg/project/repository.go
+++ b/chaoscenter/authentication/pkg/project/repository.go
@@ -634,7 +634,7 @@ func NewRepo(collection *mongo.Collection) Repository {
 
 // DeleteProject deletes the project with given projectID
 func (r repository) DeleteProject(projectID string) error {
-	query := bson.D{{"_id", projectID}}
+	query := bson.D{{"_id", bson.D{{"$eq", projectID}}}}
 
 	result, err := r.Collection.DeleteOne(context.TODO(), query)
 	if err != nil {

--- a/chaoscenter/authentication/pkg/session/revoked_token_repository.go
+++ b/chaoscenter/authentication/pkg/session/revoked_token_repository.go
@@ -29,7 +29,7 @@ func (r repository) RevokeToken(token *entities.RevokedToken) error {
 func (r repository) IsTokenRevoked(encodedToken string) bool {
 	var result = entities.RevokedToken{}
 	err := r.Collection.FindOne(context.TODO(), bson.M{
-		"token": encodedToken,
+		"token": bson.M{"$eq": encodedToken},
 	}).Decode(&result)
 
 	return err == nil

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
@@ -306,8 +306,8 @@ func (c *ChaosExperimentHandler) GetExperiment(ctx context.Context, projectID st
 	pipeline = mongo.Pipeline{
 		bson.D{
 			{"$match", bson.D{
-				{"experiment_id", experimentID},
-				{"project_id", projectID},
+				{"experiment_id", bson.D{{"$eq", experimentID}}},
+				{"project_id", bson.D{{"$eq", projectID}}},
 				{"is_removed", false},
 			}},
 		},
@@ -512,7 +512,7 @@ func (c *ChaosExperimentHandler) ListExperiment(projectID string, request model.
 	// Match with identifiers
 	matchIdStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 		}},
 	}
 
@@ -1051,7 +1051,7 @@ func (c *ChaosExperimentHandler) GetExperimentStats(ctx context.Context, project
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}
@@ -1345,7 +1345,7 @@ func (c *ChaosExperimentHandler) GetProbesInExperimentRun(ctx context.Context, p
 // validateDuplicateExperimentName validates if the name of experiment is duplicate
 func (c *ChaosExperimentHandler) validateDuplicateExperimentName(ctx context.Context, projectID, name string) error {
 	filterQuery := bson.D{
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"name", name},
 		{"is_removed", false},
 	}

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/handler/handler.go
@@ -89,7 +89,7 @@ func (c *ChaosExperimentRunHandler) GetExperimentRun(ctx context.Context, projec
 			{
 				"$match", bson.D{
 					{"experiment_run_id", experimentRunID},
-					{"project_id", projectID},
+					{"project_id", bson.D{{"$eq", projectID}}},
 					{"is_removed", false},
 				},
 			},
@@ -101,8 +101,8 @@ func (c *ChaosExperimentRunHandler) GetExperimentRun(ctx context.Context, projec
 		matchIdentifiersStage := bson.D{
 			{
 				"$match", bson.D{
-					{"notify_id", notifyID},
-					{"project_id", projectID},
+					{"notify_id", bson.D{{"$eq", notifyID}}},
+					{"project_id", bson.D{{"$eq", projectID}}},
 					{"is_removed", false},
 				},
 			},
@@ -277,7 +277,7 @@ func (c *ChaosExperimentRunHandler) ListExperimentRun(projectID string, request 
 			"$match", bson.D{{
 				"$and", bson.A{
 					bson.D{
-						{"project_id", projectID},
+						{"project_id", bson.D{{"$eq", projectID}}},
 					},
 				},
 			}},
@@ -1020,7 +1020,7 @@ func (c *ChaosExperimentRunHandler) GetExperimentRunStats(ctx context.Context, p
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 		}},
 	}
 

--- a/chaoscenter/graphql/server/pkg/chaos_infrastructure/service.go
+++ b/chaoscenter/graphql/server/pkg/chaos_infrastructure/service.go
@@ -74,7 +74,7 @@ func (in *infraService) RegisterInfra(c context.Context, projectID string, input
 	infraDetails, err := in.infraOperator.GetInfras(c, bson.D{
 		{"infra_name", input.Name},
 		{"is_removed", false},
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 	})
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (in *infraService) RegisterInfra(c context.Context, projectID string, input
 	}
 
 	envQuery := bson.D{
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"environment_id", input.EnvironmentID},
 	}
 	update := bson.D{
@@ -227,7 +227,7 @@ func (in *infraService) DeleteInfra(ctx context.Context, projectID string, infra
 
 	query := bson.D{
 		{"infra_id", infraId},
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"is_removed", false},
 	}
 
@@ -251,7 +251,7 @@ func (in *infraService) DeleteInfra(ctx context.Context, projectID string, infra
 		return "", err
 	}
 	envQuery := bson.D{
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"environment_id", infra.EnvironmentID},
 	}
 	updateQuery := bson.D{
@@ -315,8 +315,8 @@ func (in *infraService) GetInfra(ctx context.Context, projectID string, infraID 
 	// Match with identifiers and infra ID
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"infra_id", infraID},
-			{"project_id", projectID},
+			{"infra_id", bson.D{{"$eq", infraID}}},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}
@@ -471,7 +471,7 @@ func (in *infraService) ListInfras(projectID string, request *model.ListInfraReq
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}
@@ -808,7 +808,7 @@ func (in *infraService) GetInfraStats(ctx context.Context, projectID string) (*m
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}

--- a/chaoscenter/graphql/server/pkg/chaoshub/service.go
+++ b/chaoscenter/graphql/server/pkg/chaoshub/service.go
@@ -524,7 +524,7 @@ func (c *chaosHubService) ListChaosHubs(ctx context.Context, projectID string, r
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}
@@ -913,7 +913,7 @@ func (c *chaosHubService) GetChaosHubStats(ctx context.Context, projectID string
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}

--- a/chaoscenter/graphql/server/pkg/environment/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/environment/handler/handler.go
@@ -88,7 +88,7 @@ func (e *EnvironmentService) UpdateEnvironment(ctx context.Context, projectID st
 
 	query := bson.D{
 		{"environment_id", request.EnvironmentID},
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"is_removed", false},
 	}
 
@@ -148,7 +148,7 @@ func (e *EnvironmentService) DeleteEnvironment(ctx context.Context, projectID st
 
 	query := bson.D{
 		{"environment_id", environmentID},
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 		{"is_removed", false},
 	}
 
@@ -208,7 +208,7 @@ func (e *EnvironmentService) ListEnvironments(projectID string, request *model.L
 	// Match with identifiers
 	matchIdentifierStage := bson.D{
 		{"$match", bson.D{
-			{"project_id", projectID},
+			{"project_id", bson.D{{"$eq", projectID}}},
 			{"is_removed", false},
 		}},
 	}

--- a/chaoscenter/graphql/server/pkg/probe/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/probe/handler/handler.go
@@ -327,7 +327,7 @@ func (p *probe) ListProbes(ctx context.Context, probeNames []string, infrastruct
 	matchIdentifierStage := bson.D{
 		{
 			Key: "$match", Value: bson.D{
-				{"project_id", projectID},
+				{"project_id", bson.D{{"$eq", projectID}}},
 				{"is_removed", false},
 			},
 		},
@@ -386,7 +386,7 @@ func GetProbeExecutionHistoryInExperimentRuns(projectID string, probeName string
 	matchIdentifierStage := bson.D{
 		{
 			"$match", bson.D{
-				{"project_id", projectID},
+				{"project_id", bson.D{{"$eq", projectID}}},
 				{"probes.probe_names", probeName},
 			},
 		},
@@ -520,7 +520,7 @@ func (p *probe) GetProbeReference(ctx context.Context, probeName, projectID stri
 				{
 					"$and", bson.A{
 						bson.D{
-							{"project_id", projectID},
+							{"project_id", bson.D{{"$eq", projectID}}},
 							{"name", probeName},
 							{"is_removed", false},
 						},
@@ -698,7 +698,7 @@ func (p *probe) ValidateUniqueProbe(ctx context.Context, probeName, projectID st
 
 	query := bson.D{
 		{"name", probeName},
-		{"project_id", projectID},
+		{"project_id", bson.D{{"$eq", projectID}}},
 	}
 
 	isUnique, err := dbSchemaProbe.IsProbeUnique(ctx, query)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

This is a fix for the security vulnerability `Database query built from user-controlled sources` raised by CodeQL.  

The issue arises when passing an entity identity without using the `$eq` operation

References recommend using `$eq` to enhance security.


This code is an example of the modified code.

``` go
//AS-IS
query := bson.D{{"_id", projectID}}

//TO-BE
query := bson.D{{"_id", bson.D{{"$eq", projectID}}}} // uses the $eq operation
```

### References
- [Database query built from user-controlled sources](https://codeql.github.com/codeql-query-help/javascript/js-sql-injection/)
- [$eq - MongoDB Manual](https://www.mongodb.com/docs/manual/reference/operator/query/eq/)

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
