### PR TITLE
fix(ui): remove trailing breadcrumb chevron (#5252)

### DIFF
--- a/chaoscenter/web/src/components/LitmusBreadCrumbs/LitmusBreadCrumbs.tsx
+++ b/chaoscenter/web/src/components/LitmusBreadCrumbs/LitmusBreadCrumbs.tsx
@@ -9,13 +9,18 @@ interface LitmusBreadCrumbsProps extends BreadcrumbsProps {
 export default function LitmusBreadCrumbs({ baseUrl, ...rest }: LitmusBreadCrumbsProps): React.ReactElement {
   const { projectName } = useAppStore();
 
-  return (
-    <Breadcrumbs
-      {...rest}
-      links={[
-        { label: projectName || 'My Project', url: '/', iconProps: { name: 'chaos-litmuschaos' } },
-        ...(rest.links || [])
-      ]}
-    />
+  const combinedLinks = [
+    {
+      label: projectName || 'My Project',
+      url: '/',
+      iconProps: { name: 'chaos-litmuschaos' as any } // cast to 'any' to avoid TS type issue
+    },
+    ...(rest.links || [])
+  ];
+
+  const validLinks = combinedLinks.filter(
+    link => link && typeof link.label === 'string' && link.label.trim() !== ''
   );
+
+  return <Breadcrumbs {...rest} links={validLinks} />;
 }


### PR DESCRIPTION
### 🧩 Summary
Fixes issue **#5252** by removing the extra chevron (`›`) displayed at the end of the breadcrumb trail in the LitmusChaos Dashboard.

### 🔧 Fix
- Updated `LitmusBreadCrumbs.tsx` to filter out empty/invalid breadcrumb labels.  
- Ensures chevrons appear **only between** breadcrumb items, not after the last one.

### ✅ Verification
- Tested locally — no trailing chevron appears.  
- UI spacing and alignment remain consistent.  
- DCO signed ✅

