### PR TITLE
Allow older Infras to connect with Chaos Centre

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaos_infrastructure/service.go
+++ b/chaoscenter/graphql/server/pkg/chaos_infrastructure/service.go
@@ -1071,8 +1071,8 @@ func (in *infraService) VerifyInfra(identity model.InfraIdentity) (*dbChaosInfra
 	} else {
 		splitCPVersion := strings.Split(currentVersion, ".")
 		splitSubVersion := strings.Split(identity.Version, ".")
-		if len(splitSubVersion) != 3 || splitSubVersion[0] != splitCPVersion[0] || splitSubVersion[1] != splitCPVersion[1] {
-			return nil, fmt.Errorf("ERROR: infra VERSION MISMATCH (need %v.%v.x got %v)", splitCPVersion[0], splitCPVersion[1], identity.Version)
+		if len(splitSubVersion) != 3 || splitSubVersion[0] != splitCPVersion[0] {
+			return nil, fmt.Errorf("ERROR: infra VERSION MISMATCH (need %v.x.x got %v)", splitCPVersion[0], identity.Version)
 		}
 	}
 	infra, err := in.infraOperator.GetInfra(identity.InfraID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes
Fixes #4584 
Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue
This PR allows connections from older infras to connect with chaos centre
Infras with minor versions lower than chaos centre can now connect 
i.e 
```3.5.0 can connect with 3.7.0```
but 
```3.5.0 cannot connect with 4.x.x```
## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
