### PR TITLE
feat: add metrics port to litmusportal-server manifests

### DIFF
--- a/chaoscenter/manifests/litmus-installation.yaml
+++ b/chaoscenter/manifests/litmus-installation.yaml
@@ -282,9 +282,13 @@ spec:
               value: "8081"
             - name: GRPC_PORT
               value: "8001"
+            - name: METRICS_PORT
+              value: "8889"
           ports:
             - containerPort: 8081
             - containerPort: 8001
+            - containerPort: 8889
+              name: metrics
           imagePullPolicy: Always
           resources:
             requests:
@@ -327,6 +331,9 @@ spec:
     - name: graphql-rpc-server-https
       port: 8001
       targetPort: 8001
+    - name: metrics
+      port: 8889
+      targetPort: 8889
   selector:
     component: litmusportal-server
 ---

--- a/chaoscenter/manifests/litmus-without-resources.yaml
+++ b/chaoscenter/manifests/litmus-without-resources.yaml
@@ -273,9 +273,13 @@ spec:
               value: "8081"
             - name: GRPC_PORT
               value: "8001"
+            - name: METRICS_PORT
+              value: "8889"
           ports:
             - containerPort: 8081
             - containerPort: 8001
+            - containerPort: 8889
+              name: metrics
           imagePullPolicy: Always
 ---
 kind: NetworkPolicy
@@ -309,6 +313,9 @@ spec:
     - name: graphql-rpc-server-https
       port: 8001
       targetPort: 8001
+    - name: metrics
+      port: 8889
+      targetPort: 8889
   selector:
     component: litmusportal-server
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

Adds metrics port (8889) to the litmusportal-server Deployment and Service in both installation manifests. This exposes the Prometheus metrics endpoint introduced in #5495 so users can scrape metrics after installing LitmusChaos.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency

https://github.com/litmuschaos/litmus/pull/5495

## Special notes for your reviewer:
