### PR TITLE
fix(web): serialize ChaosEngine tolerations as arrays

### DIFF
--- a/chaoscenter/web/src/models/chaosEngine.ts
+++ b/chaoscenter/web/src/models/chaosEngine.ts
@@ -103,7 +103,7 @@ export interface RunnerInfo {
   // Secrets for runner pod
   secrets?: kubernetes.Secret[];
   // Tolerations for runner pod
-  tolerations?: kubernetes.Toleration;
+  tolerations?: kubernetes.Toleration[];
   // Resource requirements for the runner pod
   resources?: kubernetes.ResourceRequirements;
 }
@@ -341,7 +341,7 @@ export interface FaultComponents {
   nodeSelector?: { [key: string]: string };
   statusCheckTimeouts?: StatusCheckTimeout;
   resources?: kubernetes.ResourceRequirements;
-  tolerations?: kubernetes.Toleration;
+  tolerations?: kubernetes.Toleration[];
 }
 
 // StatusCheckTimeout contains Delay and timeouts for the status checks

--- a/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
+++ b/chaoscenter/web/src/services/experiment/KubernetesYamlService.ts
@@ -455,12 +455,12 @@ export class KubernetesYamlService extends ExperimentYamlService {
       ...manifest.spec.components,
       runner: {
         ...manifest.spec.components?.runner,
-        tolerations: tolerations
+        tolerations: [tolerations]
       }
     };
     manifest.spec.experiments[0].spec.components = {
       ...manifest.spec.experiments[0].spec.components,
-      tolerations: tolerations
+      tolerations: [tolerations]
     };
 
     return manifest;
@@ -974,29 +974,29 @@ export class KubernetesYamlService extends ExperimentYamlService {
   }
 
   updateFaultTunablesInFaultData(
-  faultData: FaultData | undefined,
-  faultTunables: FaultTunables | undefined
-): FaultData | undefined {
-  const chaosEngine = faultData?.engineCR;
-  if (!chaosEngine || !faultTunables) return faultData;
+    faultData: FaultData | undefined,
+    faultTunables: FaultTunables | undefined
+  ): FaultData | undefined {
+    const chaosEngine = faultData?.engineCR;
+    if (!chaosEngine || !faultTunables) return faultData;
 
-  const envs: EnvVar[] = Object.entries(faultTunables).map(([envName, faultTunable]) => {
-    return {
-      name: envName,
-      value: faultTunable.value?.toString(),
-      valueFrom: faultTunable.valueFrom
-    };
-  });
+    const envs: EnvVar[] = Object.entries(faultTunables).map(([envName, faultTunable]) => {
+      return {
+        name: envName,
+        value: faultTunable.value?.toString(),
+        valueFrom: faultTunable.valueFrom
+      };
+    });
 
-  if (chaosEngine.spec?.experiments?.[0].spec.components) {
-    chaosEngine.spec.experiments[0].spec.components = {
-      ...chaosEngine.spec.experiments[0].spec.components,
-      env: envs
-    };
+    if (chaosEngine.spec?.experiments?.[0].spec.components) {
+      chaosEngine.spec.experiments[0].spec.components = {
+        ...chaosEngine.spec.experiments[0].spec.components,
+        env: envs
+      };
+    }
+
+    return faultData;
   }
-
-  return faultData;
-}
 
   async preProcessChaosEngineAndExperimentManifest(
     key: ChaosObjectStoresPrimaryKeys['experiments'],

--- a/chaoscenter/web/src/services/experiment/__tests__/KubernetesYamlService.test.ts
+++ b/chaoscenter/web/src/services/experiment/__tests__/KubernetesYamlService.test.ts
@@ -1,0 +1,107 @@
+import { parse } from 'yaml';
+
+import { ChaosObjectStoreNameMap } from '@db';
+import type { Experiment } from '@db';
+import type { ChaosEngine } from '@models';
+import { KubernetesYamlService } from '../KubernetesYamlService';
+
+describe('KubernetesYamlService tolerations', () => {
+  const experimentKey = 'toleration-regression-test';
+  let service: KubernetesYamlService;
+
+  beforeEach(async () => {
+    service = new KubernetesYamlService();
+    await service.clearObjectStore(ChaosObjectStoreNameMap.EXPERIMENTS);
+
+    const experiment = {
+      id: experimentKey,
+      name: experimentKey,
+      chaosInfrastructure: {},
+      manifest: {
+        kind: 'Workflow',
+        metadata: { name: experimentKey },
+        spec: {
+          entrypoint: 'custom-chaos',
+          templates: [
+            {
+              name: 'custom-chaos',
+              steps: []
+            },
+            {
+              name: 'install-chaos-faults',
+              inputs: {
+                artifacts: [
+                  {
+                    raw: {
+                      data: `
+                        apiVersion: litmuschaos.io/v1alpha1
+                        kind: ChaosEngine
+                        spec:
+                          components:
+                            runner: {}
+                          experiments:
+                            - name: pod-http-status-code
+                              spec:
+                                components: {}
+                      `
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    } as unknown as Experiment;
+
+    await (await service.db).put(ChaosObjectStoreNameMap.EXPERIMENTS, experiment, experimentKey);
+  });
+
+  afterEach(async () => {
+    await service.clearObjectStore(ChaosObjectStoreNameMap.EXPERIMENTS);
+    await service.closeDB();
+  });
+
+  test('serializes runner and experiment tolerations as arrays', async () => {
+    await service.updateToleration(
+      experimentKey,
+      {
+        effect: 'NoExecute',
+        key: 'dedicated',
+        operator: 'Equal',
+        value: 'my-node-tag'
+      },
+      false
+    );
+
+    const experiment = await service.getExperiment(experimentKey);
+    const templates = (
+      experiment?.manifest as {
+        spec: { templates: Array<{ name: string; inputs?: { artifacts?: Array<{ raw?: { data?: string } }> } }> };
+      }
+    ).spec.templates;
+    const engineArtifact = templates.find(template => template.name === 'install-chaos-faults')?.inputs?.artifacts?.[0]
+      ?.raw?.data;
+    const engine = parse(engineArtifact ?? '') as ChaosEngine;
+    const runnerTolerations = engine.spec?.components?.runner?.tolerations;
+    const experimentTolerations = engine.spec?.experiments[0].spec.components?.tolerations;
+
+    expect(Array.isArray(runnerTolerations)).toBe(true);
+    expect(Array.isArray(experimentTolerations)).toBe(true);
+    expect(runnerTolerations).toHaveLength(1);
+    expect(experimentTolerations).toHaveLength(1);
+
+    expect(runnerTolerations?.[0]).toEqual({
+      effect: 'NoExecute',
+      key: 'dedicated',
+      operator: 'Equal',
+      value: 'my-node-tag'
+    });
+    expect(experimentTolerations?.[0]).toEqual({
+      effect: 'NoExecute',
+      key: 'dedicated',
+      operator: 'Equal',
+      value: 'my-node-tag'
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the way tolerations are generated in the ChaosEngine manifest.

Previously, the frontend generated `tolerations` as a single object instead of an array. Since Kubernetes expects an array, saving the ChaosEngine failed with a `failed to unmarshal chaosengine` error.

## Changes

- Serialize runner tolerations as an array.
- Serialize experiment tolerations as an array.
- Update the TypeScript models to use `kubernetes.Toleration[]`.
- Add a regression test to verify that runner and experiment tolerations are serialized as arrays in the generated ChaosEngine manifest.

## Verification

- Verified the generated ChaosEngine manifest now contains `tolerations` as arrays.
- Added a regression test covering the toleration serialization path to prevent future regressions.
- Ran `yarn typecheck` successfully.
- Ran `yarn test` successfully (including the new regression test).

## Note

The repository's pre-commit hook (`lint-staged`) automatically reformatted part of `KubernetesYamlService.ts`. The additional changes are formatting only and do not change the behavior of the code.

Fixes #5564