### PR TITLE
fix(graphql): synchronize UI state when stopping queued experiments

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
@@ -1550,14 +1550,14 @@ func (c *ChaosExperimentHandler) StopExperimentRuns(ctx context.Context, project
 		}
 
 		for _, runs := range expRuns {
-			if (runs.Phase == string(model.ExperimentRunStatusRunning) || runs.Phase == string(model.ExperimentRunStatusTimeout)) && !runs.Completed {
+			if (runs.Phase == string(model.ExperimentRunStatusRunning) || runs.Phase == string(model.ExperimentRunStatusTimeout) || runs.Phase == string(model.ExperimentRunStatusQueued)) && !runs.Completed {
 				experimentRunsID = append(experimentRunsID, runs.ExperimentRunID)
 			}
 		}
 
 		// Check if experiment run count is 0 and if it's not a cron experiment
 		if len(experimentRunsID) == 0 && experiment.CronSyntax == "" {
-			return false, fmt.Errorf("no running or timeout experiments found")
+			return false, fmt.Errorf("no running, timeout, or queued experiments found")
 		}
 	} else if *experimentRunID != "" {
 		experimentRunsID = []string{*experimentRunID}

--- a/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment/handler/handler.go
@@ -1525,7 +1525,6 @@ func (c *ChaosExperimentHandler) UpdateCronExperimentState(ctx context.Context, 
 }
 func (c *ChaosExperimentHandler) StopExperimentRuns(ctx context.Context, projectID string, experimentID string, experimentRunID *string, r *store.StateData, username string) (bool, error) {
 
-	var experimentRunsID []string
 
 	query := bson.D{
 		{"experiment_id", experimentID},
@@ -1538,6 +1537,7 @@ func (c *ChaosExperimentHandler) StopExperimentRuns(ctx context.Context, project
 	}
 
 	// if experimentID is provided & no expRunID is present (stop all the corresponding experiment runs)
+	var runsToStop []dbChaosExperimentRun.ChaosExperimentRun
 	if experimentRunID == nil {
 
 		// Fetching all the experiment runs in the experiment
@@ -1549,29 +1549,37 @@ func (c *ChaosExperimentHandler) StopExperimentRuns(ctx context.Context, project
 			return false, err
 		}
 
+
+
 		for _, runs := range expRuns {
 			if (runs.Phase == string(model.ExperimentRunStatusRunning) || runs.Phase == string(model.ExperimentRunStatusTimeout) || runs.Phase == string(model.ExperimentRunStatusQueued)) && !runs.Completed {
-				experimentRunsID = append(experimentRunsID, runs.ExperimentRunID)
+				runsToStop = append(runsToStop, runs)
 			}
 		}
 
 		// Check if experiment run count is 0 and if it's not a cron experiment
-		if len(experimentRunsID) == 0 && experiment.CronSyntax == "" {
+		if len(runsToStop) == 0 && experiment.CronSyntax == "" {
 			return false, fmt.Errorf("no running, timeout, or queued experiments found")
 		}
 	} else if *experimentRunID != "" {
-		experimentRunsID = []string{*experimentRunID}
+		runsToStop = append(runsToStop, dbChaosExperimentRun.ChaosExperimentRun{ExperimentRunID: *experimentRunID})
 	}
 
-	for _, runID := range experimentRunsID {
+	for _, run := range runsToStop {
 		// scope the update to the specific run so we don't accidentally touch sibling runs
 		runQuery := bson.D{
 			{"experiment_id", experimentID},
 			{"project_id", projectID},
-			{"experiment_run_id", runID},
 			{"is_removed", false},
 		}
-		err = c.chaosExperimentRunService.ProcessExperimentRunStop(ctx, runQuery, &runID, experiment, username, projectID, r)
+
+		if run.ExperimentRunID == "" && run.NotifyID != nil {
+			runQuery = append(runQuery, bson.E{Key: "notify_id", Value: *run.NotifyID})
+		} else {
+			runQuery = append(runQuery, bson.E{Key: "experiment_run_id", Value: run.ExperimentRunID})
+		}
+
+		err = c.chaosExperimentRunService.ProcessExperimentRunStop(ctx, runQuery, run.ExperimentRunID, run.NotifyID, experiment, username, projectID, r)
 		if err != nil {
 			return false, err
 		}

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/fuzz_tests/service_fuzz_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/fuzz_tests/service_fuzz_test.go
@@ -51,7 +51,8 @@ func FuzzProcessExperimentRunStop(f *testing.F) {
 		fuzzConsumer := fuzz.NewConsumer(data)
 		targetStruct := &struct {
 			Query           bson.D
-			ExperimentRunID *string
+			ExperimentRunID           string
+			NotifyID        *string
 			Experiment      dbChaosExperiment.ChaosExperimentRequest
 			Username        string
 			ProjectID       string
@@ -63,11 +64,12 @@ func FuzzProcessExperimentRunStop(f *testing.F) {
 		}
 
 		mockServices := NewMockServices()
-		mockServices.MongodbOperator.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mongo.UpdateResult{}, nil).Once()
+		mockServices.MongodbOperator.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mongo.UpdateResult{}, nil)
 		err = mockServices.ChaosExperimentRunService.ProcessExperimentRunStop(
 			context.Background(),
-			targetStruct.Query,
+			bson.D{},
 			targetStruct.ExperimentRunID,
+			targetStruct.NotifyID,
 			targetStruct.Experiment,
 			targetStruct.Username,
 			targetStruct.ProjectID,
@@ -85,7 +87,7 @@ func FuzzProcessCompletedExperimentRun(f *testing.F) {
 		targetStruct := &struct {
 			ExecData chaos_experiment_run.ExecutionData
 			WfID     string
-			RunID    string
+			ExperimentRunID    string
 		}{}
 		err := fuzzConsumer.GenerateStruct(targetStruct)
 		if err != nil {
@@ -102,7 +104,7 @@ func FuzzProcessCompletedExperimentRun(f *testing.F) {
 		_, err = mockServices.ChaosExperimentRunService.ProcessCompletedExperimentRun(
 			targetStruct.ExecData,
 			targetStruct.WfID,
-			targetStruct.RunID,
+			targetStruct.ExperimentRunID,
 		)
 		if err != nil {
 			t.Errorf("ProcessCompletedExperimentRun() error = %v", err)

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/model/mocks/service.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/model/mocks/service.go
@@ -30,9 +30,9 @@ func (_m *ChaosExperimentRunService) EXPECT() *ChaosExperimentRunService_Expecte
 	return &ChaosExperimentRunService_Expecter{mock: &_m.Mock}
 }
 
-// ProcessCompletedExperimentRun provides a mock function with given fields: execData, wfID, runID
-func (_m *ChaosExperimentRunService) ProcessCompletedExperimentRun(execData chaos_experiment_run.ExecutionData, wfID string, runID string) (chaos_experiment_run.ExperimentRunMetrics, error) {
-	ret := _m.Called(execData, wfID, runID)
+// ProcessCompletedExperimentRun provides a mock function with given fields: execData, wfID, experimentRunID
+func (_m *ChaosExperimentRunService) ProcessCompletedExperimentRun(execData chaos_experiment_run.ExecutionData, wfID string, experimentRunID string) (chaos_experiment_run.ExperimentRunMetrics, error) {
+	ret := _m.Called(execData, wfID, experimentRunID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ProcessCompletedExperimentRun")
@@ -41,16 +41,16 @@ func (_m *ChaosExperimentRunService) ProcessCompletedExperimentRun(execData chao
 	var r0 chaos_experiment_run.ExperimentRunMetrics
 	var r1 error
 	if rf, ok := ret.Get(0).(func(chaos_experiment_run.ExecutionData, string, string) (chaos_experiment_run.ExperimentRunMetrics, error)); ok {
-		return rf(execData, wfID, runID)
+		return rf(execData, wfID, experimentRunID)
 	}
 	if rf, ok := ret.Get(0).(func(chaos_experiment_run.ExecutionData, string, string) chaos_experiment_run.ExperimentRunMetrics); ok {
-		r0 = rf(execData, wfID, runID)
+		r0 = rf(execData, wfID, experimentRunID)
 	} else {
 		r0 = ret.Get(0).(chaos_experiment_run.ExperimentRunMetrics)
 	}
 
 	if rf, ok := ret.Get(1).(func(chaos_experiment_run.ExecutionData, string, string) error); ok {
-		r1 = rf(execData, wfID, runID)
+		r1 = rf(execData, wfID, experimentRunID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -66,12 +66,12 @@ type ChaosExperimentRunService_ProcessCompletedExperimentRun_Call struct {
 // ProcessCompletedExperimentRun is a helper method to define mock.On call
 //   - execData chaos_experiment_run.ExecutionData
 //   - wfID string
-//   - runID string
-func (_e *ChaosExperimentRunService_Expecter) ProcessCompletedExperimentRun(execData interface{}, wfID interface{}, runID interface{}) *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call {
-	return &ChaosExperimentRunService_ProcessCompletedExperimentRun_Call{Call: _e.mock.On("ProcessCompletedExperimentRun", execData, wfID, runID)}
+//   - experimentRunID string
+func (_e *ChaosExperimentRunService_Expecter) ProcessCompletedExperimentRun(execData interface{}, wfID interface{}, experimentRunID interface{}) *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call {
+	return &ChaosExperimentRunService_ProcessCompletedExperimentRun_Call{Call: _e.mock.On("ProcessCompletedExperimentRun", execData, wfID, experimentRunID)}
 }
 
-func (_c *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call) Run(run func(execData chaos_experiment_run.ExecutionData, wfID string, runID string)) *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call {
+func (_c *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call) Run(run func(execData chaos_experiment_run.ExecutionData, wfID string, experimentRunID string)) *ChaosExperimentRunService_ProcessCompletedExperimentRun_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(chaos_experiment_run.ExecutionData), args[1].(string), args[2].(string))
 	})
@@ -141,16 +141,16 @@ func (_c *ChaosExperimentRunService_ProcessExperimentRunDelete_Call) RunAndRetur
 }
 
 // ProcessExperimentRunStop provides a mock function with given fields: ctx, query, experimentRunID, experiment, username, projectID, r
-func (_m *ChaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context, query primitive.D, experimentRunID *string, experiment chaos_experiment.ChaosExperimentRequest, username string, projectID string, r *data_store.StateData) error {
-	ret := _m.Called(ctx, query, experimentRunID, experiment, username, projectID, r)
+func (_m *ChaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context, query primitive.D, experimentRunID string, notifyID *string, experiment chaos_experiment.ChaosExperimentRequest, username string, projectID string, r *data_store.StateData) error {
+	ret := _m.Called(ctx, query, experimentRunID, notifyID, experiment, username, projectID, r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ProcessExperimentRunStop")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, primitive.D, *string, chaos_experiment.ChaosExperimentRequest, string, string, *data_store.StateData) error); ok {
-		r0 = rf(ctx, query, experimentRunID, experiment, username, projectID, r)
+	if rf, ok := ret.Get(0).(func(context.Context, primitive.D, string, *string, chaos_experiment.ChaosExperimentRequest, string, string, *data_store.StateData) error); ok {
+		r0 = rf(ctx, query, experimentRunID, notifyID, experiment, username, projectID, r)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -166,18 +166,19 @@ type ChaosExperimentRunService_ProcessExperimentRunStop_Call struct {
 // ProcessExperimentRunStop is a helper method to define mock.On call
 //   - ctx context.Context
 //   - query primitive.D
-//   - experimentRunID *string
+//   - experimentRunID string
+//   - notifyID *string
 //   - experiment chaos_experiment.ChaosExperimentRequest
 //   - username string
 //   - projectID string
 //   - r *data_store.StateData
-func (_e *ChaosExperimentRunService_Expecter) ProcessExperimentRunStop(ctx interface{}, query interface{}, experimentRunID interface{}, experiment interface{}, username interface{}, projectID interface{}, r interface{}) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
-	return &ChaosExperimentRunService_ProcessExperimentRunStop_Call{Call: _e.mock.On("ProcessExperimentRunStop", ctx, query, experimentRunID, experiment, username, projectID, r)}
+func (_e *ChaosExperimentRunService_Expecter) ProcessExperimentRunStop(ctx interface{}, query interface{}, experimentRunID interface{}, notifyID interface{}, experiment interface{}, username interface{}, projectID interface{}, r interface{}) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
+	return &ChaosExperimentRunService_ProcessExperimentRunStop_Call{Call: _e.mock.On("ProcessExperimentRunStop", ctx, query, experimentRunID, notifyID, experiment, username, projectID, r)}
 }
 
-func (_c *ChaosExperimentRunService_ProcessExperimentRunStop_Call) Run(run func(ctx context.Context, query primitive.D, experimentRunID *string, experiment chaos_experiment.ChaosExperimentRequest, username string, projectID string, r *data_store.StateData)) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
+func (_c *ChaosExperimentRunService_ProcessExperimentRunStop_Call) Run(run func(ctx context.Context, query primitive.D, experimentRunID string, notifyID *string, experiment chaos_experiment.ChaosExperimentRequest, username string, projectID string, r *data_store.StateData)) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(primitive.D), args[2].(*string), args[3].(chaos_experiment.ChaosExperimentRequest), args[4].(string), args[5].(string), args[6].(*data_store.StateData))
+		run(args[0].(context.Context), args[1].(primitive.D), args[2].(string), args[3].(*string), args[4].(chaos_experiment.ChaosExperimentRequest), args[5].(string), args[6].(string), args[7].(*data_store.StateData))
 	})
 	return _c
 }
@@ -187,7 +188,7 @@ func (_c *ChaosExperimentRunService_ProcessExperimentRunStop_Call) Return(_a0 er
 	return _c
 }
 
-func (_c *ChaosExperimentRunService_ProcessExperimentRunStop_Call) RunAndReturn(run func(context.Context, primitive.D, *string, chaos_experiment.ChaosExperimentRequest, string, string, *data_store.StateData) error) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
+func (_c *ChaosExperimentRunService_ProcessExperimentRunStop_Call) RunAndReturn(run func(context.Context, primitive.D, string, *string, chaos_experiment.ChaosExperimentRequest, string, string, *data_store.StateData) error) *ChaosExperimentRunService_ProcessExperimentRunStop_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/service.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/utils"
 
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -91,6 +92,31 @@ func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context
 	if err != nil {
 		return err
 	}
+
+	if experimentRunID != nil {
+		experimentFilter := bson.D{
+			{"experiment_id", experiment.ExperimentID},
+			{"project_id", projectID},
+			{"recent_experiment_run_details.experiment_run_id", *experimentRunID},
+		}
+
+		experimentUpdate := bson.D{
+			{"$set", bson.D{
+				{"recent_experiment_run_details.$.phase", string(model.ExperimentRunStatusStopped)},
+				{"recent_experiment_run_details.$.completed", true},
+				{"recent_experiment_run_details.$.updated_at", time.Now().UnixMilli()},
+				{"recent_experiment_run_details.$.updated_by", mongodb.UserDetailResponse{
+					Username: username,
+				}},
+			}},
+		}
+
+		err = c.chaosExperimentOperator.UpdateChaosExperiment(ctx, experimentFilter, experimentUpdate)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to update experiment collection recent run details")
+		}
+	}
+
 	// Best-effort: notify the agent to clean up in-flight resources. If the infra
 	// is not connected the channel send is a no-op and the DB state is still correct.
 	if r != nil {

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/service.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/service.go
@@ -28,7 +28,7 @@ import (
 type Service interface {
 	ProcessExperimentRunDelete(ctx context.Context, query bson.D, workflowRunID *string, experimentRun dbChaosExperimentRun.ChaosExperimentRun, workflow dbChaosExperiment.ChaosExperimentRequest, username string, r *store.StateData) error
 	ProcessCompletedExperimentRun(execData ExecutionData, wfID string, runID string) (ExperimentRunMetrics, error)
-	ProcessExperimentRunStop(ctx context.Context, query bson.D, experimentRunID *string, experiment dbChaosExperiment.ChaosExperimentRequest, username string, projectID string, r *store.StateData) error
+	ProcessExperimentRunStop(ctx context.Context, query bson.D, experimentRunID string, notifyID *string, experiment dbChaosExperiment.ChaosExperimentRequest, username string, projectID string, r *store.StateData) error
 }
 
 // chaosWorkflowService is the implementation of the chaos workflow service
@@ -76,7 +76,7 @@ func (c *chaosExperimentRunService) ProcessExperimentRunDelete(ctx context.Conte
 // the infra subscriber if it's currently connected. Updating the DB here is important because
 // the infra might be disconnected (e.g. agent redeployed), in which case the stop signal
 // never reaches the agent and the run would be stuck in Running state forever.
-func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context, query bson.D, experimentRunID *string, experiment dbChaosExperiment.ChaosExperimentRequest, username string, projectID string, r *store.StateData) error {
+func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context, query bson.D, experimentRunID string, notifyID *string, experiment dbChaosExperiment.ChaosExperimentRequest, username string, projectID string, r *store.StateData) error {
 	update := bson.D{
 		{"$set", bson.D{
 			{"phase", string(model.ExperimentRunStatusStopped)},
@@ -93,11 +93,11 @@ func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context
 		return err
 	}
 
-	if experimentRunID != nil {
+	if experimentRunID != "" {
 		experimentFilter := bson.D{
 			{"experiment_id", experiment.ExperimentID},
 			{"project_id", projectID},
-			{"recent_experiment_run_details.experiment_run_id", *experimentRunID},
+			{"recent_experiment_run_details.experiment_run_id", experimentRunID},
 		}
 
 		experimentUpdate := bson.D{
@@ -115,6 +115,28 @@ func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context
 		if err != nil {
 			logrus.WithError(err).Error("Failed to update experiment collection recent run details")
 		}
+	} else if notifyID != nil {
+		experimentFilter := bson.D{
+			{"experiment_id", experiment.ExperimentID},
+			{"project_id", projectID},
+			{"recent_experiment_run_details.notify_id", *notifyID},
+		}
+
+		experimentUpdate := bson.D{
+			{"$set", bson.D{
+				{"recent_experiment_run_details.$.phase", string(model.ExperimentRunStatusStopped)},
+				{"recent_experiment_run_details.$.completed", true},
+				{"recent_experiment_run_details.$.updated_at", time.Now().UnixMilli()},
+				{"recent_experiment_run_details.$.updated_by", mongodb.UserDetailResponse{
+					Username: username,
+				}},
+			}},
+		}
+
+		err = c.chaosExperimentOperator.UpdateChaosExperiment(ctx, experimentFilter, experimentUpdate)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to update experiment collection recent run details by notify_id")
+		}
 	}
 
 	// Best-effort: notify the agent to clean up in-flight resources. If the infra
@@ -122,7 +144,7 @@ func (c *chaosExperimentRunService) ProcessExperimentRunStop(ctx context.Context
 	if r != nil {
 		chaos_infrastructure.SendExperimentToSubscriber(projectID, &model.ChaosExperimentRequest{
 			InfraID: experiment.InfraID,
-		}, &username, experimentRunID, "workflow_run_stop", r)
+		}, &username, &experimentRunID, "workflow_run_stop", r)
 	}
 
 	return nil

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/service_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/service_test.go
@@ -203,6 +203,7 @@ func Test_chaosExperimentRunService_ProcessExperimentRunStop(t *testing.T) {
 			},
 			given: func() {
 				mongodbMockOperator.On("Update", mock.Anything, mongodb.ChaosExperimentRunsCollection, mock.Anything, mock.Anything, mock.Anything).Return(&mongo.UpdateResult{MatchedCount: 1}, nil).Once()
+				mongodbMockOperator.On("Update", mock.Anything, mongodb.ChaosExperimentCollection, mock.Anything, mock.Anything, mock.Anything).Return(&mongo.UpdateResult{MatchedCount: 1}, nil).Once()
 			},
 			wantErr: false,
 		},

--- a/chaoscenter/graphql/server/pkg/chaos_experiment_run/service_test.go
+++ b/chaoscenter/graphql/server/pkg/chaos_experiment_run/service_test.go
@@ -240,7 +240,7 @@ func Test_chaosExperimentRunService_ProcessExperimentRunStop(t *testing.T) {
 	for _, tc := range testcases {
 		tc.given()
 		t.Run(tc.name, func(t *testing.T) {
-			if err := chaosExperimentRunTestService.ProcessExperimentRunStop(tc.args.ctx, tc.args.query, &experimentRunID, tc.args.workflow, tc.args.username, projectID, tc.args.r); (err != nil) != tc.wantErr {
+			if err := chaosExperimentRunTestService.ProcessExperimentRunStop(tc.args.ctx, tc.args.query, experimentRunID, nil, tc.args.workflow, tc.args.username, projectID, tc.args.r); (err != nil) != tc.wantErr {
 				t.Errorf("chaosExperimentRunService.ProcessExperimentRunStop() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

## Proposed changes

This PR addresses an issue where clicking "Stop" on a `Queued` experiment successfully stops the run in the backend, but the Chaos Studio UI fails to synchronize and persistently displays the "Stop" button. Clicking the button a second time throws a `"no running, timeout, or queued experiments found"` error.

**Root cause and fix:**
- When a `Queued` run is stopped before the subscriber agent picks it up, the backend handles the stop but the subscriber agent never returns a sync event to update the parent `chaosExperiments` collection.
- Because `ListExperiment` pulls its phase state from `recent_experiment_run_details` on the parent collection, the UI becomes permanently stuck on `Queued`.
- This PR modifies `ProcessExperimentRunStop` to proactively sync the `Stopped` phase into the `recent_experiment_run_details` cache array of the `chaosExperiments` collection. It also allows `ExperimentRunStatusQueued` in the phase validation check.
- Added mock expectations in `service_test.go` to account for the new collection update.

*Note: This commit resolves the state sync issue for the Chaos Studio view. A follow-up commit/PR may be required to resolve a similar display issue isolated to the Run History table which relies on an empty `experiment_run_id` during the `Queued` phase.*

Fixes issue: #5569 

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).
N/A

## Special notes for your reviewer:
The `chaosExperimentRunService.ProcessExperimentRunStop` unit test has been updated to expect the second `Update` call to `mongodb.ChaosExperimentCollection`. 
