### PR TITLE
Add slice initialization to avoid null response

### DIFF
--- a/chaoscenter/authentication/pkg/project/repository.go
+++ b/chaoscenter/authentication/pkg/project/repository.go
@@ -60,7 +60,7 @@ func (r repository) GetProjects(query bson.D) ([]*entities.Project, error) {
 		return nil, err
 	}
 
-	var projects []*entities.Project
+	var projects = []*entities.Project{}
 	err = results.All(context.TODO(), &projects)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func (r repository) GetProjects(query bson.D) ([]*entities.Project, error) {
 
 // GetProjectsByUserID returns a project based on the userID
 func (r repository) GetProjectsByUserID(request *entities.ListProjectRequest) (*entities.ListProjectResponse, error) {
-	var projects []*entities.Project
+	var projects = []*entities.Project{}
 	ctx := context.TODO()
 
 	// Construct the pipeline
@@ -184,7 +184,7 @@ func (r repository) GetProjectStats() ([]*entities.ProjectStats, error) {
 		return nil, err
 	}
 
-	var data []*entities.ProjectStats
+	var data = []*entities.ProjectStats{}
 	for result.Next(context.TODO()) {
 		res := entities.ProjectStats{}
 		if err := result.Decode(&res); err != nil {
@@ -425,7 +425,7 @@ func (r repository) GetOwnerProjects(ctx context.Context, userID string) ([]*ent
 		return nil, err
 	}
 
-	var projects []*entities.Project
+	var projects = []*entities.Project{}
 	err = cursor.All(context.TODO(), &projects)
 	if err != nil {
 		return nil, err
@@ -447,7 +447,7 @@ func (r repository) GetProjectOwners(projectID string) ([]*entities.Member, erro
 	}
 
 	// Filter the members to include only the owners
-	var owners []*entities.Member
+	var owners = []*entities.Member{}
 	for _, member := range project.Members {
 		if member.Role == entities.RoleOwner && member.Invitation == entities.AcceptedInvitation {
 			owners = append(owners, member)
@@ -615,7 +615,7 @@ func (r repository) ListInvitations(userID string, invitationState entities.Invi
 		return nil, err
 	}
 
-	var projects []*entities.Project
+	var projects = []*entities.Project{}
 	err = cursor.All(context.TODO(), &projects)
 	if err != nil {
 		return nil, err

--- a/chaoscenter/authentication/pkg/session/api_token_repository.go
+++ b/chaoscenter/authentication/pkg/session/api_token_repository.go
@@ -23,7 +23,7 @@ func (r repository) CreateApiToken(apiToken *entities.ApiToken) error {
 
 // GetApiTokensByUserID returns all the API tokens for a given user
 func (r repository) GetApiTokensByUserID(userID string) ([]entities.ApiToken, error) {
-	var apiTokens []entities.ApiToken
+	var apiTokens = []entities.ApiToken{}
 	query := bson.D{
 		{Key: "user_id", Value: userID},
 	}

--- a/chaoscenter/authentication/pkg/user/repository.go
+++ b/chaoscenter/authentication/pkg/user/repository.go
@@ -78,7 +78,7 @@ func (r repository) GetUser(uid string) (*entities.User, error) {
 
 // GetUsers fetches all the users from the database
 func (r repository) GetUsers() (*[]entities.User, error) {
-	var Users []entities.User
+	var Users = []entities.User{}
 	cursor, err := r.Collection.Find(context.Background(), bson.M{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

In some APIs that retrieve multiple entities, if there are no entities that meet the conditions, the API returns null instead of an empty list. To ensure consistent response format, we modified the code to initialize empty slices before processing the results.

### Before

<img width="1059" alt="null_apitokens" src="https://github.com/user-attachments/assets/bd9922a4-06c6-46fe-950f-8a9c94d39356">
<img width="1057" alt="null-projects" src="https://github.com/user-attachments/assets/62e2fb38-dbb6-4764-941a-c557d648d5ae">


### After

<img width="1050" alt="empty-list-apitokens" src="https://github.com/user-attachments/assets/cfb09ad6-ee88-4dc6-b5af-6b66936b7348">
<img width="1055" alt="empty-slice-projects" src="https://github.com/user-attachments/assets/d8efcf62-c4e0-48b6-9b7e-8db7be3b22b8">


### About Frontend

As frontend use optional chaining to safely handle null response(or not used in anywhere in case of projectStats), this change won't affect the frontend behaivor

<img width="1063" alt="APIToken-Frontend" src="https://github.com/user-attachments/assets/1ae92a48-96a3-4f54-8749-9d0b5ecef0f7">

<img width="1068" alt="Project-Frontend" src="https://github.com/user-attachments/assets/9d3b8d53-6945-4701-b8c0-d394ce06209b">

<img width="977" alt="image" src="https://github.com/user-attachments/assets/21d7cafe-a7f6-40fd-bc03-c8f9f10c0c32">



## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
