### PR TITLE
fix(auth): reject unverified email claims in the OIDC callback

### DIFF
--- a/chaoscenter/authentication/api/handlers/rest/dex_auth_handler.go
+++ b/chaoscenter/authentication/api/handlers/rest/dex_auth_handler.go
@@ -120,6 +120,13 @@ func OAuthCallback(userService services.ApplicationService) gin.HandlerFunc {
 			c.JSON(utils.ErrorStatusCodes[utils.ErrServerError], presenter.CreateErrorResponse(utils.ErrServerError))
 			return
 		}
+		// The email is what the account is keyed on below, so it is only usable
+		// once the provider states that it belongs to the subject.
+		if claims.Email == "" || !claims.Verified {
+			log.Errorf("OAuth Error: subject %s has no verified email claim", idToken.Subject)
+			c.JSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
+			return
+		}
 		createdAt := time.Now().UnixMilli()
 
 		var userData = entities.User{

--- a/chaoscenter/authentication/api/handlers/rest/dex_auth_handler_test.go
+++ b/chaoscenter/authentication/api/handlers/rest/dex_auth_handler_test.go
@@ -1,11 +1,25 @@
 package rest_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/litmuschaos/litmus/chaoscenter/authentication/api/handlers/rest"
+	"github.com/litmuschaos/litmus/chaoscenter/authentication/api/mocks"
+	"github.com/litmuschaos/litmus/chaoscenter/authentication/pkg/authConfig"
+	"github.com/litmuschaos/litmus/chaoscenter/authentication/pkg/entities"
+	"github.com/litmuschaos/litmus/chaoscenter/authentication/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestOAuthLogin(t *testing.T) {
@@ -15,4 +29,187 @@ func TestOAuthLogin(t *testing.T) {
 	rest.OAuthLogin()(ctx)
 
 	assert.Equal(t, 500, w.Code)
+}
+
+// newTestOIDCProvider starts a minimal OIDC provider that hands out an id_token
+// carrying the given claims, so the callback can be driven end to end.
+func newTestOIDCProvider(t *testing.T, clientID string, claims map[string]interface{}) *httptest.Server {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("unable to generate signing key: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		writeTestJSON(t, w, map[string]interface{}{
+			"issuer":                                server.URL,
+			"authorization_endpoint":                server.URL + "/auth",
+			"token_endpoint":                        server.URL + "/token",
+			"jwks_uri":                              server.URL + "/keys",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		writeTestJSON(t, w, map[string]interface{}{
+			"keys": []map[string]string{{
+				"kty": "RSA",
+				"alg": "RS256",
+				"use": "sig",
+				"kid": "test",
+				"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+			}},
+		})
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		idClaims := jwt.MapClaims{
+			"iss": server.URL,
+			"aud": clientID,
+			"sub": "attacker-subject",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+		for k, v := range claims {
+			idClaims[k] = v
+		}
+
+		idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, idClaims)
+		idToken.Header["kid"] = "test"
+		signed, err := idToken.SignedString(key)
+		if err != nil {
+			t.Errorf("unable to sign id_token: %v", err)
+			return
+		}
+
+		writeTestJSON(t, w, map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"id_token":     signed,
+		})
+	})
+
+	return server
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, payload map[string]interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Errorf("unable to write response: %v", err)
+	}
+}
+
+func TestOAuthCallbackRejectsUnusableEmailClaims(t *testing.T) {
+	const clientID = "litmus-test-client"
+
+	tests := []struct {
+		name   string
+		claims map[string]interface{}
+	}{
+		{
+			name: "email not verified by the provider",
+			claims: map[string]interface{}{
+				"email":          "victim@litmus.test",
+				"email_verified": false,
+				"name":           "attacker",
+			},
+		},
+		{
+			name: "email_verified claim absent",
+			claims: map[string]interface{}{
+				"email": "victim@litmus.test",
+				"name":  "attacker",
+			},
+		},
+		{
+			name: "no email claim at all",
+			claims: map[string]interface{}{
+				"email_verified": true,
+				"name":           "attacker",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTestOIDCProvider(t, clientID, tt.claims)
+
+			utils.OAuthOIDCIssuer = provider.URL
+			utils.OAuthClientID = clientID
+			utils.OAuthClientSecret = "test-client-secret"
+			utils.OAuthCallBackURL = "http://localhost:3000/oauth/callback"
+			utils.OAuthJwtSecret = "test-oauth-state-secret"
+
+			state, err := utils.GenerateOAuthJWT()
+			assert.NoError(t, err)
+
+			service := new(mocks.MockedApplicationService)
+			service.On("LoginUser", mock.Anything).Return(&entities.User{
+				ID:       "victim-user-id",
+				Username: "victim@litmus.test",
+				Email:    "victim@litmus.test",
+			}, nil)
+			service.On("GetConfig", "salt").Return(&authConfig.AuthConfig{Value: "salt"}, nil)
+			service.On("GetSignedJWT", mock.Anything, mock.Anything).Return("victim-session-token", nil)
+			service.On("GetOwnerProjectIDs", mock.Anything, mock.Anything).
+				Return([]*entities.Project{{ID: "victim-project"}}, nil)
+
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+state+"&code=test-code", nil)
+
+			rest.OAuthCallback(service)(ctx)
+
+			assert.Equal(t, 401, w.Code)
+			assert.NotContains(t, w.Header().Get("Location"), "victim-session-token")
+			service.AssertNotCalled(t, "GetSignedJWT", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestOAuthCallbackAcceptsVerifiedEmail(t *testing.T) {
+	const clientID = "litmus-test-client"
+
+	provider := newTestOIDCProvider(t, clientID, map[string]interface{}{
+		"email":          "user@litmus.test",
+		"email_verified": true,
+		"name":           "user",
+	})
+
+	utils.OAuthOIDCIssuer = provider.URL
+	utils.OAuthClientID = clientID
+	utils.OAuthClientSecret = "test-client-secret"
+	utils.OAuthCallBackURL = "http://localhost:3000/oauth/callback"
+	utils.OAuthJwtSecret = "test-oauth-state-secret"
+
+	state, err := utils.GenerateOAuthJWT()
+	assert.NoError(t, err)
+
+	service := new(mocks.MockedApplicationService)
+	service.On("LoginUser", mock.Anything).Return(&entities.User{
+		ID:       "user-id",
+		Username: "user@litmus.test",
+		Email:    "user@litmus.test",
+	}, nil)
+	service.On("GetConfig", "salt").Return(&authConfig.AuthConfig{Value: "salt"}, nil)
+	service.On("GetSignedJWT", mock.Anything, mock.Anything).Return("user-session-token", nil)
+	service.On("GetOwnerProjectIDs", mock.Anything, mock.Anything).
+		Return([]*entities.Project{{ID: "user-project"}}, nil)
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+state+"&code=test-code", nil)
+
+	rest.OAuthCallback(service)(ctx)
+
+	assert.Equal(t, http.StatusPermanentRedirect, w.Code)
+	assert.Contains(t, w.Header().Get("Location"), "jwtToken=user-session-token")
 }


### PR DESCRIPTION
Tracking issue: #5605

## Proposed changes

`OAuthCallback` decodes `email_verified` off the ID token into `claims.Verified` and then never looks at it. It sets both `Username` and `Email` to `claims.Email` and hands that to `LoginUser`, whose repository implementation inserts by username and, on a duplicate key, returns the *existing* record:

```go
_, err = r.Collection.InsertOne(context.Background(), user)
if err != nil {
	if mongo.IsDuplicateKeyError(err) {
		var result = entities.User{}
		findOneErr := r.Collection.FindOne(context.TODO(), bson.M{"username": user.Username}).Decode(&result)
		...
		return &result, nil
```

The handler then signs a session JWT for whatever user came back and redirects with it. So an id_token carrying someone else's address with `email_verified: false` logs the caller straight into that person's account and every project it owns. `/oauth/callback` is registered on the root engine with no middleware, so nothing upstream of this stands between the provider's claims and the session token.

Since `OIDC_ISSUER` became a free-form setting the server talks to whatever provider an operator points it at, and self-service signup on Keycloak, or an Auth0 database connection, hands out exactly that token shape until the address is confirmed. The bundled Dex connectors (google, github) both report verified emails, so default installs are unaffected. An absent `email` claim is the same defect from the other side: those logins all collapse onto one shared account with an empty username, which is why the check covers both.

The claim is validated where it is first treated as an identity rather than further down in `LoginUser`, since that path is also the local username/password login and has no notion of a provider assertion.

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency

None.

## Special notes for your reviewer:

`gofmt`, `goimports` and `make backend-services-checks` are clean, `go.mod`/`go.sum` are untouched, and `go test ./...` in `chaoscenter/authentication` passes.

The new tests in `dex_auth_handler_test.go` stand up a small OIDC provider on `httptest` and drive the callback end to end, so they exercise the real `Exchange` plus `Verify` path rather than stubbing it. On master the three rejection cases return `308` with `jwtToken=victim-session-token` in the `Location` header; with the patch they return `401` and `GetSignedJWT` is never reached. `TestOAuthCallbackAcceptsVerifiedEmail` pins the happy path so the check cannot silently start rejecting valid logins.

I did not open a public issue for this one, since SECURITY.md asks that vulnerabilities go to the security contacts instead. Happy to file a tracking issue if you would rather have one linked here.

Left alone deliberately, tell me if you want either folded in: the OAuth `state` token from `GenerateOAuthJWT` carries only `exp` and is not bound to the browser session, so it does not actually stop login CSRF, and keying accounts on `email` rather than the provider's `sub` still means a mailbox change at the IdP silently detaches a user from their projects. Both are larger behaviour changes than this one.

