### PR TITLE
fix(web): refresh useRouteWithBaseUrl when projectID or scope changes

### DIFF
--- a/chaoscenter/web/src/hooks/useRouteWithBaseUrl.ts
+++ b/chaoscenter/web/src/hooks/useRouteWithBaseUrl.ts
@@ -34,6 +34,6 @@ export function useRouteWithBaseUrl(scope?: RouteScope): UseRouteDefinitionsProp
           normalizePath(`${renderUrl}/${scope === 'account' ? route(params) : withProjectID(route(params))}`)
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [renderUrl]
+    [renderUrl, projectID, scope]
   );
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes
### Problem
When a user belongs to multiple projects and switches from project B to project A, clicking **Project Setup → Members** immediately after the switch navigates to project B's Members page instead of A's. #5508
### Root cause
`useRouteWithBaseUrl` memoizes the route map with `useMemo`, but only `renderUrl` was listed as a dependency. `projectID` (used by `withProjectID`) and `scope` (used to branch between account / project URLs) were both captured in the closure but missing from the deps array, so the memo returned stale URLs after the active project or scope changed.
​```ts
return React.useMemo(
  () =>
    mapValues(paths, route => (params?: any) =>
      normalizePath(
        `${renderUrl}/${scope === 'account' ? route(params) : withProjectID(route(params))}`
      )
    ),
  [renderUrl, projectID, scope] // was: [renderUrl]
);
​```

### Fix
Add `projectID` and `scope` to the dependency array so the route map is rebuilt whenever either value changes.
### Steps to reproduce (before the fix)
1. As a user who is **owner of project A** and **member (non-owner) of project B**, sign in.
2. Open project B, then switch to project A from the project picker.
3. Immediately click **Project Setup → Members**.
4. Observed: navigated to project B's Members page.
   Expected: navigated to project A's Members page.
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
## Dependency
None.
## Special notes for your reviewer
- This PR only addresses the **frontend routing** side of the issue. The backend currently does not verify whether the caller has access to the `projectID` carried in the request, which is the deeper cause of seeing another project's data. I plan to send a follow-up PR adding that authorization check on the server side.
- No unit test was added because the bug is a stale-closure dependency issue that is awkward to cover with the existing test setup; happy to add one if the reviewers prefer.