### PR TITLE
remove broken Gurubase badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/3202/badge)](https://www.bestpractices.dev/projects/3202)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus?ref=badge_shield)
 [![YouTube Channel](https://img.shields.io/badge/YouTube-Subscribe-red)](https://www.youtube.com/channel/UCa57PMqmz_j0wnteRa9nCaw)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LitmusChaos%20Guru-006BFF)](https://gurubase.io/g/litmuschaos)
 <br><br><br><br>
 
 #### *Read this in [other languages](translations/TRANSLATIONS.md).*


### PR DESCRIPTION
## Proposed changes

This PR removes the "Gurubase" badge from the `README.md` file. The integration link (`https://gurubase.io/g/litmuschaos`) currently redirects to a 404 error page.I am removing the badge to clean up the documentation and prevent user confusion.

Fixes #5419 

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Dependency
- None

## Special notes for your reviewer:
This is a documentation cleanup task. I verified that the existing Gurubase link returns a 404 and could not find an alternative active URL for a LitmusChaos Gurubase page.