### PR TITLE
fix(auth): prevent unauthorized project membership operations (#5604)

### DIFF
--- a/chaoscenter/authentication/api/handlers/rest/project_handler.go
+++ b/chaoscenter/authentication/api/handlers/rest/project_handler.go
@@ -572,8 +572,14 @@ func AcceptInvitation(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
+		uid := c.MustGet("uid").(string)
+		if member.UserID != uid {
+			c.JSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
+			return
+		}
+
 		// admin/user shouldn't be able to perform any task if it's default pwd is not changes(initial login is true)
-		initialLogin, err := CheckInitialLogin(service, c.MustGet("uid").(string))
+		initialLogin, err := CheckInitialLogin(service, uid)
 		if err != nil {
 			c.JSON(utils.ErrorStatusCodes[utils.ErrServerError], presenter.CreateErrorResponse(utils.ErrServerError))
 			return
@@ -584,7 +590,7 @@ func AcceptInvitation(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
-		err = validations.RbacValidator(c.MustGet("uid").(string), member.ProjectID,
+		err = validations.RbacValidator(uid, member.ProjectID,
 			validations.MutationRbacRules["acceptInvitation"],
 			string(entities.PendingInvitation),
 			service)
@@ -630,8 +636,14 @@ func DeclineInvitation(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
+		uid := c.MustGet("uid").(string)
+		if member.UserID != uid {
+			c.JSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
+			return
+		}
+
 		// admin/user shouldn't be able to perform any task if it's default pwd is not changes(initial login is true)
-		initialLogin, err := CheckInitialLogin(service, c.MustGet("uid").(string))
+		initialLogin, err := CheckInitialLogin(service, uid)
 		if err != nil {
 			c.JSON(utils.ErrorStatusCodes[utils.ErrServerError], presenter.CreateErrorResponse(utils.ErrServerError))
 			return
@@ -642,7 +654,7 @@ func DeclineInvitation(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
-		err = validations.RbacValidator(c.MustGet("uid").(string), member.ProjectID,
+		err = validations.RbacValidator(uid, member.ProjectID,
 			validations.MutationRbacRules["declineInvitation"],
 			string(entities.PendingInvitation),
 			service)
@@ -688,6 +700,12 @@ func LeaveProject(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
+		uid := c.MustGet("uid").(string)
+		if member.UserID != uid {
+			c.JSON(utils.ErrorStatusCodes[utils.ErrUnauthorized], presenter.CreateErrorResponse(utils.ErrUnauthorized))
+			return
+		}
+
 		if member.Role != nil && *member.Role == entities.RoleOwner {
 			owners, err := service.GetProjectOwners(member.ProjectID)
 			if err != nil {
@@ -703,7 +721,7 @@ func LeaveProject(service services.ApplicationService) gin.HandlerFunc {
 		}
 
 		// admin/user shouldn't be able to perform any task if it's default pwd is not changes(initial login is true)
-		initialLogin, err := CheckInitialLogin(service, c.MustGet("uid").(string))
+		initialLogin, err := CheckInitialLogin(service, uid)
 		if err != nil {
 			c.JSON(utils.ErrorStatusCodes[utils.ErrServerError], presenter.CreateErrorResponse(utils.ErrServerError))
 			return
@@ -714,7 +732,7 @@ func LeaveProject(service services.ApplicationService) gin.HandlerFunc {
 			return
 		}
 
-		err = validations.RbacValidator(c.MustGet("uid").(string), member.ProjectID,
+		err = validations.RbacValidator(uid, member.ProjectID,
 			validations.MutationRbacRules["leaveProject"],
 			string(entities.AcceptedInvitation),
 			service)

--- a/chaoscenter/authentication/api/handlers/rest/project_handler_test.go
+++ b/chaoscenter/authentication/api/handlers/rest/project_handler_test.go
@@ -1,6 +1,8 @@
 package rest_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +14,7 @@ import (
 	"github.com/litmuschaos/litmus/chaoscenter/authentication/pkg/entities"
 	"github.com/litmuschaos/litmus/chaoscenter/authentication/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -309,3 +312,166 @@ func TestGetProject(t *testing.T) {
 	})
 
 }
+
+func TestLeaveProjectBOLA(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("Legitimate self-operation - User A leaves project", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userA",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/leave_project", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		userA := &entities.User{
+			ID:             "userA",
+			IsInitialLogin: false,
+		}
+		projects := []*entities.Project{{ID: "projX"}}
+
+		service.On("GetUser", "userA").Return(userA, nil)
+		service.On("GetProjects", mock.Anything).Return(projects, nil)
+		service.On("UpdateInvite", "projX", "userA", entities.ExitedProject, (*entities.MemberRole)(nil)).Return(nil)
+
+		rest.LeaveProject(service)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		service.AssertCalled(t, "UpdateInvite", "projX", "userA", entities.ExitedProject, (*entities.MemberRole)(nil))
+	})
+
+	t.Run("Cross-user operation - User A attempts to remove User B", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userB",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/leave_project", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		rest.LeaveProject(service)(c)
+
+		assert.Equal(t, utils.ErrorStatusCodes[utils.ErrUnauthorized], w.Code)
+		service.AssertNotCalled(t, "UpdateInvite", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestAcceptInvitationBOLA(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("Legitimate self-operation - User A accepts invitation", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userA",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/accept_invitation", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		userA := &entities.User{
+			ID:             "userA",
+			IsInitialLogin: false,
+		}
+		projects := []*entities.Project{{ID: "projX"}}
+
+		service.On("GetUser", "userA").Return(userA, nil)
+		service.On("GetProjects", mock.Anything).Return(projects, nil)
+		service.On("UpdateInvite", "projX", "userA", entities.AcceptedInvitation, (*entities.MemberRole)(nil)).Return(nil)
+
+		rest.AcceptInvitation(service)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		service.AssertCalled(t, "UpdateInvite", "projX", "userA", entities.AcceptedInvitation, (*entities.MemberRole)(nil))
+	})
+
+	t.Run("Cross-user operation - User A attempts to accept for User B", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userB",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/accept_invitation", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		rest.AcceptInvitation(service)(c)
+
+		assert.Equal(t, utils.ErrorStatusCodes[utils.ErrUnauthorized], w.Code)
+		service.AssertNotCalled(t, "UpdateInvite", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestDeclineInvitationBOLA(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("Legitimate self-operation - User A declines invitation", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userA",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/decline_invitation", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		userA := &entities.User{
+			ID:             "userA",
+			IsInitialLogin: false,
+		}
+		projects := []*entities.Project{{ID: "projX"}}
+
+		service.On("GetUser", "userA").Return(userA, nil)
+		service.On("GetProjects", mock.Anything).Return(projects, nil)
+		service.On("UpdateInvite", "projX", "userA", entities.DeclinedInvitation, (*entities.MemberRole)(nil)).Return(nil)
+
+		rest.DeclineInvitation(service)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		service.AssertCalled(t, "UpdateInvite", "projX", "userA", entities.DeclinedInvitation, (*entities.MemberRole)(nil))
+	})
+
+	t.Run("Cross-user operation - User A attempts to decline for User B", func(t *testing.T) {
+		service := new(mocks.MockedApplicationService)
+		w := httptest.NewRecorder()
+		c := GetTestGinContext(w)
+		c.Set("uid", "userA")
+		c.Set("role", string(entities.RoleUser))
+
+		body, _ := json.Marshal(entities.MemberInput{
+			ProjectID: "projX",
+			UserID:    "userB",
+		})
+		c.Request, _ = http.NewRequest(http.MethodPost, "/decline_invitation", bytes.NewBuffer(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		rest.DeclineInvitation(service)(c)
+
+		assert.Equal(t, utils.ErrorStatusCodes[utils.ErrUnauthorized], w.Code)
+		service.AssertNotCalled(t, "UpdateInvite", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+


### PR DESCRIPTION
## Description
Fixes a Broken Object Level Authorization (BOLA) vulnerability in project membership and invitation operations (`LeaveProject`, `AcceptInvitation`, and `DeclineInvitation`). 

Previously, while `RbacValidator` checked if the caller had project access, the handlers passed the request-controlled `member.UserID` to `service.UpdateInvite`. This allowed an authenticated user to supply another user's `userID` and modify that user's membership or invitation state.

## What Changed
- Added identity authorization checks in `LeaveProject`, `AcceptInvitation`, and `DeclineInvitation` REST handlers to verify that `member.UserID` matches the authenticated user ID (`c.MustGet("uid")`).
- Rejects cross-user operation attempts with `401 Unauthorized` before performing any database updates.
- Added comprehensive unit regression tests asserting both valid self-operations and rejection of cross-user attempts.

## Issues Referenced
Fixes #5604

## How Has This Been Tested?
- Added unit tests in `chaoscenter/authentication/api/handlers/rest/project_handler_test.go`:
  - `TestLeaveProjectBOLA`
  - `TestAcceptInvitationBOLA`
  - `TestDeclineInvitationBOLA`
- Verified that cross-user mutation requests return 401 and `service.UpdateInvite` is not called.
- Ran package test suite: `go test -v ./api/handlers/rest/...` (all tests PASS).

## Checklist
- [x] Code adheres to repository style guidelines
- [x] Tests added to cover security regression scenarios
- [x] All unit tests passing locally
- [x] Commits are DCO signed
