### PR TITLE
test(server): add comprehensive unit tests for project initializer

### DIFF
--- a/chaoscenter/graphql/server/pkg/projects/project_handler_test.go
+++ b/chaoscenter/graphql/server/pkg/projects/project_handler_test.go
@@ -1,0 +1,52 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb"
+	dbMocks "github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/mocks"
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/database/mongodb/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProjectInitializer_Success(t *testing.T) {
+	mockOp := new(dbMocks.MongoOperator)
+	
+	// ProjectInitializer calls irOp.InsertImageRegistry which eventually calls MongoOperator.Create
+	mockOp.On("Create", mock.Anything, mongodb.ImageRegistryCollection, mock.Anything).
+		Return(nil).Once()
+
+	proj := project.Project{
+		ID:        "project-1",
+		Audit: mongodb.Audit{
+			CreatedBy: mongodb.UserDetailResponse{UserID: "user-1"},
+			UpdatedBy: mongodb.UserDetailResponse{UserID: "user-1"},
+		},
+	}
+
+	err := ProjectInitializer(context.Background(), proj, "admin", mockOp)
+	
+	assert.NoError(t, err)
+	mockOp.AssertExpectations(t)
+}
+
+func TestProjectInitializer_Error(t *testing.T) {
+	mockOp := new(dbMocks.MongoOperator)
+	
+	dbErr := errors.New("db error while creating registry")
+	mockOp.On("Create", mock.Anything, mongodb.ImageRegistryCollection, mock.Anything).
+		Return(dbErr).Once()
+
+	proj := project.Project{
+		ID: "project-2",
+	}
+
+	err := ProjectInitializer(context.Background(), proj, "admin", mockOp)
+	
+	assert.Error(t, err)
+	assert.Equal(t, dbErr, err)
+	mockOp.AssertExpectations(t)
+}


### PR DESCRIPTION
## Proposed changes

Addresses the missing unit test coverage highlighted in #5594.

Issue #5594 noted that `pkg/projects` lacks any unit tests. This PR implements comprehensive test coverage for `ProjectInitializer` in `pkg/projects/project_handler.go` by leveraging the existing `MongoOperator` mocks.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices applies)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- N/A

## Special notes for your reviewer:
Ran `go test ./chaoscenter/graphql/server/pkg/projects/...` locally - all tests pass.