### PR TITLE
fix(subscriber): prevent nil pointer panic on transient API errors in IsAgentConfirmed

### DIFF
--- a/chaoscenter/subscriber/pkg/k8s/operations.go
+++ b/chaoscenter/subscriber/pkg/k8s/operations.go
@@ -134,21 +134,23 @@ func (k8s *k8sSubscriber) IsAgentConfirmed() (bool, string, error) {
 	}
 
 	getCM, err := clientset.CoreV1().ConfigMaps(InfraNamespace).Get(context.TODO(), InfraConfigName, metav1.GetOptions{})
-	if k8s_errors.IsNotFound(err) {
-		return false, "", errors.New(InfraConfigName + " configmap not found")
-	} else if getCM.Data["IS_INFRA_CONFIRMED"] == "true" {
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return false, "", errors.New(InfraConfigName + " configmap not found")
+		}
+		return false, "", err
+	}
+
+	if getCM.Data["IS_INFRA_CONFIRMED"] == "true" {
 		getSecret, err := clientset.CoreV1().Secrets(InfraNamespace).Get(context.TODO(), InfraSecretName, metav1.GetOptions{})
 		if err != nil {
-			return false, "", errors.New(InfraSecretName + " secret not found")
-		}
-
-		if k8s_errors.IsNotFound(err) {
+			if k8s_errors.IsNotFound(err) {
+				return false, "", errors.New(InfraSecretName + " secret not found")
+			}
 			return false, "", err
 		}
 
 		return true, string(getSecret.Data["ACCESS_KEY"]), nil
-	} else if err != nil {
-		return false, "", err
 	}
 
 	return false, "", nil


### PR DESCRIPTION
Fixes #5559.

### Summary
This PR fixes a critical panic in the subscriber agent (`IsAgentConfirmed`) caused by improper error handling during Kubernetes API calls.

### Root Cause
Previously, if `clientset.CoreV1().ConfigMaps(...).Get(...)` returned a transient error (e.g. dial timeout, temporary unauthorized), the error check bypassed it because it only checked `if k8s_errors.IsNotFound(err)`. This caused the flow to fall through to `else if getCM.Data["IS_INFRA_CONFIRMED"] == "true"`, where reading from the `nil` `getCM` pointer caused an immediate agent panic.

A similar error-handling flaw existed in the subsequent `Secrets` retrieval, which contained dead code (`IsNotFound` check placed after an unconditional error return).

### Fix
- Explicitly check `err != nil` first. If an error is present, check if it's `IsNotFound`. If so, return the formatted "not found" error. Otherwise, return the actual transient error cleanly without crashing.
- Removed the dead code from the Secrets error check and implemented the same pattern.

### Verification
- The agent will now gracefully backoff and retry when the Kubernetes API server is temporarily unreachable, instead of panicking.