### PR TITLE
Fix bug where passing existing experiment name into UpdateChaosExperiment causes error

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/fuzz_tests/handler_fuzz_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/fuzz_tests/handler_fuzz_test.go
@@ -158,7 +158,9 @@ func FuzzUpdateChaosExperiment(f *testing.F) {
 		experimentType := dbChaosExperiment.NonCronExperiment
 		ctx := context.Background()
 		mockServices := NewMockServices()
-		mockServices.MongodbOperator.On("CountDocuments", ctx, mongodb.ChaosExperimentCollection, mock.Anything, mock.Anything).Return(int64(0), nil).Once()
+		// Mock the List call to check for duplicate experiment names
+		cursor, _ := mongo.NewCursorFromDocuments(nil, nil, nil)
+		mockServices.MongodbOperator.On("List", mock.Anything, mongodb.ChaosExperimentCollection, mock.Anything).Return(cursor, nil).Once()
 		mockServices.ChaosExperimentService.On("ProcessExperiment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model.ChaosExperimentRequest{
 			ExperimentID:   new(string),
 			InfraID:        "abc",


### PR DESCRIPTION
Fixes #5320 

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Fetches the existing experiments with the declared experiment name and compares it with the experiment being edited. If they are the same, skip the duplicate name check which was previously erroring.

Changes to tests:
- Mock the fetch for the existing experiment
- Rename tests to use `success` and `failure` like other tests in file
- Add test to ensure that passing a duplicate experiment name throws an error

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)