### PR TITLE
when experiment run can not get argo pod logs, make pod log message intuitive

### DIFF
--- a/chaoscenter/graphql/definitions/shared/chaos_experiment.graphqls
+++ b/chaoscenter/graphql/definitions/shared/chaos_experiment.graphqls
@@ -326,6 +326,27 @@ type Weightages {
   weightage: Int!
 }
 
+
+input ExperimentRunPhaseRequest {
+  projectID: ID!
+  
+  """
+  ID of the infra infra in which the experiment is running
+  """
+  infraID: InfraIdentity!
+  
+  """
+  ID of the experiment run which is to be queried
+  """
+  experimentRunID: String!	
+  
+  """
+  notifyID is required to give an ack for non cron experiment execution
+  """
+  notifyID: String
+}
+
+
 """
 Defines the details of a experiment run
 """

--- a/chaoscenter/graphql/definitions/shared/chaos_experiment_run.graphqls
+++ b/chaoscenter/graphql/definitions/shared/chaos_experiment_run.graphqls
@@ -16,6 +16,7 @@ extend type Query {
   Query to get experiment run stats
   """
   getExperimentRunStats(projectID: ID!): GetExperimentRunStatsResponse!
+  getExperimentRunPhase(request: ExperimentRunPhaseRequest!): ExperimentRun!
 }
 
 extend type Mutation {

--- a/chaoscenter/graphql/definitions/shared/chaos_infrastructure.graphqls
+++ b/chaoscenter/graphql/definitions/shared/chaos_infrastructure.graphqls
@@ -288,6 +288,10 @@ input PodLogRequest {
   """
   infraID: ID!
   """
+
+  """
+  projectID: ID!
+  """
   ID of a experiment run
   """
   experimentRunID: ID!

--- a/chaoscenter/graphql/server/graph/chaos_experiment_run.resolvers.go
+++ b/chaoscenter/graphql/server/graph/chaos_experiment_run.resolvers.go
@@ -146,3 +146,20 @@ func (r *queryResolver) GetExperimentRunStats(ctx context.Context, projectID str
 	}
 	return uiResponse, err
 }
+
+// GetExperimentRunPhase is the resolver for the getExperimentRunPhase field.
+func (r *queryResolver) GetExperimentRunPhase(ctx context.Context, request model.ExperimentRunPhaseRequest) (*model.ExperimentRun, error) {
+	_, err := r.chaosInfrastructureService.VerifyInfra(*request.InfraID)
+
+	if err != nil {
+		logrus.Error("Validation failed : ", request.InfraID)
+		return nil, err
+	}
+
+	expRunResponse, err := r.chaosExperimentRunHandler.GetExperimentRun(ctx, request.ProjectID, &request.ExperimentRunID, request.NotifyID)
+	if err != nil {
+		logrus.Error("failed to get chaosExpeirmentRun: ", err)
+		return nil, err
+	}
+	return expRunResponse, err
+}

--- a/chaoscenter/graphql/server/graph/generated/generated.go
+++ b/chaoscenter/graphql/server/graph/generated/generated.go
@@ -608,6 +608,7 @@ type ComplexityRoot struct {
 		GetEnvironment            func(childComplexity int, projectID string, environmentID string) int
 		GetExperiment             func(childComplexity int, projectID string, experimentID string) int
 		GetExperimentRun          func(childComplexity int, projectID string, experimentRunID *string, notifyID *string) int
+		GetExperimentRunPhase     func(childComplexity int, request model.ExperimentRunPhaseRequest) int
 		GetExperimentRunStats     func(childComplexity int, projectID string) int
 		GetExperimentStats        func(childComplexity int, projectID string) int
 		GetGitOpsDetails          func(childComplexity int, projectID string) int
@@ -769,6 +770,7 @@ type QueryResolver interface {
 	GetExperimentRun(ctx context.Context, projectID string, experimentRunID *string, notifyID *string) (*model.ExperimentRun, error)
 	ListExperimentRun(ctx context.Context, projectID string, request model.ListExperimentRunRequest) (*model.ListExperimentRunResponse, error)
 	GetExperimentRunStats(ctx context.Context, projectID string) (*model.GetExperimentRunStatsResponse, error)
+	GetExperimentRunPhase(ctx context.Context, request model.ExperimentRunPhaseRequest) (*model.ExperimentRun, error)
 	GetInfra(ctx context.Context, projectID string, infraID string) (*model.Infra, error)
 	ListInfras(ctx context.Context, projectID string, request *model.ListInfraRequest) (*model.ListInfraResponse, error)
 	GetInfraDetails(ctx context.Context, infraID string, projectID string) (*model.Infra, error)
@@ -3731,6 +3733,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.GetExperimentRun(childComplexity, args["projectID"].(string), args["experimentRunID"].(*string), args["notifyID"].(*string)), true
 
+	case "Query.getExperimentRunPhase":
+		if e.complexity.Query.GetExperimentRunPhase == nil {
+			break
+		}
+
+		args, err := ec.field_Query_getExperimentRunPhase_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.GetExperimentRunPhase(childComplexity, args["request"].(model.ExperimentRunPhaseRequest)), true
+
 	case "Query.getExperimentRunStats":
 		if e.complexity.Query.GetExperimentRunStats == nil {
 			break
@@ -4423,6 +4437,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputExperimentFilterInput,
 		ec.unmarshalInputExperimentRequest,
 		ec.unmarshalInputExperimentRunFilterInput,
+		ec.unmarshalInputExperimentRunPhaseRequest,
 		ec.unmarshalInputExperimentRunRequest,
 		ec.unmarshalInputExperimentRunSortInput,
 		ec.unmarshalInputExperimentSortInput,
@@ -4904,6 +4919,27 @@ type Weightages {
   weightage: Int!
 }
 
+
+input ExperimentRunPhaseRequest {
+  projectID: ID!
+  
+  """
+  ID of the infra infra in which the experiment is running
+  """
+  infraID: InfraIdentity!
+  
+  """
+  ID of the experiment run which is to be queried
+  """
+  experimentRunID: String!	
+  
+  """
+  notifyID is required to give an ack for non cron experiment execution
+  """
+  notifyID: String
+}
+
+
 """
 Defines the details of a experiment run
 """
@@ -5376,6 +5412,7 @@ type Mutation {
   Query to get experiment run stats
   """
   getExperimentRunStats(projectID: ID!): GetExperimentRunStatsResponse!
+  getExperimentRunPhase(request: ExperimentRunPhaseRequest!): ExperimentRun!
 }
 
 extend type Mutation {
@@ -5687,6 +5724,10 @@ input PodLogRequest {
   ID of the cluster
   """
   infraID: ID!
+  """
+
+  """
+  projectID: ID!
   """
   ID of a experiment run
   """
@@ -9269,6 +9310,21 @@ func (ec *executionContext) field_Query_getEnvironment_args(ctx context.Context,
 		}
 	}
 	args["environmentID"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_getExperimentRunPhase_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.ExperimentRunPhaseRequest
+	if tmp, ok := rawArgs["request"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("request"))
+		arg0, err = ec.unmarshalNExperimentRunPhaseRequest2githubᚗcomᚋlitmuschaosᚋlitmusᚋchaoscenterᚋgraphqlᚋserverᚋgraphᚋmodelᚐExperimentRunPhaseRequest(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["request"] = arg0
 	return args, nil
 }
 
@@ -28843,6 +28899,111 @@ func (ec *executionContext) fieldContext_Query_getExperimentRunStats(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_getExperimentRunPhase(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_getExperimentRunPhase(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().GetExperimentRunPhase(rctx, fc.Args["request"].(model.ExperimentRunPhaseRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ExperimentRun)
+	fc.Result = res
+	return ec.marshalNExperimentRun2ᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋchaoscenterᚋgraphqlᚋserverᚋgraphᚋmodelᚐExperimentRun(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_getExperimentRunPhase(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "projectID":
+				return ec.fieldContext_ExperimentRun_projectID(ctx, field)
+			case "experimentRunID":
+				return ec.fieldContext_ExperimentRun_experimentRunID(ctx, field)
+			case "experimentType":
+				return ec.fieldContext_ExperimentRun_experimentType(ctx, field)
+			case "experimentID":
+				return ec.fieldContext_ExperimentRun_experimentID(ctx, field)
+			case "weightages":
+				return ec.fieldContext_ExperimentRun_weightages(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ExperimentRun_updatedAt(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ExperimentRun_createdAt(ctx, field)
+			case "infra":
+				return ec.fieldContext_ExperimentRun_infra(ctx, field)
+			case "experimentName":
+				return ec.fieldContext_ExperimentRun_experimentName(ctx, field)
+			case "experimentManifest":
+				return ec.fieldContext_ExperimentRun_experimentManifest(ctx, field)
+			case "phase":
+				return ec.fieldContext_ExperimentRun_phase(ctx, field)
+			case "resiliencyScore":
+				return ec.fieldContext_ExperimentRun_resiliencyScore(ctx, field)
+			case "faultsPassed":
+				return ec.fieldContext_ExperimentRun_faultsPassed(ctx, field)
+			case "faultsFailed":
+				return ec.fieldContext_ExperimentRun_faultsFailed(ctx, field)
+			case "faultsAwaited":
+				return ec.fieldContext_ExperimentRun_faultsAwaited(ctx, field)
+			case "faultsStopped":
+				return ec.fieldContext_ExperimentRun_faultsStopped(ctx, field)
+			case "faultsNa":
+				return ec.fieldContext_ExperimentRun_faultsNa(ctx, field)
+			case "totalFaults":
+				return ec.fieldContext_ExperimentRun_totalFaults(ctx, field)
+			case "executionData":
+				return ec.fieldContext_ExperimentRun_executionData(ctx, field)
+			case "isRemoved":
+				return ec.fieldContext_ExperimentRun_isRemoved(ctx, field)
+			case "updatedBy":
+				return ec.fieldContext_ExperimentRun_updatedBy(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_ExperimentRun_createdBy(ctx, field)
+			case "notifyID":
+				return ec.fieldContext_ExperimentRun_notifyID(ctx, field)
+			case "runSequence":
+				return ec.fieldContext_ExperimentRun_runSequence(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ExperimentRun", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_getExperimentRunPhase_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_getInfra(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_getInfra(ctx, field)
 	if err != nil {
@@ -36363,6 +36524,54 @@ func (ec *executionContext) unmarshalInputExperimentRunFilterInput(ctx context.C
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputExperimentRunPhaseRequest(ctx context.Context, obj interface{}) (model.ExperimentRunPhaseRequest, error) {
+	var it model.ExperimentRunPhaseRequest
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"projectID", "infraID", "experimentRunID", "notifyID"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "projectID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectID"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProjectID = data
+		case "infraID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("infraID"))
+			data, err := ec.unmarshalNInfraIdentity2ᚖgithubᚗcomᚋlitmuschaosᚋlitmusᚋchaoscenterᚋgraphqlᚋserverᚋgraphᚋmodelᚐInfraIdentity(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.InfraID = data
+		case "experimentRunID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("experimentRunID"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExperimentRunID = data
+		case "notifyID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("notifyID"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NotifyID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputExperimentRunRequest(ctx context.Context, obj interface{}) (model.ExperimentRunRequest, error) {
 	var it model.ExperimentRunRequest
 	asMap := map[string]interface{}{}
@@ -38042,7 +38251,7 @@ func (ec *executionContext) unmarshalInputPodLogRequest(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"infraID", "experimentRunID", "podName", "podNamespace", "podType", "expPod", "runnerPod", "chaosNamespace"}
+	fieldsInOrder := [...]string{"infraID", "projectID", "experimentRunID", "podName", "podNamespace", "podType", "expPod", "runnerPod", "chaosNamespace"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -38056,6 +38265,13 @@ func (ec *executionContext) unmarshalInputPodLogRequest(ctx context.Context, obj
 				return it, err
 			}
 			it.InfraID = data
+		case "projectID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectID"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProjectID = data
 		case "experimentRunID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("experimentRunID"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -42578,6 +42794,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "getExperimentRunPhase":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_getExperimentRunPhase(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "getInfra":
 			field := field
 
@@ -44526,6 +44764,11 @@ func (ec *executionContext) marshalNExperimentRun2ᚖgithubᚗcomᚋlitmuschaos�
 		return graphql.Null
 	}
 	return ec._ExperimentRun(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNExperimentRunPhaseRequest2githubᚗcomᚋlitmuschaosᚋlitmusᚋchaoscenterᚋgraphqlᚋserverᚋgraphᚋmodelᚐExperimentRunPhaseRequest(ctx context.Context, v interface{}) (model.ExperimentRunPhaseRequest, error) {
+	res, err := ec.unmarshalInputExperimentRunPhaseRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNExperimentRunRequest2githubᚗcomᚋlitmuschaosᚋlitmusᚋchaoscenterᚋgraphqlᚋserverᚋgraphᚋmodelᚐExperimentRunRequest(ctx context.Context, v interface{}) (model.ExperimentRunRequest, error) {

--- a/chaoscenter/graphql/server/graph/model/models_gen.go
+++ b/chaoscenter/graphql/server/graph/model/models_gen.go
@@ -646,6 +646,16 @@ type ExperimentRunFilterInput struct {
 	InfraTypes []*InfrastructureType `json:"infraTypes,omitempty"`
 }
 
+type ExperimentRunPhaseRequest struct {
+	ProjectID string `json:"projectID"`
+	// ID of the infra infra in which the experiment is running
+	InfraID *InfraIdentity `json:"infraID"`
+	// ID of the experiment run which is to be queried
+	ExperimentRunID string `json:"experimentRunID"`
+	// notifyID is required to give an ack for non cron experiment execution
+	NotifyID *string `json:"notifyID,omitempty"`
+}
+
 // Defines the details for a experiment run
 type ExperimentRunRequest struct {
 	// ID of the experiment
@@ -1663,7 +1673,8 @@ type PodLog struct {
 // Defines the details for fetching the pod logs
 type PodLogRequest struct {
 	// ID of the cluster
-	InfraID string `json:"infraID"`
+	InfraID   string `json:"infraID"`
+	ProjectID string `json:"projectID"`
 	// ID of a experiment run
 	ExperimentRunID string `json:"experimentRunID"`
 	// Name of the pod for which logs are required

--- a/chaoscenter/subscriber/pkg/graphql/definations.go
+++ b/chaoscenter/subscriber/pkg/graphql/definations.go
@@ -1,8 +1,14 @@
 package graphql
 
+import (
+	"subscriber/pkg/types"
+)
+
 type SubscriberGql interface {
 	SendRequest(server string, payload []byte) (string, error)
 	MarshalGQLData(gqlData interface{}) (string, error)
+	SendExperimentRunRuquest(infraData map[string]string, podLog types.PodLogRequest) (types.ExperimentRunResponse, error)
+	GenerateExperimentRunPayload(cid, accessKey, version string, podLog types.PodLogRequest) ([]byte, error)
 }
 
 type subscriberGql struct {

--- a/chaoscenter/subscriber/pkg/k8s/defination.go
+++ b/chaoscenter/subscriber/pkg/k8s/defination.go
@@ -15,9 +15,9 @@ import (
 
 type SubscriberK8s interface {
 	GetLogs(podName, namespace, container string) (string, error)
-	CreatePodLog(podLog types.PodLogRequest) (types.PodLog, error)
+	CreatePodLog(infraData map[string]string, podLog types.PodLogRequest) (types.PodLog, error)
 	SendPodLogs(infraData map[string]string, podLog types.PodLogRequest)
-	GenerateLogPayload(cid, accessKey, version string, podLog types.PodLogRequest) ([]byte, error)
+	GenerateLogPayload(cid, accessKey, version, processed string, podLog types.PodLogRequest) ([]byte, error)
 	GetKubernetesNamespaces(request types.KubeNamespaceRequest) ([]*types.KubeNamespace, error)
 	GetKubernetesObjects(request types.KubeObjRequest) (*types.KubeObject, error)
 	GetObjectDataByNamespace(namespace string, dynamicClient dynamic.Interface, resourceType schema.GroupVersionResource) ([]types.ObjectData, error)

--- a/chaoscenter/subscriber/pkg/k8s/defination.go
+++ b/chaoscenter/subscriber/pkg/k8s/defination.go
@@ -15,7 +15,9 @@ import (
 
 type SubscriberK8s interface {
 	GetLogs(podName, namespace, container string) (string, error)
-	CreatePodLog(infraData map[string]string, podLog types.PodLogRequest) (types.PodLog, error)
+	GetPodLogs(infraData map[string]string, podLog types.PodLogRequest) (types.PodLog, error)
+	categorizeLogByPhase(phase string) string
+	CreatePodLog(infraData map[string]string, logDetails types.PodLog, podLog types.PodLogRequest) (types.PodLog, error)
 	SendPodLogs(infraData map[string]string, podLog types.PodLogRequest)
 	GenerateLogPayload(cid, accessKey, version, processed string, podLog types.PodLogRequest) ([]byte, error)
 	GetKubernetesNamespaces(request types.KubeNamespaceRequest) ([]*types.KubeNamespace, error)

--- a/chaoscenter/subscriber/pkg/types/graphql.go
+++ b/chaoscenter/subscriber/pkg/types/graphql.go
@@ -1,0 +1,13 @@
+package types
+
+type ExperimentRunResponse struct {
+	Data ExperimentRun `json:"data"`
+}
+
+type ExperimentRun struct {
+	ExperimentRun Phase `json:"getExperimentRunPhase"`
+}
+
+type Phase struct {
+	Phase string `json:"phase"`
+}

--- a/chaoscenter/subscriber/pkg/types/log.go
+++ b/chaoscenter/subscriber/pkg/types/log.go
@@ -2,6 +2,7 @@ package types
 
 type PodLogRequest struct {
 	RequestID       string  `json:"requestID"`
+	ProjectID       string  `json:"projectID"`
 	InfraID         string  `json:"infraID"`
 	ExperimentRunID string  `json:"experimentRunID"`
 	PodName         string  `json:"podName"`

--- a/chaoscenter/web/src/api/core/log/getPodLog.ts
+++ b/chaoscenter/web/src/api/core/log/getPodLog.ts
@@ -14,6 +14,7 @@ interface GetPodLogsRequest {
   request: {
     // requestID: string;
     infraID: string;
+    projectID: string;
     experimentRunID?: string;
     podName: string;
     podNamespace: string;
@@ -43,6 +44,7 @@ export function getPodLogsSubscription({
       variables: {
         request: {
           infraID: request.infraID,
+          projectID: request.projectID,
           experimentRunID: request.experimentRunID,
           podName: request.podName,
           podNamespace: request.podNamespace,

--- a/chaoscenter/web/src/controllers/CustomStepLog/CustomStepLog.tsx
+++ b/chaoscenter/web/src/controllers/CustomStepLog/CustomStepLog.tsx
@@ -11,6 +11,7 @@ interface CustomStepLogControllerProps {
   namespace: string | undefined;
   workflowRunID: string | undefined;
   infraID: string | undefined;
+  projectID: string | undefined;
   podName: string;
   requestID: string;
   phase: ExperimentRunStatus | undefined;
@@ -19,6 +20,7 @@ interface CustomStepLogControllerProps {
 export default function CustomStepLogController({
   workflowRunID,
   infraID,
+  projectID,
   podName,
   chaosData,
   nodeType,
@@ -36,6 +38,7 @@ export default function CustomStepLogController({
       ...scope,
       infraID: infraID ?? '',
       // requestID: requestID,
+      projectID: projectID ?? '',
       experimentRunID: workflowRunID,
       podName: podName,
       podNamespace: namespace ?? '',

--- a/chaoscenter/web/src/controllers/LogsTab/LogsTab.tsx
+++ b/chaoscenter/web/src/controllers/LogsTab/LogsTab.tsx
@@ -7,6 +7,7 @@ interface LogsTabControllerProps {
   nodeType: string | undefined;
   chaosData: ChaosData | undefined;
   infraID: string | undefined;
+  projectID: string | undefined;
   workflowRunID: string | undefined;
   podID: string;
   experimentPod?: string;

--- a/chaoscenter/web/src/views/ExperimentRunDetails/ExperimentRunDetails.tsx
+++ b/chaoscenter/web/src/views/ExperimentRunDetails/ExperimentRunDetails.tsx
@@ -198,6 +198,7 @@ export default function ExperimentRunDetailsView({
             namespace={experimentExecutionDetails?.namespace}
             probeData={probeData}
             infraID={infra?.infraID}
+            projectID={scope.projectID}
             setSelectedNodeID={setSelectedNodeID}
             experimentRunID={experimentRunID}
             podID={selectedNodeID}

--- a/chaoscenter/web/src/views/ExperimentRunDetailsPanel/ExperimentRunDetailsPanel.tsx
+++ b/chaoscenter/web/src/views/ExperimentRunDetailsPanel/ExperimentRunDetailsPanel.tsx
@@ -31,6 +31,7 @@ interface DetailsTabProps {
   probeData: ProbeInRuns[] | undefined;
   experimentRunID: string | undefined;
   infraID: string | undefined;
+  projectID: string | undefined;
   namespace: string | undefined;
   phase: ExperimentRunStatus | undefined;
   podID: string;
@@ -44,6 +45,7 @@ const DetailsTabs = ({
   phase,
   experimentRunID,
   infraID,
+  projectID,
   podID,
   manifest,
   probeData,
@@ -88,6 +90,7 @@ const DetailsTabs = ({
                 phase={phase}
                 workflowRunID={experimentRunID}
                 infraID={infraID}
+                projectID={projectID}
                 podID={podID}
               />
             )
@@ -110,6 +113,7 @@ const ExperimentRunDetailsPanel = ({
   phase,
   namespace,
   infraID,
+  projectID,
   probeData,
   podID,
   manifest,
@@ -261,6 +265,7 @@ const ExperimentRunDetailsPanel = ({
           probeData={probeData}
           experimentRunID={experimentRunID}
           infraID={infraID}
+          projectID={projectID}
           loading={loading}
           phase={phase}
           namespace={namespace}

--- a/chaoscenter/web/src/views/ExperimentRunDetailsPanel/Tabs/LogsTab.tsx
+++ b/chaoscenter/web/src/views/ExperimentRunDetailsPanel/Tabs/LogsTab.tsx
@@ -10,6 +10,7 @@ interface LogsTabViewProps {
   nodeType: string | undefined;
   chaosData: ChaosData | undefined;
   infraID: string | undefined;
+  projectID: string | undefined;
   workflowRunID: string | undefined;
   podID: string;
   requestID: string;
@@ -22,6 +23,7 @@ export default function LogsTabView({
   nodeType,
   chaosData,
   infraID,
+  projectID,
   workflowRunID,
   podID,
   requestID,
@@ -37,6 +39,7 @@ export default function LogsTabView({
         nodeType={nodeType}
         namespace={namespace}
         infraID={infraID}
+        projectID={projectID}
         requestID={requestID}
         workflowRunID={workflowRunID}
         podName={podID}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

When experiment pods fail to get from Argo Pod, the imported logs always return the same value. This is not intuitive for users.

So, by fetching the phase state from the chaos experiment run, made the log message different for each experiment phase. 




## Special notes for your reviewer:

https://github.com/litmuschaos/litmus/issues/4532