### PR TITLE
fix(web): fetch infrastructure details by ID during edit mode to prevent empty field rendering

### DIFF
--- a/chaoscenter/web/src/api/core/infrastructures/getInfraDetails.ts
+++ b/chaoscenter/web/src/api/core/infrastructures/getInfraDetails.ts
@@ -1,0 +1,63 @@
+import { gql, useQuery } from '@apollo/client';
+import type { KubernetesChaosInfrastructure } from '../../entities';
+import type { GqlAPIQueryRequest, GqlAPIQueryResponse } from '../../types';
+
+export interface GetInfraDetailsRequest {
+  projectID: string;
+  infraID: string;
+}
+
+export interface GetInfraDetailsResponse {
+  getInfraDetails: KubernetesChaosInfrastructure;
+}
+
+export function getInfraDetails({
+  projectID,
+  infraID,
+  options = {}
+}: GqlAPIQueryRequest<GetInfraDetailsResponse, GetInfraDetailsRequest, never>): GqlAPIQueryResponse<
+  GetInfraDetailsResponse,
+  GetInfraDetailsRequest
+> {
+  const { data, loading, ...rest } = useQuery<GetInfraDetailsResponse, GetInfraDetailsRequest>(
+    gql`
+      query getInfraDetails($projectID: ID!, $infraID: ID!) {
+        getInfraDetails(projectID: $projectID, infraID: $infraID) {
+          infraID
+          name
+          environmentID
+          description
+          platformName
+          isActive
+          isInfraConfirmed
+          updatedAt
+          createdAt
+          noOfExperiments
+          noOfExperimentRuns
+          lastExperimentTimestamp
+          infraNamespace
+          serviceAccount
+          infraScope
+          startTime
+          version
+          tags
+          updateStatus
+        }
+      }
+    `,
+    {
+      variables: {
+        projectID,
+        infraID
+      },
+      skip: !infraID,
+      fetchPolicy: options.fetchPolicy ?? 'cache-and-network',
+      ...options
+    }
+  );
+  return {
+    data,
+    loading: loading,
+    ...rest
+  };
+}

--- a/chaoscenter/web/src/api/core/infrastructures/index.ts
+++ b/chaoscenter/web/src/api/core/infrastructures/index.ts
@@ -4,3 +4,4 @@ export * from './testKubernetesChaosInfrastructureConnection';
 export * from './getVersionDetails';
 export * from './listKubernetesChaosInfrastructure';
 export * from './getKubeObject';
+export * from './getInfraDetails';

--- a/chaoscenter/web/src/controllers/KubernetesChaosInfrastructureReferenceField/KubernetesChaosInfrastructureReferenceField.tsx
+++ b/chaoscenter/web/src/controllers/KubernetesChaosInfrastructureReferenceField/KubernetesChaosInfrastructureReferenceField.tsx
@@ -1,6 +1,6 @@
 import { Pagination, useToaster } from '@harnessio/uicore';
 import React from 'react';
-import { listChaosInfra } from '@api/core';
+import { getInfraDetails, listChaosInfra } from '@api/core';
 import { getScope } from '@utils';
 import ChaosInfrastructureReferenceFieldView from '@views/ChaosInfrastructureReferenceField';
 import { AllEnv, type ChaosInfrastructureReferenceFieldProps } from '@models';
@@ -35,6 +35,15 @@ function KubernetesChaosInfrastructureReferenceFieldController({
     }
   });
 
+  const { data: specificInfraData, loading: specificInfraLoading } = getInfraDetails({
+    ...scope,
+    infraID: initialInfrastructureID as string,
+    options: {
+      skip: !initialInfrastructureID,
+      onError: error => showError(error.message)
+    }
+  });
+
   const environmentList = listEnvironmentData?.listEnvironments?.environments;
 
   React.useEffect(() => {
@@ -47,10 +56,10 @@ function KubernetesChaosInfrastructureReferenceFieldController({
     ({ environmentID }) => environmentID === initialEnvironmentID
   );
 
-  // TODO: replace with get API as this becomes empty during edit
-  const preSelectedInfrastructure = listChaosInfraData?.listInfras.infras.find(
-    ({ infraID }) => infraID === initialInfrastructureID
-  );
+  // replace with get API as this becomes empty during edit
+  const preSelectedInfrastructure =
+    listChaosInfraData?.listInfras.infras.find(({ infraID }) => infraID === initialInfrastructureID) ||
+    specificInfraData?.getInfraDetails;
 
   const preSelectedInfrastructureDetails: InfrastructureDetails | undefined = preSelectedInfrastructure && {
     id: preSelectedInfrastructure?.infraID,
@@ -129,7 +138,7 @@ function KubernetesChaosInfrastructureReferenceFieldController({
       envID={envID}
       setEnvID={setEnvID}
       loading={{
-        listChaosInfra: listChaosInfraLoading
+        listChaosInfra: listChaosInfraLoading || specificInfraLoading
       }}
       pagination={<PaginationComponent />}
     />


### PR DESCRIPTION
Resolves an issue where target infrastructure renders empty

## Description
This PR fixes a bug where the Target Infrastructure reference field rendered completely empty during Chaos Experiment edit mode (`StudioOverview`). 

Previously, `KubernetesChaosInfrastructureReferenceFieldController` solely relied on `.find()` against the paginated `listChaosInfraData` array. If the target infrastructure wasn't on the first page, the reference field failed to bind to its initial value. 

This PR introduces the `getInfraDetails` GraphQL query to directly fetch the infrastructure by ID when `initialInfrastructureID` is provided, and gracefully merges the result with the paginated list results.

## Testing
Manually tested that navigating to an experiment in Edit mode successfully pre-populates the Target Infrastructure regardless of pagination depth.