### PR TITLE
Fix: Subscriber ConfigMap uses correct GraphQL endpoint

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaos_infrastructure/infra_utils.go
+++ b/chaoscenter/graphql/server/pkg/chaos_infrastructure/infra_utils.go
@@ -21,11 +21,14 @@ type SubscriberConfigurations struct {
 
 func GetEndpoint(host string) (string, error) {
 	// returns endpoint from env, if provided by user
+	if utils.Config.ChaosCenterGqlEndpoint != "" {
+		return utils.Config.ChaosCenterGqlEndpoint + "/query", nil
+	}
 	if utils.Config.ChaosCenterUiEndpoint != "" {
-		return utils.Config.ChaosCenterUiEndpoint + "/api/query", nil
+		return utils.Config.ChaosCenterUiEndpoint + "/query", nil
 	}
 
-	return host + "/api/query", nil
+	return host + "/query", nil
 }
 
 func GetK8sInfraYaml(host string, infra dbChaosInfra.ChaosInfra) ([]byte, error) {

--- a/chaoscenter/graphql/server/utils/variables.go
+++ b/chaoscenter/graphql/server/utils/variables.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	ContainerRuntimeExecutor    string   `required:"true" split_words:"true"`
 	WorkflowHelperImageVersion  string   `required:"true" split_words:"true"`
 	ChaosCenterUiEndpoint       string   `split_words:"true" default:"https://localhost:8080"`
+	ChaosCenterGqlEndpoint      string   `split_words:"true" default:"http://chaos-litmus-server-service:9002"`
 	TlsCertB64                  string   `split_words:"true"`
 	LitmusAuthGrpcEndpoint      string   `split_words:"true" default:"localhost"`
 	LitmusAuthGrpcPort          string   `split_words:"true" default:"3030"`


### PR DESCRIPTION
## Proposed changes

**Problem:** The `subscriber-config` ConfigMap was being initialized with a hardcoded `localhost:32506` URL because `SERVER_ADDR` was derived from the `Referer` header in the request, which includes the external/ingress address. This caused the subscriber pod to crash with `CrashLoopBackOff` when trying to connect to the Litmus server from within the Kubernetes cluster.

**Solution:** Introduced a new configuration variable `ChaosCenterGqlEndpoint` to explicitly define the internal GraphQL server address (e.g., `http://chaos-litmus-server-service:9002/query`). 

Closes #5369

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- No dependent PRs

## Special notes for your reviewer:
NA