### PR TITLE
Add operator interface for Probe pkg

### DIFF
--- a/chaoscenter/graphql/server/graph/resolver.go
+++ b/chaoscenter/graphql/server/graph/resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/environments"
 	gitops2 "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/gitops"
 	image_registry2 "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/image_registry"
+	dbSchemaProbe "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/probe"
 	envHandler "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/environment/handler"
 	gitops3 "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/gitops"
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/image_registry"
@@ -55,9 +56,10 @@ func NewConfig(mongodbOperator mongodb.MongoOperator) generated.Config {
 	gitopsOperator := gitops2.NewGitOpsOperator(mongodbOperator)
 	imageRegistryOperator := image_registry2.NewImageRegistryOperator(mongodbOperator)
 	EnvironmentOperator := environments.NewEnvironmentOperator(mongodbOperator)
+	probeOperator := dbSchemaProbe.NewChaosProbeOperator(mongodbOperator)
 
 	//service
-	probeService := probe.NewProbeService()
+	probeService := probe.NewProbeService(probeOperator)
 	chaosHubService := chaoshub.NewService(chaosHubOperator)
 	chaosInfrastructureService := chaos_infrastructure.NewChaosInfrastructureService(chaosInfraOperator, EnvironmentOperator)
 	chaosExperimentService := chaos_experiment2.NewChaosExperimentService(chaosExperimentOperator, chaosInfraOperator, chaosExperimentRunOperator, probeService)
@@ -67,8 +69,8 @@ func NewConfig(mongodbOperator mongodb.MongoOperator) generated.Config {
 	environmentService := envHandler.NewEnvironmentService(EnvironmentOperator)
 
 	//handler
-	chaosExperimentHandler := handler.NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, chaosInfrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, mongodbOperator)
-	choasExperimentRunHandler := runHandler.NewChaosExperimentRunHandler(chaosExperimentRunService, chaosInfrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, mongodbOperator)
+	chaosExperimentHandler := handler.NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, chaosInfrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, probeOperator, mongodbOperator)
+	choasExperimentRunHandler := runHandler.NewChaosExperimentRunHandler(chaosExperimentRunService, chaosInfrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, probeOperator, mongodbOperator)
 
 	config := generated.Config{
 		Resolvers: &Resolver{

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/fuzz_tests/handler_fuzz_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/fuzz_tests/handler_fuzz_test.go
@@ -2,6 +2,7 @@ package fuzz_tests
 
 import (
 	"context"
+	dbSchemaProbe "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/probe"
 	"testing"
 
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/chaos_experiment/handler"
@@ -45,8 +46,9 @@ func NewMockServices() *MockServices {
 		chaosExperimentOperator    = dbChaosExperiment.NewChaosExperimentOperator(mongodbMockOperator)
 		chaosExperimentRunOperator = dbChaosExperimentRun.NewChaosExperimentRunOperator(mongodbMockOperator)
 		chaosExperimentService     = new(chaosExperimentMocks.ChaosExperimentService)
+		probeOperator              = dbSchemaProbe.NewChaosProbeOperator(mongodbMockOperator)
 	)
-	var chaosExperimentHandler = handler.NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, mongodbMockOperator)
+	var chaosExperimentHandler = handler.NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, probeOperator, mongodbMockOperator)
 	return &MockServices{
 		ChaosExperimentService:     chaosExperimentService,
 		ChaosExperimentRunService:  chaosExperimentRunService,

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	dbSchemaProbe "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/probe"
 	"reflect"
 	"testing"
 
@@ -46,8 +47,9 @@ func NewMockServices() *MockServices {
 		chaosExperimentOperator    = dbChaosExperiment.NewChaosExperimentOperator(mongodbMockOperator)
 		chaosExperimentRunOperator = dbChaosExperimentRun.NewChaosExperimentRunOperator(mongodbMockOperator)
 		chaosExperimentService     = new(chaosExperimentMocks.ChaosExperimentService)
+		probeOperator              = dbSchemaProbe.NewChaosProbeOperator(mongodbMockOperator)
 	)
-	var chaosExperimentHandler = NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, mongodbMockOperator)
+	var chaosExperimentHandler = NewChaosExperimentHandler(chaosExperimentService, chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, probeOperator, mongodbMockOperator)
 	return &MockServices{
 		ChaosExperimentService:     chaosExperimentService,
 		ChaosExperimentRunService:  chaosExperimentRunService,

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/ops/service_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/ops/service_test.go
@@ -3,6 +3,7 @@ package ops
 import (
 	"context"
 	"errors"
+	dbSchemaProbe "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/probe"
 	"io"
 	"log"
 	"math/rand"
@@ -28,10 +29,11 @@ import (
 
 var (
 	mongodbMockOperator        = new(dbMocks.MongoOperator)
+	probeOperator              = dbSchemaProbe.NewChaosProbeOperator(mongodbMockOperator)
 	infraOperator              = dbChaosInfra.NewInfrastructureOperator(mongodbMockOperator)
 	chaosExperimentOperator    = dbChaosExperiment.NewChaosExperimentOperator(mongodbMockOperator)
 	chaosExperimentRunOperator = dbChaosExperimentRun.NewChaosExperimentRunOperator(mongodbMockOperator)
-	probeService               = probe.NewProbeService()
+	probeService               = probe.NewProbeService(probeOperator)
 )
 
 var chaosExperimentRunTestService = NewChaosExperimentService(chaosExperimentOperator, infraOperator, chaosExperimentRunOperator, probeService)

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/handler/handler_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	dbSchemaProbe "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/probe"
 	"io"
 	"log"
 	"os"
@@ -36,11 +37,12 @@ var (
 	infrastructureService      = new(chaosInfraMocks.InfraService)
 	chaosExperimentRunService  = new(choasExperimentRunMocks.ChaosExperimentRunService)
 	gitOpsService              = new(dbGitOpsMocks.GitOpsService)
+	probeOperator              = dbSchemaProbe.NewChaosProbeOperator(mongodbMockOperator)
 	chaosExperimentOperator    = dbChaosExperiment.NewChaosExperimentOperator(mongodbMockOperator)
 	chaosExperimentRunOperator = dbChaosExperimentRun.NewChaosExperimentRunOperator(mongodbMockOperator)
 )
 
-var chaosExperimentRunHandler = NewChaosExperimentRunHandler(chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, mongodbMockOperator)
+var chaosExperimentRunHandler = NewChaosExperimentRunHandler(chaosExperimentRunService, infrastructureService, gitOpsService, chaosExperimentOperator, chaosExperimentRunOperator, probeOperator, mongodbMockOperator)
 
 // TestMain is the entry point for testing
 func TestMain(m *testing.M) {
@@ -56,6 +58,7 @@ func TestNewChaosExperimentRunHandler(t *testing.T) {
 		gitOpsService              gitops.Service
 		chaosExperimentOperator    *dbChaosExperiment.Operator
 		chaosExperimentRunOperator *dbChaosExperimentRun.Operator
+		probeOperator              *dbSchemaProbe.Operator
 		mongodbOperator            mongodb.MongoOperator
 	}
 	tests := []struct {
@@ -71,6 +74,7 @@ func TestNewChaosExperimentRunHandler(t *testing.T) {
 				gitOpsService:              gitOpsService,
 				chaosExperimentOperator:    chaosExperimentOperator,
 				chaosExperimentRunOperator: chaosExperimentRunOperator,
+				probeOperator:              probeOperator,
 				mongodbOperator:            mongodbMockOperator,
 			},
 			want: &ChaosExperimentRunHandler{
@@ -79,13 +83,14 @@ func TestNewChaosExperimentRunHandler(t *testing.T) {
 				gitOpsService:              gitOpsService,
 				chaosExperimentOperator:    chaosExperimentOperator,
 				chaosExperimentRunOperator: chaosExperimentRunOperator,
+				probeOperator:              probeOperator,
 				mongodbOperator:            mongodbMockOperator,
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := NewChaosExperimentRunHandler(tc.args.chaosExperimentRunService, tc.args.infrastructureService, tc.args.gitOpsService, tc.args.chaosExperimentOperator, tc.args.chaosExperimentRunOperator, tc.args.mongodbOperator); !reflect.DeepEqual(got, tc.want) {
+			if got := NewChaosExperimentRunHandler(tc.args.chaosExperimentRunService, tc.args.infrastructureService, tc.args.gitOpsService, tc.args.chaosExperimentOperator, tc.args.chaosExperimentRunOperator, tc.args.probeOperator, tc.args.mongodbOperator); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("NewChaosExperimentRunHandler() = %v, want %v", got, tc.want)
 			}
 		})

--- a/chaoscenter/graphql/server/pkg/database/mongodb/probe/operations.go
+++ b/chaoscenter/graphql/server/pkg/database/mongodb/probe/operations.go
@@ -10,10 +10,22 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// Operator is the model for probe collection
+type Operator struct {
+	operator mongodb.MongoOperator
+}
+
+// NewChaosProbeOperator returns a new instance of Operator
+func NewChaosProbeOperator(mongodbOperator mongodb.MongoOperator) *Operator {
+	return &Operator{
+		operator: mongodbOperator,
+	}
+}
+
 // CreateProbe creates a probe of a specific type (HTTP, PROM, K8s or CMD)
 // as a shared entity in the database
-func CreateProbe(ctx context.Context, probe Probe) error {
-	err := mongodb.Operator.Create(ctx, mongodb.ChaosProbeCollection, probe)
+func (p *Operator) CreateProbe(ctx context.Context, probe Probe) error {
+	err := p.operator.Create(ctx, mongodb.ChaosProbeCollection, probe)
 	if err != nil {
 		return err
 	}
@@ -21,8 +33,8 @@ func CreateProbe(ctx context.Context, probe Probe) error {
 }
 
 // GetAggregateProbes takes a mongo pipeline to retrieve the project details from the database
-func GetAggregateProbes(ctx context.Context, pipeline mongo.Pipeline) (*mongo.Cursor, error) {
-	results, err := mongodb.Operator.Aggregate(ctx, mongodb.ChaosProbeCollection, pipeline)
+func (p *Operator) GetAggregateProbes(ctx context.Context, pipeline mongo.Pipeline) (*mongo.Cursor, error) {
+	results, err := p.operator.Aggregate(ctx, mongodb.ChaosProbeCollection, pipeline)
 	if err != nil {
 		return nil, err
 	}
@@ -31,8 +43,8 @@ func GetAggregateProbes(ctx context.Context, pipeline mongo.Pipeline) (*mongo.Cu
 }
 
 // IsProbeUnique returns true if probe is unique
-func IsProbeUnique(ctx context.Context, query bson.D) (bool, error) {
-	count, err := mongodb.Operator.CountDocuments(ctx, mongodb.ChaosProbeCollection, query)
+func (p *Operator) IsProbeUnique(ctx context.Context, query bson.D) (bool, error) {
+	count, err := p.operator.CountDocuments(ctx, mongodb.ChaosProbeCollection, query)
 	if err != nil {
 		return false, err
 	}
@@ -44,8 +56,8 @@ func IsProbeUnique(ctx context.Context, query bson.D) (bool, error) {
 }
 
 // UpdateProbe updates details of a Probe
-func UpdateProbe(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo.UpdateResult, error) {
-	result, err := mongodb.Operator.Update(ctx, mongodb.ChaosProbeCollection, query, updateQuery)
+func (p *Operator) UpdateProbe(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo.UpdateResult, error) {
+	result, err := p.operator.Update(ctx, mongodb.ChaosProbeCollection, query, updateQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +68,8 @@ func UpdateProbe(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo.
 }
 
 // UpdateProbes updates details of Probe
-func UpdateProbes(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo.UpdateResult, error) {
-	result, err := mongodb.Operator.UpdateMany(ctx, mongodb.ChaosProbeCollection, query, updateQuery)
+func (p *Operator) UpdateProbes(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo.UpdateResult, error) {
+	result, err := p.operator.UpdateMany(ctx, mongodb.ChaosProbeCollection, query, updateQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +80,9 @@ func UpdateProbes(ctx context.Context, query bson.D, updateQuery bson.D) (*mongo
 }
 
 // GetProbeByName fetches the details of a single Probe with its Probe Name
-func GetProbeByName(ctx context.Context, probeName string, projectID string) (Probe, error) {
+func (p *Operator) GetProbeByName(ctx context.Context, probeName string, projectID string) (Probe, error) {
 	var probe Probe
-	result, err := mongodb.Operator.Get(ctx, mongodb.ChaosProbeCollection, bson.D{{"name", probeName}, {"project_id", projectID}, {"is_removed", false}})
+	result, err := p.operator.Get(ctx, mongodb.ChaosProbeCollection, bson.D{{"name", probeName}, {"project_id", projectID}, {"is_removed", false}})
 	err = result.Decode(&probe)
 	if err != nil {
 		return Probe{}, err

--- a/chaoscenter/graphql/server/pkg/probe/utils/utils.go
+++ b/chaoscenter/graphql/server/pkg/probe/utils/utils.go
@@ -697,7 +697,7 @@ func ParseProbesFromManifestForRuns(wfType *dbChaosExperiment.ChaosExperimentTyp
 }
 
 // GenerateExperimentManifestWithProbes - uses GenerateProbeManifest to get and store the respective probe attribute into Raw Data template for Non Cron Workflow
-func GenerateExperimentManifestWithProbes(manifest string, projectID string) (argoTypes.Workflow, error) {
+func GenerateExperimentManifestWithProbes(manifest string, projectID string, probeOperator *dbSchemaProbe.Operator) (argoTypes.Workflow, error) {
 	var (
 		backgroundContext = context.Background()
 		nonCronManifest   argoTypes.Workflow
@@ -750,7 +750,7 @@ func GenerateExperimentManifestWithProbes(manifest string, projectID string) (ar
 								return argoTypes.Workflow{}, fmt.Errorf("failed to unmarshal experiment annotation object, error: %s", err.Error())
 							}
 							for _, annotationKey := range manifestAnnotation {
-								probe, err := dbSchemaProbe.GetProbeByName(ctx, annotationKey.Name, projectID)
+								probe, err := probeOperator.GetProbeByName(ctx, annotationKey.Name, projectID)
 								if err != nil {
 									return argoTypes.Workflow{}, fmt.Errorf("failed to fetch probe details, error: %s", err.Error())
 								}
@@ -855,7 +855,7 @@ func GenerateExperimentManifestWithProbes(manifest string, projectID string) (ar
 }
 
 // GenerateCronExperimentManifestWithProbes - uses GenerateProbeManifest to get and store the respective probe attribute into Raw Data template
-func GenerateCronExperimentManifestWithProbes(manifest string, projectID string) (argoTypes.CronWorkflow, error) {
+func GenerateCronExperimentManifestWithProbes(manifest string, projectID string, probeOperator *dbSchemaProbe.Operator) (argoTypes.CronWorkflow, error) {
 	var (
 		backgroundContext = context.Background()
 		cronManifest      argoTypes.CronWorkflow
@@ -906,7 +906,7 @@ func GenerateCronExperimentManifestWithProbes(manifest string, projectID string)
 							return argoTypes.CronWorkflow{}, fmt.Errorf("failed to unmarshal experiment annotation object, error: %s", err.Error())
 						}
 						for _, annotationKey := range manifestAnnotation {
-							probe, err := dbSchemaProbe.GetProbeByName(ctx, annotationKey.Name, projectID)
+							probe, err := probeOperator.GetProbeByName(ctx, annotationKey.Name, projectID)
 							if err != nil {
 								return argoTypes.CronWorkflow{}, fmt.Errorf("failed to fetch probe details, error: %s", err.Error())
 							}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR adds operator interface to probe pkg

#4836, I tried to add fuzz test for probe handler.
However, the current architecture made it impossible to mock probe operations, so I added probe operator interface.

This picture is about probe pkg.

![image](https://github.com/user-attachments/assets/aa74d2dd-99e0-42c3-a019-231408e08173)

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:

I need feedback on the approach of passing `probeOperator` as a parameter to functions.

For example, the function `GenerateExperimentManifestWithProbes` in chaoscenter/graphql/server/pkg/probe/utils/utils.go directly accesses probe operation. I have added the `probeOperator` dependency to the handler that uses `GenerateExperimentManifestWithProbes` and updated the function calls to pass `probeOperator` as a parameter.
