### PR TITLE
docs: update community meeting link to invite form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ You can choose from a list of sub-dependent repos to contribute to, a few highli
 
 The litmus community will have a weekly contributor sync-up on Tuesdays 16.00-16.30 IST / 12.30-13.00 CEST
 
-- The sync up meeting is held online on [Google Hangouts](https://meet.google.com/uvt-ozaw-bvp)
+- Fill out the [LitmusChaos Meetings invite form](https://lnkd.in/gKAzxN_e) to get your Calendar invite!
 - The release items are tracked in the [release sheet](https://github.com/litmuschaos/litmus/releases).
 
 If you cannot attend, participate asynchronously via Slack or GitHub discussions.


### PR DESCRIPTION
Replace outdated Google Hangouts link with LitmusChaos Meetings invite form for better access to community meetings.

Fixes community meeting access issue.

<!--  Thanks for sending a pull request!  -->

## Proposed changes

## Description

Updates the outdated Google Hangouts meeting link in CONTRIBUTING.md to the current LitmusChaos Meetings invite form.

## Changes Made

-  Replaced deprecated Google Hangouts link with invite form link
-  Updated text to match current format: "Fill out the [LitmusChaos Meetings invite form](https://lnkd.in/gKAzxN_e) to get your Calendar invite!"

## Context

This issue was identified during today's community meeting where participants noticed the incorrect link at the bottom of the CONTRIBUTING.md file.


## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
