### PR TITLE
fix(graphql): path traversal in GetChaosFault (#5606)

### DIFF
--- a/chaoscenter/graphql/server/pkg/chaoshub/service.go
+++ b/chaoscenter/graphql/server/pkg/chaoshub/service.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -474,35 +476,63 @@ func (c *chaosHubService) ListChaosFaults(ctx context.Context, hubID string, pro
 	return ChartsData, nil
 }
 
+// isSubPath checks whether targetPath is contained within baseDir after path resolution.
+func isSubPath(baseDir, targetPath string) bool {
+	cleanBase := filepath.Clean(baseDir)
+	cleanTarget := filepath.Clean(targetPath)
+
+	rel, err := filepath.Rel(cleanBase, cleanTarget)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false
+	}
+	return true
+}
+
 // GetChaosFault is used for getting details of chartserviceversion.yaml.
 func (c *chaosHubService) GetChaosFault(ctx context.Context, request model.ExperimentRequest, projectID string) (*model.FaultDetails, error) {
 	chaosHub, err := c.getChaosHubDetails(ctx, request.HubID, projectID)
 	if err != nil {
 		return nil, err
 	}
-	var basePath string
+	var hubPath string
 	if chaosHub.IsDefault {
-		basePath = "/tmp/default/" + chaosHub.Name + "/faults/" + request.Category + "/" + request.ExperimentName
+		hubPath = "/tmp/default/" + chaosHub.Name + "/faults"
 	} else {
-		basePath = DefaultPath + projectID + "/" + chaosHub.Name + "/faults/" + request.Category + "/" + request.ExperimentName
+		hubPath = DefaultPath + projectID + "/" + chaosHub.Name + "/faults"
+	}
+
+	cleanHubPath := filepath.Clean(hubPath)
+	basePath := filepath.Join(cleanHubPath, request.Category, request.ExperimentName)
+
+	if !isSubPath(cleanHubPath, basePath) {
+		return nil, fmt.Errorf("invalid path: path traversal detected")
 	}
 
 	//Get fault chartserviceversion.yaml data
-	csvPath := basePath + "/" + request.ExperimentName + ".chartserviceversion.yaml"
+	csvPath := filepath.Join(basePath, request.ExperimentName+".chartserviceversion.yaml")
+	if !isSubPath(cleanHubPath, csvPath) {
+		return nil, fmt.Errorf("invalid path: path traversal detected")
+	}
 	csvYaml, err := os.ReadFile(csvPath)
 	if err != nil {
 		csvYaml = []byte("")
 	}
 
 	//Get engine.yaml data
-	enginePath := basePath + "/" + "engine.yaml"
+	enginePath := filepath.Join(basePath, "engine.yaml")
+	if !isSubPath(cleanHubPath, enginePath) {
+		return nil, fmt.Errorf("invalid path: path traversal detected")
+	}
 	engineYaml, err := os.ReadFile(enginePath)
 	if err != nil {
 		engineYaml = []byte("")
 	}
 
 	//Get fault.yaml data
-	faultPath := basePath + "/" + "fault.yaml"
+	faultPath := filepath.Join(basePath, "fault.yaml")
+	if !isSubPath(cleanHubPath, faultPath) {
+		return nil, fmt.Errorf("invalid path: path traversal detected")
+	}
 	faultYaml, err := os.ReadFile(faultPath)
 	if err != nil {
 		faultYaml = []byte("")

--- a/chaoscenter/graphql/server/pkg/chaoshub/service_test.go
+++ b/chaoscenter/graphql/server/pkg/chaoshub/service_test.go
@@ -1,0 +1,109 @@
+package chaoshub_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/pkg/chaoshub"
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetChaosFault_Valid(t *testing.T) {
+	utils.Config.DefaultHubName = "test-default-hub"
+	hubDir := filepath.Join("/tmp", "default", "test-default-hub", "faults", "pod-delete", "pod-delete")
+	err := os.MkdirAll(hubDir, 0755)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(filepath.Join("/tmp", "default", "test-default-hub"))
+	})
+
+	csvPath := filepath.Join(hubDir, "pod-delete.chartserviceversion.yaml")
+	enginePath := filepath.Join(hubDir, "engine.yaml")
+	faultPath := filepath.Join(hubDir, "fault.yaml")
+
+	assert.NoError(t, os.WriteFile(csvPath, []byte("csv-data"), 0644))
+	assert.NoError(t, os.WriteFile(enginePath, []byte("engine-data"), 0644))
+	assert.NoError(t, os.WriteFile(faultPath, []byte("fault-data"), 0644))
+
+	service := chaoshub.NewService(nil)
+	req := model.ExperimentRequest{
+		HubID:          chaoshub.DefaultHubID,
+		Category:       "pod-delete",
+		ExperimentName: "pod-delete",
+	}
+
+	details, err := service.GetChaosFault(context.Background(), req, "test-project")
+	assert.NoError(t, err)
+	assert.NotNil(t, details)
+	assert.Equal(t, "csv-data", details.CSV)
+	assert.Equal(t, "engine-data", details.Engine)
+	assert.Equal(t, "fault-data", details.Fault)
+}
+
+func TestGetChaosFault_PathTraversal_Relative(t *testing.T) {
+	utils.Config.DefaultHubName = "test-default-hub"
+	service := chaoshub.NewService(nil)
+
+	req := model.ExperimentRequest{
+		HubID:          chaoshub.DefaultHubID,
+		Category:       "../../../etc",
+		ExperimentName: "passwd",
+	}
+
+	details, err := service.GetChaosFault(context.Background(), req, "test-project")
+	assert.Error(t, err)
+	assert.Nil(t, details)
+	assert.Contains(t, err.Error(), "path traversal detected")
+}
+
+func TestGetChaosFault_PathTraversal_Nested(t *testing.T) {
+	utils.Config.DefaultHubName = "test-default-hub"
+	service := chaoshub.NewService(nil)
+
+	req := model.ExperimentRequest{
+		HubID:          chaoshub.DefaultHubID,
+		Category:       "pod-delete/../../etc",
+		ExperimentName: "passwd",
+	}
+
+	details, err := service.GetChaosFault(context.Background(), req, "test-project")
+	assert.Error(t, err)
+	assert.Nil(t, details)
+	assert.Contains(t, err.Error(), "path traversal detected")
+}
+
+func TestGetChaosFault_PathTraversal_ContainmentPrefix(t *testing.T) {
+	utils.Config.DefaultHubName = "test-hub"
+	service := chaoshub.NewService(nil)
+
+	req := model.ExperimentRequest{
+		HubID:          chaoshub.DefaultHubID,
+		Category:       "../../test-hub-other/faults/pod-delete",
+		ExperimentName: "pod-delete",
+	}
+
+	details, err := service.GetChaosFault(context.Background(), req, "test-project")
+	assert.Error(t, err)
+	assert.Nil(t, details)
+	assert.Contains(t, err.Error(), "path traversal detected")
+}
+
+func TestGetChaosFault_PathTraversal_AbsolutePath(t *testing.T) {
+	utils.Config.DefaultHubName = "test-default-hub"
+	service := chaoshub.NewService(nil)
+
+	req := model.ExperimentRequest{
+		HubID:          chaoshub.DefaultHubID,
+		Category:       "../../..",
+		ExperimentName: "etc/passwd",
+	}
+
+	details, err := service.GetChaosFault(context.Background(), req, "test-project")
+	assert.Error(t, err)
+	assert.Nil(t, details)
+	assert.Contains(t, err.Error(), "path traversal detected")
+}


### PR DESCRIPTION
## Proposed changes

Fixes #5606

### Summary of Changes:
- **Path Containment Check**: Implemented `isSubPath(baseDir, targetPath string) bool` helper using standard Go `filepath.Clean` and `filepath.Rel` in `chaoscenter/graphql/server/pkg/chaoshub/service.go`.
- **Root Directory Enforcement**: Updated `GetChaosFault` to clean the ChaosHub faults directory path (`cleanHubPath`) and ensure `basePath`, `csvPath`, `enginePath`, and `faultPath` cannot escape `cleanHubPath`.
- **Safe Rejection**: Rejects any path traversal attempt (such as `../../../etc`, `pod-delete/../../etc`, or absolute paths) with error `invalid path: path traversal detected`.
- **Unit Tests**: Added regression tests in `chaoscenter/graphql/server/pkg/chaoshub/service_test.go` covering:
  - Legitimate category & experiment path resolution
  - Relative path traversal (`../../../etc`)
  - Nested path traversal (`pod-delete/../../etc`)
  - Containment-prefix manipulation (`../../test-hub-other/faults/pod-delete`)
  - Absolute path resolution

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- None

## Special notes for your reviewer:
- Uses Go standard library primitives (`path/filepath`) for path resolution and containment checking without adding external dependencies.
- Verified locally with `gofmt` and `go test -v .` in `chaoscenter/graphql/server/pkg/chaoshub`.
