### PR TITLE
fix: Replaced Litmus Logo with Spring Boot Logo in Chaos Fault Cards

### DIFF
--- a/chaoscenter/web/src/views/ChaosHub/ChaosFaults/ChaosFaults.tsx
+++ b/chaoscenter/web/src/views/ChaosHub/ChaosFaults/ChaosFaults.tsx
@@ -92,6 +92,8 @@ function ChaosFaults({ hubDetails, faultCategories, loading, searchValue }: Chao
     const isChartNameAws = fault.chartName.toLowerCase().includes('aws');
     const isK6Fault = fault.name.toLowerCase().includes('k6-loadgen');
     const isGcpFault = fault.tag.toLowerCase() === 'gcp';
+    const isSpringbootFault = fault.chartName.toLowerCase() === 'spring-boot';
+
     return (
       <Link
         to={{
@@ -120,6 +122,14 @@ function ChaosFaults({ hubDetails, faultCategories, loading, searchValue }: Chao
                 <img
                   src="https://hub.litmuschaos.io/api/icon/3.22.0/gcp/gcp-vm-instance-stop.png"
                   alt="GCP"
+                  width={23}
+                  height={23}
+                  style={{ objectFit: 'contain' }}
+                />
+              ) : isSpringbootFault ? (
+                <img
+                  src="https://hub.litmuschaos.io/api/icon/3.22.0/spring-boot/spring-boot.png"
+                  alt="spring-boot"
                   width={23}
                   height={23}
                   style={{ objectFit: 'contain' }}


### PR DESCRIPTION
Fixes #5292 

## Proposed changes

The Litmus logo has been replaced with the Spring Boot logo in Chaos Fault Cards within ChaosCenter.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Screenshot of the fix
<img width="1900" height="978" alt="Screenshot 2025-11-03 192714" src="https://github.com/user-attachments/assets/2cb8f349-4458-44b0-80cf-74fb4d267eb0" />

