### PR TITLE
fix(web): handle undefined image registry in updateContainerImage

### DIFF
--- a/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
+++ b/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
@@ -1172,13 +1172,15 @@ export class KubernetesYamlService extends ExperimentYamlService {
 }
 
 function updateContainerImage(image: string, registry: ImageRegistry | undefined): string {
+  if (!registry?.repo) return image;
+
   // Extract image name + tag from original image
   // Example: docker.io/litmuschaos/litmus-checker:2.11.0
   const parts = image.split('/');
   const lastPart = parts[parts.length - 1]; // litmus-checker:2.11.0
 
   // Build new image
-  const newImage = `${registry?.repo}/${lastPart}`;
+  const newImage = `${registry.repo}/${lastPart}`;
 
   return newImage;
 }


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/litmuschaos/litmus/issues/5434

When a project has no Image Registry explicitly configured in Settings → Image Registry, the `updateContainerImage` function produces broken image references with a literal `undefined` prefix (e.g., `undefined/go-runner:3.24.0`), causing `ImagePullBackOff` on experiment execution.

The fix adds an early return when `registry` is not configured, preserving the original image string which already contains the correct registry path from the ChaosHub fault definition:

```diff
 function updateContainerImage(image: string, registry: ImageRegistry | undefined): string {
+  if (!registry?.repo) return image;
+
   const parts = image.split('/');
   const lastPart = parts[parts.length - 1];
-  const newImage = `${registry?.repo}/${lastPart}`;
+  const newImage = `${registry.repo}/${lastPart}`;
   return newImage;
 }
```

This is consistent with how other code paths in the same file handle undefined registry:
- `preProcessChaosEngineManifest` (line 1122): `experiment?.imageRegistry?.repo ?? 'litmuschaos'`
- `blankCanvasTemplate.ts`: default parameter `{ repo: 'litmuschaos', secret: '' }`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency

None.

## Special notes for your reviewer:

- Single line fix — adds an early return guard for undefined registry.
- The optional chaining `?.` was already present but only prevents runtime errors; it does not prevent template literals from stringifying `undefined` to the literal string `"undefined"`.
- The removed `?.` in `registry.repo` on the template literal is safe because the early return guarantees `registry` is defined at that point.
- No existing unit tests for `KubernetesYamlService.ts` in the repository.