### PR TITLE
feat(server): implement GraphQL query complexity limiting for DoS protection

### DIFF
--- a/chaoscenter/graphql/server/server.go
+++ b/chaoscenter/graphql/server/server.go
@@ -151,6 +151,10 @@ func main() {
 		srv.Use(extension.Introspection{})
 	}
 
+	// Add GraphQL complexity limit (Security patch for #5562)
+	// Limits the maximum complexity of queries to prevent DoS attacks
+	srv.Use(extension.FixedComplexityLimit(150))
+
 	// GraphQL operation tracking middleware
 	srv.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
 		oc := graphql.GetOperationContext(ctx)


### PR DESCRIPTION
## Proposed changes

Addresses #5594

The `chaoscenter/graphql/server` lacked protections against deeply nested or complex GraphQL queries, which could expose the control plane to resource exhaustion (DoS) attacks.

This PR injects `extension.FixedComplexityLimit(150)` into the gqlgen handler middleware in `server.go`. This hard limit ensures that any incoming query exceeding a complexity weight of 150 is immediately rejected before execution, protecting the underlying MongoDB and gRPC resources.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- N/A

## Special notes for your reviewer:
Verified the server builds cleanly and the gqlgen extension loads without errors.