### PR TITLE
fix: Fix typos in documentation

### DIFF
--- a/adopters/organizations/akridata.md
+++ b/adopters/organizations/akridata.md
@@ -9,4 +9,4 @@ To execute pod chaos experiments in Kubernetes clusters on AWS & Azure cloud
 Litmus is being used as part of the QA cycles to catch bugs & verify resiliency. 
 
 ## Benefits in using Litmus.   
-We needed a clean way to introduce anomolies in the system to figure out its behaviour, Litmus was the one that was clean and easy to use
+We needed a clean way to introduce anomalies in the system to figure out its behaviour, Litmus was the one that was clean and easy to use

--- a/mkdocs/docs/experiments/troubleshooting/experiments.md
+++ b/mkdocs/docs/experiments/troubleshooting/experiments.md
@@ -266,7 +266,7 @@ The error message indicates that the stress process inside the target container 
     W0817 06:32:26.531145       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
     time="2021-08-17T06:32:26Z" level=error msg="unable to get ChaosEngineUID, error: unable to get ChaosEngine name: pod-delete-chaos, in namespace: default, error: Get \"https://10.100.0.1:443/apis/litmuschaos.io/v1alpha1/namespaces/default/chaosengines/pod-delete-chaos\": dial tcp 10.100.0.1:443: connect: connection refused"
 
-If istio is enabled for the `chaos-namespace`, it will launch the chaos-runner and chaos-experiment pods with the istio sidecar. Which may block/delay the external traffic of those pods for the intial few seconds. Which can fail the experiment.
+If istio is enabled for the `chaos-namespace`, it will launch the chaos-runner and chaos-experiment pods with the istio sidecar. Which may block/delay the external traffic of those pods for the initial few seconds. Which can fail the experiment.
 
 We can fix the above failure by avoiding istio sidecar for the chaos pods. Refer the following manifest:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

Fixes two small documentation typos:

- `adopters/organizations/akridata.md:12` — the adopter story text said "anomolies", corrected to "anomalies".
- `mkdocs/docs/experiments/troubleshooting/experiments.md:269` — the Istio troubleshooting section said "intial few seconds", corrected to "initial few seconds".

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
None

## Special notes for your reviewer: