### PR TITLE
fix: [4998]: added tolerations in chaos engine spec when configured from advanced options

### DIFF
--- a/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
+++ b/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
@@ -363,26 +363,68 @@ export class KubernetesYamlService extends ExperimentYamlService {
       if (!experiment) return;
 
       experiment.unsavedChanges = true;
-      const [, , spec] = this.getTemplatesAndSteps(experiment?.manifest as KubernetesExperimentManifest);
+      const [templates, , spec] = this.getTemplatesAndSteps(experiment?.manifest as KubernetesExperimentManifest);
+
+      toleration = {
+        effect: toleration.effect ? toleration.effect : 'NoExecute',
+        key: toleration.key ?? '',
+        operator: toleration.operator ? toleration.operator : 'Equal',
+        value: toleration.value ?? ''
+      };
 
       if (spec && !remove) {
-        spec.tolerations = [
-          {
-            effect: toleration.effect ? toleration.effect : 'NoExecute',
-            key: toleration.key ?? '',
-            operator: toleration.operator ? toleration.operator : 'Equal',
-            value: toleration.value ?? ''
-          }
-        ];
+        spec.tolerations = [toleration];
       } else {
         delete spec?.tolerations;
       }
+
+      templates?.map(template => {
+        if (template.inputs?.artifacts?.[0]?.raw?.data) {
+          const chaosEngineCR = parse(template.inputs.artifacts[0].raw.data ?? '') as ChaosEngine;
+          if (chaosEngineCR.kind === 'ChaosEngine') {
+            const updatedEngineCR = this.updateTolerationInChaosEngine(chaosEngineCR, toleration, remove);
+            template.inputs.artifacts[0].raw.data = yamlStringify(updatedEngineCR);
+          }
+        }
+      });
 
       await store.put({ ...experiment }, key);
       await tx.done;
     } catch (_) {
       this.handleIDBFailure();
     }
+  }
+
+  private updateTolerationInChaosEngine(
+    manifest: ChaosEngine | undefined,
+    tolerations: WorkflowToleration,
+    remove: boolean
+  ): ChaosEngine | undefined {
+    if (!manifest?.spec) return;
+
+    if (remove) {
+      if (manifest.spec?.components?.runner?.tolerations) {
+        delete manifest.spec?.components?.runner?.tolerations;
+      }
+      if (manifest.spec?.experiments[0].spec.components?.tolerations) {
+        delete manifest.spec?.experiments[0].spec.components?.tolerations;
+      }
+      return manifest;
+    }
+
+    manifest.spec.components = {
+      ...manifest.spec.components,
+      runner: {
+        ...manifest.spec.components?.runner,
+        tolerations: tolerations
+      }
+    };
+    manifest.spec.experiments[0].spec.components = {
+      ...manifest.spec.experiments[0].spec.components,
+      tolerations: tolerations
+    };
+
+    return manifest;
   }
 
   async convertToNonCronExperiment(key: ChaosObjectStoresPrimaryKeys['experiments']): Promise<void> {


### PR DESCRIPTION
Fixes issue #4998 

<!--  Thanks for sending a pull request!  -->

## Proposed changes
Added change details in `notes for your reviewer` section below.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
1. Once the tolerations are configured in advance section:
<img width="593" height="326" alt="Screenshot 2025-10-24 at 5 08 22 PM" src="https://github.com/user-attachments/assets/c9d1a61d-6344-43e8-88f2-fb94b8fb76b3" />

2. They are added in the experiment spec:
<img width="441" height="251" alt="Screenshot 2025-10-24 at 5 08 44 PM" src="https://github.com/user-attachments/assets/c2909ffb-9557-40f9-87f0-d56cb8a8ff4f" />

3. They are also added to the chaos engine spec at `components.runner.tolerations` and `experiments[].spec.components.tolerations`:
<img width="441" height="353" alt="Screenshot 2025-10-24 at 5 11 21 PM" src="https://github.com/user-attachments/assets/a741bd83-9651-48d8-8e41-bcbb0d2fe91c" />


