### PR TITLE
fix: duplicate name key err for probes

### DIFF
--- a/chaoscenter/graphql/server/pkg/database/mongodb/init.go
+++ b/chaoscenter/graphql/server/pkg/database/mongodb/init.go
@@ -278,15 +278,11 @@ func (m *MongoClient) initAllCollection() {
 	m.ChaosProbeCollection = m.Database.Collection(Collections[ChaosProbeCollection])
 	_, err = m.ChaosProbeCollection.Indexes().CreateMany(backgroundContext, []mongo.IndexModel{
 		{
-			Keys: bson.M{
-				"name": 1,
+			Keys: bson.D{
+				{Key: "name", Value: 1},
+				{Key: "project_id", Value: 1},
 			},
 			Options: options.Index().SetUnique(true),
-		},
-		{
-			Keys: bson.D{
-				{"project_id", 1},
-			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR updates the index definition in the `chaosProbes` collection, making the combination of `name` and `project_id` unique instead of `name` field alone.

fixes #5035 

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency

## Special notes for your reviewer:
