### PR TITLE
litmus checker Image registry bug fix for edit and clone experiments

### DIFF
--- a/chaoscenter/web/src/controllers/ChaosStudioClone/ChaosStudioClone.tsx
+++ b/chaoscenter/web/src/controllers/ChaosStudioClone/ChaosStudioClone.tsx
@@ -8,7 +8,7 @@ import { listExperiment, runChaosExperiment, saveChaosExperiment } from '@api/co
 import experimentYamlService from '@services/experiment';
 import { InfrastructureType } from '@api/entities';
 import Loader from '@components/Loader';
-import { useSearchParams, useUpdateSearchParams } from '@hooks';
+import { useSearchParams, useUpdateSearchParams, useImageRegistry } from '@hooks';
 import { ExperimentManifest, StudioMode } from '@models';
 
 export default function ChaosStudioCloneController(): React.ReactElement {
@@ -17,6 +17,7 @@ export default function ChaosStudioCloneController(): React.ReactElement {
   const searchParams = useSearchParams();
   const updateSearchParams = useUpdateSearchParams();
   const hasUnsavedChangesInURL = searchParams.get('unsavedChanges') === 'true';
+  const { imageRegistry } = useImageRegistry();
 
   // <!-- counting state since we have 2 async functions and need to flip state when both of said functions have resolved their promises -->
   const [showStudio, setShowStudio] = React.useState<number>(0);
@@ -56,7 +57,8 @@ export default function ChaosStudioCloneController(): React.ReactElement {
             id: experimentData?.infra?.infraID,
             namespace: experimentData.infra?.infraNamespace,
             environmentID: experimentData.infra?.environmentID
-          }
+          },
+          imageRegistry: imageRegistry
         })
         .then(() => setShowStudio(oldState => oldState + 1));
       const parsedManifest = parse(experimentData.experimentManifest) as ExperimentManifest;
@@ -66,7 +68,7 @@ export default function ChaosStudioCloneController(): React.ReactElement {
         .then(() => setShowStudio(oldState => oldState + 1));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentData, experimentID, hasUnsavedChangesInURL]);
+  }, [experimentData, experimentID, hasUnsavedChangesInURL, imageRegistry]);
 
   const [saveChaosExperimentMutation, { loading: saveChaosExperimentLoading }] = saveChaosExperiment({
     onError: error => showError(error.message)

--- a/chaoscenter/web/src/controllers/ChaosStudioEdit/ChaosStudioEdit.tsx
+++ b/chaoscenter/web/src/controllers/ChaosStudioEdit/ChaosStudioEdit.tsx
@@ -8,7 +8,7 @@ import { listExperiment, runChaosExperiment, saveChaosExperiment } from '@api/co
 import experimentYamlService from '@services/experiment';
 import { ExperimentType, InfrastructureType, RecentExperimentRun } from '@api/entities';
 import Loader from '@components/Loader';
-import { useSearchParams, useUpdateSearchParams } from '@hooks';
+import { useSearchParams, useUpdateSearchParams, useImageRegistry } from '@hooks';
 import RightSideBarV2 from '@components/RightSideBarV2';
 import { StudioMode } from '@models';
 import { cronEnabled } from 'utils';
@@ -20,6 +20,7 @@ export default function ChaosStudioEditController(): React.ReactElement {
   const updateSearchParams = useUpdateSearchParams();
   const hasUnsavedChangesInURL = searchParams.get('unsavedChanges') === 'true';
   const experimentType = searchParams.get('experimentType');
+  const { imageRegistry } = useImageRegistry();
 
   // <!-- counting state since we have 2 async functions and need to flip state when both of said functions have resolved their promises -->
   const [showStudio, setShowStudio] = React.useState<number>(0);
@@ -61,7 +62,8 @@ export default function ChaosStudioEditController(): React.ReactElement {
             id: experimentData?.infra?.infraID,
             namespace: experimentData.infra?.infraNamespace,
             environmentID: experimentData?.infra?.environmentID
-          }
+          },
+          imageRegistry: imageRegistry
         })
         .then(() => setShowStudio(oldState => oldState + 1));
       experimentHandler
@@ -75,7 +77,7 @@ export default function ChaosStudioEditController(): React.ReactElement {
       setIsCronEnabled(validateCron);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentData, experimentID, hasUnsavedChangesInURL]);
+  }, [experimentData, experimentID, hasUnsavedChangesInURL, imageRegistry]);
 
   const [saveChaosExperimentMutation, { loading: saveChaosExperimentLoading }] = saveChaosExperiment({
     onError: error => showError(error.message),

--- a/chaoscenter/web/src/hooks/index.ts
+++ b/chaoscenter/web/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useTrackedRef';
 export * from './useDocumentTitle';
 export * from './useDeepCompareEffect';
 export * from './useProjectFilters';
+export * from './useImageRegistry';

--- a/chaoscenter/web/src/hooks/useImageRegistry.ts
+++ b/chaoscenter/web/src/hooks/useImageRegistry.ts
@@ -1,0 +1,29 @@
+import { getImageRegistry } from '@api/core/ImageRegistry';
+import { getScope } from '@utils';
+import type { ImageRegistry } from '@db';
+
+export function useImageRegistry(): { imageRegistry: ImageRegistry; loading: boolean } {
+  const scope = getScope();
+  
+  // Fetch imageRegistry data
+  const { data: getImageRegistryData, loading } = getImageRegistry({
+    projectID: scope.projectID,
+    options: {
+      fetchPolicy: 'cache-first'
+    }
+  });
+
+  // Create imageRegistry object with fallback values
+  const imageRegistry = getImageRegistryData?.getImageRegistry?.imageRegistryInfo ? {
+    name: getImageRegistryData.getImageRegistry.imageRegistryInfo.imageRegistryName,
+    repo: getImageRegistryData.getImageRegistry.imageRegistryInfo.imageRepoName,
+    secret: getImageRegistryData.getImageRegistry.imageRegistryInfo.secretName,
+    server: getImageRegistryData.getImageRegistry.imageRegistryInfo.imageRegistryName
+  } : {
+    server: 'docker.io/litmuschaos',
+    repo: 'litmuschaos',
+    secret: ''
+  };
+
+  return { imageRegistry, loading };
+}

--- a/chaoscenter/web/src/views/StudioOverview/StudioOverview.tsx
+++ b/chaoscenter/web/src/views/StudioOverview/StudioOverview.tsx
@@ -17,14 +17,12 @@ import { isEqual } from 'lodash-es';
 import type { ExperimentMetadata } from '@db';
 import { useStrings } from '@strings';
 import FormErrorListener from '@components/FormErrorListener';
-import { useUpdateSearchParams } from '@hooks';
+import { useUpdateSearchParams, useImageRegistry } from '@hooks';
 import NameDescriptionTags from '@components/NameIdDescriptionTags';
 import { ChaosInfrastructureReferenceFieldProps, StudioErrorState, StudioTabs } from '@models';
 import experimentYamlService from 'services/experiment';
 import KubernetesChaosInfrastructureReferenceFieldController from '@controllers/KubernetesChaosInfrastructureReferenceField';
 import { InfrastructureType } from '@api/entities';
-import { getImageRegistry } from '@api/core/ImageRegistry'; 
-import { getScope } from '@utils'; 
 import css from './StudioOverview.module.scss';
 
 interface StudioOverviewViewProps {
@@ -54,19 +52,7 @@ export default function StudioOverviewView({
 
   const [currentExperiment, setCurrentExperiment] = React.useState<ExperimentMetadata | undefined>();
 
-  const scope = getScope();
-
-   // Fetch the image registry data using Apollo's useQuery hook
-   const { data: getImageRegistryData, loading: imageRegistryLoading } = getImageRegistry({
-    projectID: scope.projectID,
-  });
-
-  const imageRegistry = getImageRegistryData?.getImageRegistry?{
-      name: getImageRegistryData.getImageRegistry.imageRegistryInfo.imageRegistryName,
-      repo: getImageRegistryData.getImageRegistry.imageRegistryInfo.imageRepoName,
-      secret: getImageRegistryData.getImageRegistry.imageRegistryInfo.secretName,
-  }
-  : undefined;
+  const { imageRegistry, loading: imageRegistryLoading } = useImageRegistry();
 
   React.useEffect(() => {
     experimentHandler?.getExperiment(experimentKey).then(experiment => {


### PR DESCRIPTION
## Proposed changes

Introduced a new useImageRegistry hook to centralize image registry data fetching and fallback logic. Updated ChaosStudioClone, ChaosStudioEdit, and StudioOverview components to use this hook, replacing direct queries and improving code reuse.


## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
